### PR TITLE
feature/add cli generator config options

### DIFF
--- a/asyncapi-generator-cli/src/main/kotlin/dev/banking/asyncapi/generator/cli/Main.kt
+++ b/asyncapi-generator-cli/src/main/kotlin/dev/banking/asyncapi/generator/cli/Main.kt
@@ -32,6 +32,9 @@ class AsyncApiGeneratorCli : CliktCommand(name = "asyncapi-generator") {
         .file(canBeFile = false)
         .default(File("./generated"))
 
+    private val outputFile by option("--output-file", help = "Write bundled AsyncAPI YAML to file")
+        .file(canBeDir = false)
+
     private val generator by option("--generator", "-g", help = "Target language (KOTLIN, JAVA)")
         .choice(
             "kotlin" to KOTLIN,
@@ -40,7 +43,6 @@ class AsyncApiGeneratorCli : CliktCommand(name = "asyncapi-generator") {
         .default(KOTLIN)
 
     private val modelPackage by option("--model-package", help = "Package for generated models")
-        .required()
 
     private val clientPackage by option(
         "--client-package",
@@ -76,34 +78,56 @@ class AsyncApiGeneratorCli : CliktCommand(name = "asyncapi-generator") {
 
         val bundler = AsyncApiBundler()
         val bundledDoc = bundler.bundle(document)
-
-        val effClientPackage = clientPackage ?: modelPackage
-        val effSchemaPackage = schemaPackage ?: modelPackage
-
-        val sourceRootName = if (generator == KOTLIN) {
-            "src/main/kotlin"
-        } else {
-            "src/main/java"
+        outputFile?.let { file ->
+            AsyncApiRegistry.writeYaml(file, bundledDoc)
         }
-        val sourceRoot = output.resolve(sourceRootName)
         val configOptions = parseConfigOptions(configOptionsRaw)
+
         val clientType = configOptions["client.type"]
         val schemaType = configOptions["schema.type"]
-        val options = GeneratorOptions(
-            generatorName = generator,
-            modelPackage = modelPackage,
-            clientPackage = effClientPackage,
-            schemaPackage = effSchemaPackage,
-            outputDir = sourceRoot,
-            generateModels = true,
-            generateSpringKafkaClient = clientType == "spring-kafka",
-            generateQuarkusKafkaClient = clientType == "quarkus-kafka",
-            generateAvroSchema = schemaType == "avro"
-        )
+        val modelAnnotation = configOptions["model.annotation"]
 
-        val coreGenerator = AsyncApiGenerator()
-        coreGenerator.generate(bundledDoc, options)
+        val hasModelPackage = modelPackage != null
+        val hasClientPackage = clientPackage != null
+        val hasSchemaPackage = schemaPackage != null
 
+        if (clientType != null && !hasClientPackage) {
+            throw IllegalArgumentException("client.type requires --client-package")
+        }
+
+        if (schemaType != null && !hasSchemaPackage) {
+            throw IllegalArgumentException("schema.type requires --schema-package")
+        }
+
+        if (modelAnnotation != null && !hasModelPackage) {
+            throw IllegalArgumentException("model.annotation requires --model-package")
+        }
+
+        if (hasModelPackage || hasClientPackage || hasSchemaPackage) {
+            val effectiveModelPackage = modelPackage ?: "unused"
+            val effectiveClientPackage = clientPackage ?: "unused"
+            val effectiveSchemaPackage = schemaPackage ?: "unused"
+            val sourceRootName = if (generator == KOTLIN) {
+                "src/main/kotlin"
+            } else {
+                "src/main/java"
+            }
+            val sourceRoot = output.resolve(sourceRootName)
+            val options = GeneratorOptions(
+                generatorName = generator,
+                modelPackage = effectiveModelPackage,
+                clientPackage = effectiveClientPackage,
+                schemaPackage = effectiveSchemaPackage,
+                outputDir = sourceRoot,
+                generateModels = hasModelPackage,
+                generateSpringKafkaClient = hasClientPackage && clientType == "spring-kafka",
+                generateQuarkusKafkaClient = hasClientPackage && clientType == "quarkus-kafka",
+                generateAvroSchema = hasSchemaPackage && schemaType == "avro",
+                configOptions = configOptions
+            )
+            val coreGenerator = AsyncApiGenerator()
+            coreGenerator.generate(bundledDoc, options)
+        }
         echo("Generation complete.")
     }
     private fun parseConfigOptions(raw: List<String>): Map<String, String> {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -41,7 +41,13 @@ class AsyncApiGenerator {
         when (generatorOptions.generatorName) {
             KOTLIN -> {
                 if (generatorOptions.generateModels) {
-                    val factory = KotlinGeneratorModelFactory(generatorOptions.modelPackage, context, polymorphic)
+                    val annotation = generatorOptions.configOptions["model.annotation"]
+                    val factory = KotlinGeneratorModelFactory(
+                        generatorOptions.modelPackage,
+                        context,
+                        polymorphic,
+                        annotation
+                    )
                     val kotlinGenerationModel = analyzedSchemas.mapNotNull { (name, schema) ->
                         factory.create(name, schema)
                     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinDataClassGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinDataClassGenerator.kt
@@ -33,7 +33,9 @@ class KotlinDataClassGenerator(
                )
            }
 
-        val imports = importMapper.computeImports(model.name, model.properties)
+        val imports = (importMapper.computeImports(model.name, model.properties) + model.classAnnotationImports)
+            .distinct()
+            .sorted()
         val implementsClause = if (model.parentInterfaces.isNotEmpty()) {
             " : " + model.parentInterfaces.joinToString(", ")
         } else {
@@ -46,7 +48,8 @@ class KotlinDataClassGenerator(
             classDocLines = model.description,
             fields = fields,
             imports = imports,
-            implementsClause = implementsClause
+            implementsClause = implementsClause,
+            classAnnotations = model.classAnnotations
         )
 
         val writer = StringWriter()

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
@@ -10,6 +10,7 @@ class KotlinGeneratorModelFactory(
     val packageName: String,
     val context: GeneratorContext,
     val polymorphicRelationships: Map<String, List<String>>,
+    val annotation: String? = null,
 ) {
     private val propertyFactory = PropertyFactory(context)
 
@@ -38,12 +39,20 @@ class KotlinGeneratorModelFactory(
                 val properties = schema.properties?.map { (propName, propSchema) ->
                     propertyFactory.createProperty(propName, propSchema, schema.required ?: emptyList())
                 } ?: emptyList()
+                val (classAnnotations, classAnnotationImports) = if (annotation.isNullOrBlank()) {
+                    emptyList<String>() to emptyList()
+                } else {
+                    val shortName = annotation.substringAfterLast(".")
+                    listOf("@$shortName") to listOf(annotation)
+                }
                 GeneratorItem.DataClassModel(
                     name = name,
                     packageName = packageName,
                     description = description,
                     properties = properties,
-                    parentInterfaces = polymorphicRelationships[name] ?: emptyList()
+                    parentInterfaces = polymorphicRelationships[name] ?: emptyList(),
+                    classAnnotations = classAnnotations,
+                    classAnnotationImports = classAnnotationImports
                 )
             }
             else -> null // This schema type does not result in its own generated file (e.g., a primitive type alias)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/model/GeneratorItem.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/model/GeneratorItem.kt
@@ -11,6 +11,8 @@ sealed interface GeneratorItem {
         override val description: List<String>,
         val properties: List<PropertyModel>,
         val parentInterfaces: List<String>,
+        val classAnnotations: List<String> = emptyList(),
+        val classAnnotationImports: List<String> = emptyList(),
     ) : GeneratorItem
 
     data class EnumClassModel(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/model/KotlinClassTemplate.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/model/KotlinClassTemplate.kt
@@ -7,4 +7,5 @@ data class KotlinClassTemplate(
     val fields: List<Map<String, Any?>>,
     val imports: List<String> = emptyList(),
     val implementsClause: String = "",
+    val classAnnotations: List<String> = emptyList(),
 )

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/model/GeneratorOptions.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/model/GeneratorOptions.kt
@@ -14,7 +14,6 @@ data class GeneratorOptions(
     val generateSpringKafkaClient: Boolean = false,
     val generateQuarkusKafkaClient: Boolean = false,
     val generateAvroSchema: Boolean = false,
-
-    // Experimental options
-    val experimental: Map<String, String> = emptyMap()
+    // Flat config options (for future use)
+    val configOptions: Map<String, String> = emptyMap()
 )

--- a/asyncapi-generator-core/src/main/resources/kotlin/dataClass.mustache
+++ b/asyncapi-generator-core/src/main/resources/kotlin/dataClass.mustache
@@ -20,6 +20,9 @@ import {{.}}
  *
 {{/fields}}
  */
+{{#classAnnotations}}
+{{{.}}}
+{{/classAnnotations}}
 data class {{className}}(
 {{#fields}}
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractKotlinGeneratorClass.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractKotlinGeneratorClass.kt
@@ -27,6 +27,7 @@ abstract class AbstractKotlinGeneratorClass {
         generateModels: Boolean = true,
         generateSpringKafkaClient: Boolean = false,
         generateQuarkusKafkaClient: Boolean = false,
+        configOptions: Map<String, String> = emptyMap(),
     ): String {
         val root = AsyncApiRegistry.readYaml(yaml, asyncApiContext)
         val asyncApi = parser.parse(root)
@@ -44,6 +45,7 @@ abstract class AbstractKotlinGeneratorClass {
             generateModels = generateModels,
             generateSpringKafkaClient = generateSpringKafkaClient,
             generateQuarkusKafkaClient = generateQuarkusKafkaClient,
+            configOptions = configOptions,
         )
         generator.generate(
             asyncApiDocument = bundled,

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/noarg/GenerateNoArgAnnotationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/noarg/GenerateNoArgAnnotationTest.kt
@@ -1,0 +1,38 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin.noarg
+
+import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GenerateNoArgAnnotationTest : AbstractKotlinGeneratorClass() {
+
+    @Test
+    fun `should include no-arg annotation when configured`() {
+        val generated = generateElement(
+            yaml = File("src/test/resources/generator/asyncapi_nullable_types.yaml"),
+            generated = "NullableObject.kt",
+            modelPackage = "dev.banking.asyncapi.generator.core.model.generated.noarg",
+            configOptions = mapOf(
+                "model.annotation" to "com.example.NoArg"
+            )
+        )
+        assertTrue(generated.contains("import com.example.NoArg"))
+        assertTrue(generated.contains("@NoArg"))
+        assertTrue(generated.contains("data class NullableObject"))
+    }
+
+    @Test
+    fun `should not include no-arg annotation when not configured`() {
+        val generated = generateElement(
+            yaml = File("src/test/resources/generator/asyncapi_nullable_types.yaml"),
+            generated = "NullableObject.kt",
+            modelPackage = "dev.banking.asyncapi.generator.core.model.generated.noarg",
+        )
+        assertFalse(
+            generated.contains("@com.example.NoArg"),
+            "NoArg annotation should not be present when not configured"
+        )
+    }
+}

--- a/asyncapi-generator-maven-plugin/src/main/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojo.kt
+++ b/asyncapi-generator-maven-plugin/src/main/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojo.kt
@@ -35,8 +35,8 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
     @Parameter(property = "outputDir", defaultValue = "\${project.build.directory}/generated-sources/asyncapi")
     private lateinit var outputDir: File
 
-    @Parameter(property = "modelPackage", required = true)
-    private lateinit var modelPackage: String
+    @Parameter(property = "modelPackage")
+    private var modelPackage: String? = null
 
     @Parameter(property = "clientPackage")
     private var clientPackage: String? = null
@@ -46,6 +46,7 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
 
     @Parameter
     private var configOptions: Map<String, String> = emptyMap()
+
     private val context = AsyncApiContext()
     private val parser = AsyncApiParser(context)
     private val validator = AsyncApiValidator(context)
@@ -70,7 +71,7 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
 
         outputFile?.let { file ->
             log.info("Writing bundled AsyncAPI specification to: ${file.absolutePath}")
-            AsyncApiRegistry.writeYaml(outputDir.resolve(file), bundled)
+            AsyncApiRegistry.writeYaml(file, bundled)
         }
 
         val targetLanguage = try {
@@ -82,18 +83,44 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
         }
         val clientType = configOptions["client.type"]
         val schemaType = configOptions["schema.type"]
-        val options = GeneratorOptions(
-            generatorName = targetLanguage,
-            modelPackage = modelPackage,
-            clientPackage = clientPackage ?: modelPackage,
-            schemaPackage = schemaPackage ?: modelPackage,
-            outputDir = outputDir,
-            generateModels = true,
-            generateSpringKafkaClient = clientType == "spring-kafka",
-            generateQuarkusKafkaClient = clientType == "quarkus-kafka",
-            generateAvroSchema = schemaType == "avro",
-        )
-        generator.generate(bundled, options)
+        val modelAnnotation = configOptions["model.annotation"]
+
+        val hasModelPackage = modelPackage != null
+        val hasClientPackage = clientPackage != null
+        val hasSchemaPackage = schemaPackage != null
+
+        if (clientType != null && !hasClientPackage) {
+            throw MojoExecutionException("client.type requires clientPackage")
+        }
+
+        if (schemaType != null && !hasSchemaPackage) {
+            throw MojoExecutionException("schema.type requires schemaPackage")
+        }
+
+        if (modelAnnotation != null && !hasModelPackage) {
+            throw MojoExecutionException("model.annotation requires modelPackage")
+        }
+
+        if (hasModelPackage || hasClientPackage || hasSchemaPackage) {
+
+            val effectiveModelPackage = modelPackage ?: "unused"
+            val effectiveClientPackage = clientPackage ?: "unused"
+            val effectiveSchemaPackage = schemaPackage ?: "unused"
+
+            val options = GeneratorOptions(
+                generatorName = targetLanguage,
+                modelPackage = effectiveModelPackage,
+                clientPackage = effectiveClientPackage,
+                schemaPackage = effectiveSchemaPackage,
+                outputDir = outputDir,
+                generateModels = hasModelPackage,
+                generateSpringKafkaClient = hasClientPackage && clientType == "spring-kafka",
+                generateQuarkusKafkaClient = hasClientPackage && clientType == "quarkus-kafka",
+                generateAvroSchema = hasSchemaPackage && schemaType == "avro",
+                configOptions = configOptions
+            )
+            generator.generate(bundled, options)
+        }
 
         project.addCompileSourceRoot(outputDir.absolutePath)
         log.info("asyncapi-generator-maven-plugin completed successfully")

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-only-relative/pom.xml
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-only-relative/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dev.banking.asyncapi.generator.it</groupId>
+    <artifactId>bundle-only-relative</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>dev.banking.asyncapi.generator</groupId>
+                <artifactId>asyncapi-generator-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>bundle-only-relative</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputFile>${project.basedir}/src/main/resources/asyncapi.yaml</inputFile>
+                            <outputFile>bundled/relative-bundled.yaml</outputFile>
+                            <generatorName>kotlin</generatorName>
+                            <!-- no modelPackage/clientPackage/schemaPackage -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-only-relative/src/main/resources/asyncapi.yaml
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-only-relative/src/main/resources/asyncapi.yaml
@@ -1,0 +1,24 @@
+asyncapi: 3.0.0
+info:
+  title: Bundle Only Relative
+  version: 1.0.0
+channels:
+  somethingUpdated:
+    address: test.bundle.only.relative.v1
+    messages:
+      - $ref: '#/components/messages/SomethingUpdated'
+components:
+  messages:
+    SomethingUpdated:
+      name: SomethingUpdated
+      title: SomethingUpdated
+      payload:
+        $ref: '#/components/schemas/SomethingUpdated'
+  schemas:
+    SomethingUpdated:
+      type: object
+      properties:
+        id:
+          type: string
+      required:
+        - id

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-only-relative/verify.groovy
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-only-relative/verify.groovy
@@ -1,0 +1,6 @@
+def bundled = new File(basedir, "bundled/relative-bundled.yaml")
+assert bundled.exists() : "Expected bundled/relative-bundled.yaml to exist"
+assert bundled.length() > 0 : "Expected bundled/relative-bundled.yaml to be non-empty"
+
+def generatedDir = new File(basedir, "target/generated-sources/asyncapi")
+assert !generatedDir.exists() : "Did not expect any generated code when no packages are set"

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-only/pom.xml
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-only/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dev.banking.asyncapi.generator.it</groupId>
+    <artifactId>bundle-only</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>dev.banking.asyncapi.generator</groupId>
+                <artifactId>asyncapi-generator-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>bundle-only</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputFile>${project.basedir}/src/main/resources/asyncapi.yaml</inputFile>
+                            <outputFile>${project.build.directory}/bundled.yaml</outputFile>
+                            <generatorName>kotlin</generatorName>
+                            <!-- no modelPackage/clientPackage/schemaPackage -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-only/src/main/resources/asyncapi.yaml
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-only/src/main/resources/asyncapi.yaml
@@ -1,0 +1,24 @@
+asyncapi: 3.0.0
+info:
+  title: Bundle Only
+  version: 1.0.0
+channels:
+  somethingUpdated:
+    address: test.bundle.only.v1
+    messages:
+      - $ref: '#/components/messages/SomethingUpdated'
+components:
+  messages:
+    SomethingUpdated:
+      name: SomethingUpdated
+      title: SomethingUpdated
+      payload:
+        $ref: '#/components/schemas/SomethingUpdated'
+  schemas:
+    SomethingUpdated:
+      type: object
+      properties:
+        id:
+          type: string
+      required:
+        - id

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-only/verify.groovy
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-only/verify.groovy
@@ -1,0 +1,6 @@
+def bundled = new File(basedir, "target/bundled.yaml")
+assert bundled.exists() : "Expected bundled.yaml to exist"
+assert bundled.length() > 0 : "Expected bundled.yaml to be non-empty"
+
+def generatedDir = new File(basedir, "target/generated-sources/asyncapi")
+assert !generatedDir.exists() : "Did not expect any generated code when no packages are set"

--- a/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojoTest.kt
+++ b/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojoTest.kt
@@ -43,9 +43,11 @@ class AsyncApiGeneratorMojoTest {
             modelPackage("com.example.kafka.model")
             clientPackage("com.example.kafka.client")
             generatorName("kotlin")
-            configOptions(mapOf(
-                "client.type" to "spring-kafka"
-            ))
+            configOptions(
+                mapOf(
+                    "client.type" to "spring-kafka"
+                )
+            )
         }.execute()
         val clientDir = File("target/generated-sources/asyncapi/com/example/kafka/client")
         assertTrue(clientDir.exists(), "Client directory should exist")
@@ -60,9 +62,11 @@ class AsyncApiGeneratorMojoTest {
             modelPackage("com.example.kafka.model")
             clientPackage("com.example.kafka.client")
             generatorName("java")
-            configOptions(mapOf(
-                "client.type" to "spring-kafka"
-            ))
+            configOptions(
+                mapOf(
+                    "client.type" to "spring-kafka"
+                )
+            )
         }.execute()
         val clientDir = File("target/generated-sources/asyncapi/com/example/kafka/client")
         assertTrue(clientDir.exists(), "Client directory should exist")
@@ -77,7 +81,7 @@ class AsyncApiGeneratorMojoTest {
             project(MavenProject())
             inputFile(inputPath("asyncapi_kafka_complex.yaml"))
             outputDir(outputPath("target/generated-sources/asyncapi"))
-            outputFile(File("bundled/asyncapi.bundled.yaml"))
+            outputFile(File("target/generated-sources/asyncapi/bundled/asyncapi.bundled.yaml"))
             modelPackage("com.example.bundled")
             generatorName("kotlin")
         }.execute()
@@ -95,12 +99,33 @@ class AsyncApiGeneratorMojoTest {
             modelPackage("com.example.avro.model")
             schemaPackage("com.example.avro.schema")
             generatorName("kotlin")
-            configOptions(mapOf(
-                "schema.type" to "avro"
-            ))
+            configOptions(
+                mapOf(
+                    "schema.type" to "avro"
+                )
+            )
         }.execute()
         val schemaDir = File("target/generated-sources/asyncapi/com/example/avro/schema")
         assertTrue(schemaDir.exists(), "Schema directory should exist")
+    }
+
+    @Test
+    fun `should allow bundle-only output with no packages`() {
+        val bundledFile = File("target/generated-sources/asyncapi/bundled/asyncapi.bundle-only.yaml")
+        if (bundledFile.exists()) bundledFile.delete()
+        val bundleOnlyOutputDir = outputPath("target/generated-sources/asyncapi-bundle-only")
+        AsyncApiGeneratorMojo().apply {
+            project(MavenProject())
+            inputFile(inputPath("asyncapi_kafka_complex.yaml"))
+            outputDir(bundleOnlyOutputDir)
+            outputFile(File("target/generated-sources/asyncapi/bundled/asyncapi.bundle-only.yaml"))
+            generatorName("kotlin")
+            // no modelPackage/clientPackage/schemaPackage set
+        }.execute()
+        assertTrue(bundledFile.exists(), "Bundled output file should exist")
+        assertTrue(bundledFile.length() > 0, "Bundled output file should not be empty")
+        val generatedPackageRoot = bundleOnlyOutputDir.resolve("com")
+        assertTrue(!generatedPackageRoot.exists(), "No code should be generated when packages are not set")
     }
 
     @Test

--- a/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/MavenTestHelper.kt
+++ b/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/MavenTestHelper.kt
@@ -48,10 +48,6 @@ object MavenTestHelper {
         writeField("configOptions", value)
     }
 
-    fun Mojo.experimental(value: Map<String, String>) {
-        writeField("experimental", value)
-    }
-
     private fun Mojo.writeField(name: String, value: Any?) {
         val field = this.javaClass.getDeclaredField(name)
         field.isAccessible = true


### PR DESCRIPTION
- **updated Main.kt for 'configOptions' and tests**
- **added tests for better coverage with configOptions setup**

Updated the CLI to use flat `--config-option key=value` flags for configOptions, matching Maven/Gradle, #38. Legacy `--spring-kafka` and `--avro` options are replaced by `client.type` and `schema.type` mapping in GeneratorOptions. Tests were updated and expanded to cover schema generation and invalid config‑option parsing