### PR TITLE
renamed outputDir to codegenOutputDirectory and added resourceDirectory

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -53,7 +53,7 @@ class AsyncApiGenerator {
                     }
                     val kotlinModelGenerator = KotlinGenerator(
                         packageName = generatorOptions.modelPackage,
-                        outputDir = generatorOptions.outputDir,
+                        outputDir = generatorOptions.codegenOutputDirectory,
                         generationModel = kotlinGenerationModel,
                     )
                     kotlinModelGenerator.generate()
@@ -61,7 +61,7 @@ class AsyncApiGenerator {
 
                 if (generatorOptions.generateSpringKafkaClient) {
                     val kafkaGenerator = KotlinSpringKafkaGenerator(
-                        outputDir = generatorOptions.outputDir,
+                        outputDir = generatorOptions.codegenOutputDirectory,
                         clientPackage = generatorOptions.clientPackage,
                         modelPackage = generatorOptions.modelPackage,
                     )
@@ -81,14 +81,14 @@ class AsyncApiGenerator {
                     }
                     val javaGenerator = JavaGenerator(
                         packageName = generatorOptions.modelPackage,
-                        outputDir = generatorOptions.outputDir,
+                        outputDir = generatorOptions.codegenOutputDirectory,
                         generationModel = javaGenerationModel,
                     )
                     javaGenerator.generate()
                 }
                 if (generatorOptions.generateSpringKafkaClient) {
                     val kafkaGenerator = JavaSpringKafkaGenerator(
-                        outputDir = generatorOptions.outputDir,
+                        outputDir = generatorOptions.codegenOutputDirectory,
                         clientPackage = generatorOptions.clientPackage,
                         modelPackage = generatorOptions.modelPackage,
                     )
@@ -103,7 +103,7 @@ class AsyncApiGenerator {
 
         if (generatorOptions.generateAvroSchema) {
             val avroGenerator = AvroGenerator(
-                outputDir = generatorOptions.outputDir,
+                outputDir = generatorOptions.resourceOutputDirectory,
                 packageName = generatorOptions.schemaPackage,
             )
             avroGenerator.generate(analyzedSchemas)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/model/GeneratorOptions.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/model/GeneratorOptions.kt
@@ -7,7 +7,8 @@ data class GeneratorOptions(
     val modelPackage: String,
     val clientPackage: String,
     val schemaPackage: String,
-    val outputDir: File,
+    val codegenOutputDirectory: File,
+    val resourceOutputDirectory: File,
 
     // Feature Flags
     val generateModels: Boolean = true,

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractAvroGeneratorClass.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractAvroGeneratorClass.kt
@@ -19,7 +19,8 @@ abstract class AbstractAvroGeneratorClass {
 
     protected fun generateAvro(
         yaml: File,
-        outputDir: File = File("target/generated-sources/asyncapi"),
+        codegenOutputDirectory: File = File("target/generated-sources/asyncapi"),
+        resourceOutputDirectory: File = File("target/generated-resources/asyncapi"),
         packageName: String,
         schema: String? = null,
     ): String {
@@ -36,7 +37,8 @@ abstract class AbstractAvroGeneratorClass {
             modelPackage = packageName,
             clientPackage = packageName,
             schemaPackage = packageName,
-            outputDir = outputDir,
+            codegenOutputDirectory = codegenOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
             generateModels = false,
             generateSpringKafkaClient = false,
             generateAvroSchema = true,
@@ -49,7 +51,7 @@ abstract class AbstractAvroGeneratorClass {
 
         if (schema != null) {
             val packagePath = packageName.replace('.', '/')
-            val output = outputDir
+            val output = resourceOutputDirectory
                 .resolve(packagePath)
                 .resolve(schema)
             if (output.exists()) return output.readText()

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractJavaGeneratorClass.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractJavaGeneratorClass.kt
@@ -19,7 +19,8 @@ abstract class AbstractJavaGeneratorClass {
 
     protected fun generateElement(
         yaml: File,
-        outputDir: File = File("target/generated-sources/asyncapi"),
+        codegenOutputDirectory: File = File("target/generated-sources/asyncapi"),
+        resourceOutputDirectory: File = File("target/generated-resources/asyncapi"),
         generated: String? = null,
         modelPackage: String,
         clientPackage: String? = null,
@@ -40,7 +41,8 @@ abstract class AbstractJavaGeneratorClass {
             modelPackage = modelPackage,
             clientPackage = clientPackage ?: modelPackage,
             schemaPackage = schemaPackage ?: modelPackage,
-            outputDir = outputDir,
+            codegenOutputDirectory = codegenOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
             generateModels = generateModels,
             generateSpringKafkaClient = generateSpringKafkaClient,
             generateQuarkusKafkaClient = generateQuarkusKafkaClient,
@@ -52,7 +54,7 @@ abstract class AbstractJavaGeneratorClass {
 
         if (generated != null) {
             val modelPath = modelPackage.replace('.', '/')
-            val output = outputDir
+            val output = codegenOutputDirectory
                 .resolve(modelPath)
                 .resolve(generated)
             return output.readText()

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractKotlinGeneratorClass.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AbstractKotlinGeneratorClass.kt
@@ -20,7 +20,8 @@ abstract class AbstractKotlinGeneratorClass {
     fun generateElement(
         yaml: File,
         generated: String? = null,
-        outputDir: File = File("target/generated-sources/asyncapi"),
+        codegenOutputDirectory: File = File("target/generated-sources/asyncapi"),
+        resourceOutputDirectory: File = File("target/generated-resources/asyncapi"),
         modelPackage: String,
         clientPackage: String? = null,
         schemaPackage: String? = null,
@@ -41,7 +42,8 @@ abstract class AbstractKotlinGeneratorClass {
             modelPackage = modelPackage,
             clientPackage = clientPackage ?: modelPackage,
             schemaPackage = schemaPackage ?: modelPackage,
-            outputDir = outputDir,
+            codegenOutputDirectory = codegenOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
             generateModels = generateModels,
             generateSpringKafkaClient = generateSpringKafkaClient,
             generateQuarkusKafkaClient = generateQuarkusKafkaClient,
@@ -53,7 +55,7 @@ abstract class AbstractKotlinGeneratorClass {
         )
         if (generated != null) {
             val modelPath = modelPackage.replace('.', '/')
-            val output = outputDir
+            val output = codegenOutputDirectory
                 .resolve(modelPath)
                 .resolve(generated)
             return output.readText()

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/complexorder/AvroComplexOrderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/complexorder/AvroComplexOrderTest.kt
@@ -47,7 +47,7 @@ class AvroComplexOrderTest : AbstractAvroGeneratorClass() {
         )
 
         val packagePath = "com/example/avro"
-        val outputPath =  File("target/generated-sources/asyncapi")
+        val outputPath =  File("target/generated-resources/asyncapi")
         val packageDir = outputPath.resolve(packagePath)
 
         assertTrue(packageDir.resolve("ComplexOrderPayloadType.avsc").exists(), "Main schema missing")

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/enumvalue/AvroEnumTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/enumvalue/AvroEnumTest.kt
@@ -20,7 +20,7 @@ class AvroEnumTest : AbstractAvroGeneratorClass() {
         assertTrue(content.contains("\"type\": [\"null\", \"com.example.avro.TaskStatus\"]"), "TaskStatus reference missing")
         assertTrue(content.contains("\"type\": [\"null\", \"com.example.avro.Priority\"]"), "Priority reference missing")
 
-        val statusFile = File("target/generated-sources/asyncapi/com/example/avro/TaskStatus.avsc")
+        val statusFile = File("target/generated-resources/asyncapi/com/example/avro/TaskStatus.avsc")
         assertTrue(statusFile.exists(), "TaskStatus.avsc missing")
         val statusContent = statusFile.readText()
 
@@ -28,7 +28,7 @@ class AvroEnumTest : AbstractAvroGeneratorClass() {
         assertTrue(statusContent.contains("\"symbols\": ["), "TaskStatus symbols missing")
         assertTrue(statusContent.contains("\"OPEN\""), "Symbol OPEN missing")
 
-        val priorityFile = File("target/generated-sources/asyncapi/com/example/avro/Priority.avsc")
+        val priorityFile = File("target/generated-resources/asyncapi/com/example/avro/Priority.avsc")
         assertTrue(priorityFile.exists(), "Priority.avsc missing")
         val priorityContent = priorityFile.readText()
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/oneof/AvroOneOfTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/oneof/AvroOneOfTest.kt
@@ -16,7 +16,7 @@ class AvroOneOfTest : AbstractAvroGeneratorClass() {
             schema = null
         )
 
-        val outputDir = File("target/generated-sources/asyncapi")
+        val outputDir = File("target/generated-resources/asyncapi")
         val packageDir = outputDir.resolve("com/example/poly")
 
         assertTrue(packageDir.resolve("CardPayment.avsc").exists(), "CardPayment missing")

--- a/asyncapi-generator-gradle-plugin/src/main/kotlin/dev/banking/asyncapi/generator/gradle/plugin/AsyncApiPlugin.kt
+++ b/asyncapi-generator-gradle-plugin/src/main/kotlin/dev/banking/asyncapi/generator/gradle/plugin/AsyncApiPlugin.kt
@@ -15,18 +15,17 @@ class AsyncApiPlugin : Plugin<Project> {
             project.objects
         )
 
-        val task = project.tasks.register<GenerateAsyncApiTask>("generateAsyncApi") {
-            group = "code generation"
-            description = "Generates source code and clients from an AsyncAPI specification"
+        extension.inputFile.convention(project.layout.projectDirectory.file("src/main/resources/asyncapi.yaml"))
+        extension.codegenOutputDirectory.convention(project.layout.buildDirectory.dir("generated/asyncapi"))
+        extension.resourceOutputDirectory.convention(project.layout.buildDirectory.dir("generated-resources/asyncapi"))
+        extension.generatorName.convention("kotlin")
 
-            inputFile.convention(project.layout.projectDirectory.file("src/main/resources/asyncapi.yaml"))
-            outputDir.convention(project.layout.buildDirectory.dir("generated/asyncapi"))
-            modelPackage.convention("com.example.asyncapi.model")
-            generatorName.convention("kotlin")
+        val task = project.tasks.register<GenerateAsyncApiTask>("generateAsyncApi") {
 
             inputFile.set(extension.inputFile)
             outputFile.set(extension.outputFile)
-            outputDir.set(extension.outputDir)
+            codegenOutputDirectory.set(extension.codegenOutputDirectory)
+            resourceOutputDirectory.set(extension.resourceOutputDirectory)
             modelPackage.set(extension.modelPackage)
             clientPackage.set(extension.clientPackage)
             schemaPackage.set(extension.schemaPackage)
@@ -40,8 +39,8 @@ class AsyncApiPlugin : Plugin<Project> {
             if (javaPluginExtension != null) {
                 val sourceSet = javaPluginExtension.sourceSets.getByName("main")
 
-                sourceSet.java.srcDir(task.map { it.outputDir.dir("src/main/kotlin") })
-                sourceSet.java.srcDir(task.map { it.outputDir.dir("src/main/java") })
+                sourceSet.java.srcDir(task.map { it.codegenOutputDirectory.dir("src/main/kotlin") })
+                sourceSet.java.srcDir(task.map { it.codegenOutputDirectory.dir("src/main/java") })
             }
         }
     }

--- a/asyncapi-generator-gradle-plugin/src/main/kotlin/dev/banking/asyncapi/generator/gradle/plugin/extensions/AsyncApiExtension.kt
+++ b/asyncapi-generator-gradle-plugin/src/main/kotlin/dev/banking/asyncapi/generator/gradle/plugin/extensions/AsyncApiExtension.kt
@@ -10,7 +10,8 @@ import javax.inject.Inject
 abstract class AsyncApiExtension @Inject constructor(objects: ObjectFactory) {
     val inputFile: RegularFileProperty = objects.fileProperty()
     val outputFile: RegularFileProperty = objects.fileProperty()
-    val outputDir: DirectoryProperty = objects.directoryProperty()
+    val codegenOutputDirectory: DirectoryProperty = objects.directoryProperty()
+    val resourceOutputDirectory: DirectoryProperty = objects.directoryProperty()
 
     val modelPackage: Property<String> = objects.property(String::class.java)
     val clientPackage: Property<String> = objects.property(String::class.java)

--- a/asyncapi-generator-gradle-plugin/src/main/kotlin/dev/banking/asyncapi/generator/gradle/plugin/tasks/GenerateAsyncApiTask.kt
+++ b/asyncapi-generator-gradle-plugin/src/main/kotlin/dev/banking/asyncapi/generator/gradle/plugin/tasks/GenerateAsyncApiTask.kt
@@ -29,7 +29,10 @@ abstract class GenerateAsyncApiTask : DefaultTask() {
     abstract val outputFile: RegularFileProperty
 
     @get:OutputDirectory
-    abstract val outputDir: DirectoryProperty
+    abstract val codegenOutputDirectory: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val resourceOutputDirectory: DirectoryProperty
 
     @get:Input
     @get:Optional
@@ -87,7 +90,7 @@ abstract class GenerateAsyncApiTask : DefaultTask() {
             KOTLIN -> "src/main/kotlin"
             JAVA -> "src/main/java"
         }
-        val sourceRoot = outputDir.get().asFile.resolve(sourceRootName)
+        val codegenSourceRoot = codegenOutputDirectory.get().asFile.resolve(sourceRootName)
         val configMap = configOptions.getOrElse(emptyMap())
 
         val clientType = configMap["client.type"]
@@ -120,7 +123,8 @@ abstract class GenerateAsyncApiTask : DefaultTask() {
                 modelPackage = effectiveModelPackage,
                 clientPackage = effectiveClientPackage,
                 schemaPackage = effectiveSchemaPackage,
-                outputDir = sourceRoot,
+                codegenOutputDirectory = codegenSourceRoot,
+                resourceOutputDirectory = resourceOutputDirectory.get().asFile,
                 generateModels = hasModelPackage,
                 generateSpringKafkaClient = hasClientPackage && clientType == "spring-kafka",
                 generateQuarkusKafkaClient = hasClientPackage && clientType == "quarkus-kafka",

--- a/asyncapi-generator-gradle-plugin/src/test/kotlin/dev/banking/asyncapi/generator/gradle/plugin/AsyncApiPluginTest.kt
+++ b/asyncapi-generator-gradle-plugin/src/test/kotlin/dev/banking/asyncapi/generator/gradle/plugin/AsyncApiPluginTest.kt
@@ -23,8 +23,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("specs/api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
-
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   modelPackage.set("com.example.model")
                   generatorName.set("kotlin")
               }"""
@@ -32,12 +31,10 @@ class AsyncApiPluginTest {
 
         val result = GradleTestHelper.runGradle(projectDir, "generateAsyncApi")
         assertEquals(TaskOutcome.SUCCESS, result.task(":generateAsyncApi")?.outcome)
-
-        val outputDir = File(projectDir, "build/generated/src/main/kotlin/com/example/model")
+        val outputDir = File(projectDir, "build/generated/asyncapi/src/main/kotlin/com/example/model")
         assertTrue(outputDir.exists(), "Output directory should exist")
         assertEquals(outputDir.list()?.isNotEmpty(), true, "Output directory should not be empty")
-
-        GradleTestHelper.copyGeneratedOutputToProjectBuild(File(projectDir, "build/generated"))
+        GradleTestHelper.copyGeneratedOutputToProjectBuild(File(projectDir, "build/generated/asyncapi"))
     }
 
     @Test
@@ -50,7 +47,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   outputFile.set(layout.buildDirectory.file("bundled.yaml"))
                   generatorName.set("kotlin")
                   // no modelPackage/clientPackage/schemaPackage set
@@ -61,8 +58,9 @@ class AsyncApiPluginTest {
         val bundledFile = File(projectDir, "build/bundled.yaml")
         assertTrue(bundledFile.exists(), "Bundled file should exist")
         assertTrue(bundledFile.length() > 0, "Bundled file should not be empty")
-        val generatedPackageRoot = File(projectDir, "build/generated/src/main/kotlin/com")
-        assertTrue(!generatedPackageRoot.exists(), "No code should be generated when packages are not set")
+        val codegenRoot = File(projectDir, "build/generated/asyncapi/src/main/kotlin")
+        val hasKotlinFiles = codegenRoot.exists() && codegenRoot.walkTopDown().any { it.isFile && it.extension == "kt" }
+        assertTrue(!hasKotlinFiles, "No Kotlin files should be generated when packages are not set")
     }
 
     @Test
@@ -74,7 +72,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   modelPackage.set("com.example.model")
                   generatorName.set("kotlin")
                   configOptions.set(mapOf(
@@ -98,7 +96,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("specs/api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   modelPackage.set("com.example.model")
                   clientPackage.set("com.example.client")
                   schemaPackage.set("com.example.schema")
@@ -107,9 +105,9 @@ class AsyncApiPluginTest {
         )
         val result = GradleTestHelper.runGradle(projectDir, "generateAsyncApi")
         assertEquals(TaskOutcome.SUCCESS, result.task(":generateAsyncApi")?.outcome)
-        val modelDir = File(projectDir, "build/generated/src/main/kotlin/com/example/model")
-        val clientDir = File(projectDir, "build/generated/src/main/kotlin/com/example/client")
-        val schemaDir = File(projectDir, "build/generated/src/main/kotlin/com/example/schema")
+        val modelDir = File(projectDir, "build/generated/asyncapi/src/main/kotlin/com/example/model")
+        val clientDir = File(projectDir, "build/generated/asyncapi/src/main/kotlin/com/example/client")
+        val schemaDir = File(projectDir, "build/generated/asyncapi/src/main/kotlin/com/example/schema")
         assertTrue(modelDir.exists(), "Model directory should exist")
         assertTrue(!clientDir.exists(), "Client directory should not exist without client.type")
         assertTrue(!schemaDir.exists(), "Schema directory should not exist without schema.type")
@@ -129,8 +127,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("specs/api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
-
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   modelPackage.set("com.example.kafka.model")
                   clientPackage.set("com.example.kafka.client")
                   generatorName.set("kotlin")
@@ -142,11 +139,9 @@ class AsyncApiPluginTest {
 
         val result = GradleTestHelper.runGradle(projectDir, "generateAsyncApi")
         assertEquals(TaskOutcome.SUCCESS, result.task(":generateAsyncApi")?.outcome)
-
-        val clientDir = File(projectDir, "build/generated/src/main/kotlin/com/example/kafka/client")
+        val clientDir = File(projectDir, "build/generated/asyncapi/src/main/kotlin/com/example/kafka/client")
         assertTrue(clientDir.exists(), "Client directory should exist")
-
-        GradleTestHelper.copyGeneratedOutputToProjectBuild(File(projectDir, "build/generated"))
+        GradleTestHelper.copyGeneratedOutputToProjectBuild(File(projectDir, "build/generated/asyncapi"))
     }
 
     @Test
@@ -163,8 +158,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("specs/api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
-
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   modelPackage.set("com.example.kafka.model")
                   clientPackage.set("com.example.kafka.client")
                   generatorName.set("java")
@@ -176,11 +170,9 @@ class AsyncApiPluginTest {
 
         val result = GradleTestHelper.runGradle(projectDir, "generateAsyncApi")
         assertEquals(TaskOutcome.SUCCESS, result.task(":generateAsyncApi")?.outcome)
-
-        val clientDir = File(projectDir, "build/generated/src/main/java/com/example/kafka/client")
+        val clientDir = File(projectDir, "build/generated/asyncapi/src/main/java/com/example/kafka/client")
         assertTrue(clientDir.exists(), "Client directory should exist")
-
-        GradleTestHelper.copyGeneratedOutputToProjectBuild(File(projectDir, "build/generated"))
+        GradleTestHelper.copyGeneratedOutputToProjectBuild(File(projectDir, "build/generated/asyncapi"))
     }
 
     @Test
@@ -194,9 +186,9 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   outputFile.set(layout.buildDirectory.file("bundled.yaml")) // Configured output file
-
+                  
                   modelPackage.set("com.example.bundled")
                   generatorName.set("kotlin")
               }"""
@@ -222,7 +214,8 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("specs/api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
+                  resourceOutputDirectory.set(layout.buildDirectory.dir("generated-resources/asyncapi"))
                   modelPackage.set("com.example.avro.model")
                   schemaPackage.set("com.example.avro.schema")
                   generatorName.set("kotlin")
@@ -233,7 +226,7 @@ class AsyncApiPluginTest {
         )
         val result = GradleTestHelper.runGradle(projectDir, "generateAsyncApi")
         assertEquals(TaskOutcome.SUCCESS, result.task(":generateAsyncApi")?.outcome)
-        val schemaDir = File(projectDir, "build/generated/src/main/kotlin/com/example/avro/schema")
+        val schemaDir = File(projectDir, "build/generated-resources/asyncapi/com/example/avro/schema")
         assertTrue(schemaDir.exists(), "Schema directory should exist")
     }
 
@@ -246,7 +239,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("missing.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   modelPackage.set("com.example.fail")
                   generatorName.set("kotlin")
               }"""
@@ -268,7 +261,7 @@ class AsyncApiPluginTest {
               plugins { id("dev.banking.asyncapi.generator") }
               asyncapiGenerate {
                   inputFile.set(file("api.yaml"))
-                  outputDir.set(layout.buildDirectory.dir("generated"))
+                  codegenOutputDirectory.set(layout.buildDirectory.dir("generated/asyncapi"))
                   modelPackage.set("com.example.fail")
                   generatorName.set("python") // Invalid
               }"""

--- a/asyncapi-generator-maven-plugin/src/main/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojo.kt
+++ b/asyncapi-generator-maven-plugin/src/main/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojo.kt
@@ -32,8 +32,11 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
     @Parameter(property = "outputFile")
     private var outputFile: File? = null
 
-    @Parameter(property = "outputDir", defaultValue = "\${project.build.directory}/generated-sources/asyncapi")
-    private lateinit var outputDir: File
+    @Parameter(property = "codegenOutputDirectory", defaultValue = "\${project.build.directory}/generated-sources/asyncapi")
+    private lateinit var codegenOutputDirectory: File
+
+    @Parameter(property = "resourceOutputDirectory", defaultValue = "\${project.build.directory}/generated-resources/asyncapi")
+    private lateinit var resourceOutputDirectory: File
 
     @Parameter(property = "modelPackage")
     private var modelPackage: String? = null
@@ -112,7 +115,8 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
                 modelPackage = effectiveModelPackage,
                 clientPackage = effectiveClientPackage,
                 schemaPackage = effectiveSchemaPackage,
-                outputDir = outputDir,
+                codegenOutputDirectory = codegenOutputDirectory,
+                resourceOutputDirectory = resourceOutputDirectory,
                 generateModels = hasModelPackage,
                 generateSpringKafkaClient = hasClientPackage && clientType == "spring-kafka",
                 generateQuarkusKafkaClient = hasClientPackage && clientType == "quarkus-kafka",
@@ -122,7 +126,7 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
             generator.generate(bundled, options)
         }
 
-        project.addCompileSourceRoot(outputDir.absolutePath)
+        project.addCompileSourceRoot(codegenOutputDirectory.absolutePath)
         log.info("asyncapi-generator-maven-plugin completed successfully")
     }
 }

--- a/asyncapi-generator-maven-plugin/src/test/it/codegen-output-only/pom.xml
+++ b/asyncapi-generator-maven-plugin/src/test/it/codegen-output-only/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dev.banking.asyncapi.generator.it</groupId>
+    <artifactId>codegen-output-only</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>dev.banking.asyncapi.generator</groupId>
+                <artifactId>asyncapi-generator-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>codegen-only</id>
+                        <phase>compile</phase>
+                        <goals><goal>generate</goal></goals>
+                        <configuration>
+                            <inputFile>${project.basedir}/src/main/resources/asyncapi.yaml</inputFile>
+                            <codegenOutputDirectory>${project.build.directory}/custom-codegen</codegenOutputDirectory>
+                            <modelPackage>com.example.codegen</modelPackage>
+                            <generatorName>kotlin</generatorName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/asyncapi-generator-maven-plugin/src/test/it/codegen-output-only/src/main/resources/asyncapi.yaml
+++ b/asyncapi-generator-maven-plugin/src/test/it/codegen-output-only/src/main/resources/asyncapi.yaml
@@ -1,0 +1,22 @@
+asyncapi: 3.0.0
+info:
+  title: Codegen Output Only
+  version: 1.0.0
+channels:
+  sample:
+    address: test.codegen.v1
+    messages:
+      - $ref: '#/components/messages/SampleMessage'
+components:
+  messages:
+    SampleMessage:
+      name: SampleMessage
+      payload:
+        $ref: '#/components/schemas/SampleMessage'
+  schemas:
+    SampleMessage:
+      type: object
+      properties:
+        id:
+          type: string
+      required: [id]

--- a/asyncapi-generator-maven-plugin/src/test/it/codegen-output-only/verify.groovy
+++ b/asyncapi-generator-maven-plugin/src/test/it/codegen-output-only/verify.groovy
@@ -1,0 +1,6 @@
+def codegenBase = new File(basedir, "target/custom-codegen")
+
+def modelDir = new File(codegenBase, "com/example/codegen")
+
+assert modelDir.exists() : "Expected codegen output directory to exist"
+assert modelDir.list().length > 0 : "Expected generated source files in codegen output"

--- a/asyncapi-generator-maven-plugin/src/test/it/config-merge/verify.groovy
+++ b/asyncapi-generator-maven-plugin/src/test/it/config-merge/verify.groovy
@@ -1,12 +1,13 @@
-def base = new File(basedir, "target/generated-sources/asyncapi")
+def codegenBase = new File(basedir, "target/generated-sources/asyncapi")
+def resourceBase = new File(basedir, "target/generated-resources/asyncapi")
 
 // define where the generated files should be for each contract, based on the configuration in the pom.xml
-def aClientDir = new File(base, "com/example/a/client")
-def aSchemaDir = new File(base, "com/example/a/schema")
-def bClientDir = new File(base, "com/example/b/client")
-def bSchemaDir = new File(base, "com/example/b/schema")
-def aModelDir = new File(base, "com/example/a/model")
-def bModelDir = new File(base, "com/example/b/model")
+def aClientDir = new File(codegenBase, "com/example/a/client")
+def aSchemaDir = new File(resourceBase, "com/example/a/schema")
+def bClientDir = new File(codegenBase, "com/example/b/client")
+def bSchemaDir = new File(resourceBase, "com/example/b/schema")
+def aModelDir = new File(codegenBase, "com/example/a/model")
+def bModelDir = new File(codegenBase, "com/example/b/model")
 
 // assert that the expected directories exist or do not exist based on the configuration in the pom.xml
 assert aModelDir.exists() : "Expected model directory for contract A"

--- a/asyncapi-generator-maven-plugin/src/test/it/per-execution-only/verify.groovy
+++ b/asyncapi-generator-maven-plugin/src/test/it/per-execution-only/verify.groovy
@@ -1,12 +1,13 @@
-def base = new File(basedir, "target/generated-sources/asyncapi")
+def codegenBase = new File(basedir, "target/generated-sources/asyncapi")
+def resourceBase = new File(basedir, "target/generated-resources/asyncapi")
 
 // Verify that the expected directories were generated based on the per-execution configuration
-def aClientDir = new File(base, "com/example/a/client")
-def aSchemaDir = new File(base, "com/example/a/schema")
-def bClientDir = new File(base, "com/example/b/client")
-def bSchemaDir = new File(base, "com/example/b/schema")
-def aModelDir = new File(base, "com/example/a/model")
-def bModelDir = new File(base, "com/example/b/model")
+def aClientDir = new File(codegenBase, "com/example/a/client")
+def aSchemaDir = new File(resourceBase, "com/example/a/schema")
+def bClientDir = new File(codegenBase, "com/example/b/client")
+def bSchemaDir = new File(resourceBase, "com/example/b/schema")
+def aModelDir = new File(codegenBase, "com/example/a/model")
+def bModelDir = new File(codegenBase, "com/example/b/model")
 
 // Assertions to verify the presence or absence of directories based on the configuration
 assert aModelDir.exists() : "Expected model directory for contract A"

--- a/asyncapi-generator-maven-plugin/src/test/it/resource-output-only/pom.xml
+++ b/asyncapi-generator-maven-plugin/src/test/it/resource-output-only/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dev.banking.asyncapi.generator.it</groupId>
+    <artifactId>resource-output-only</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>dev.banking.asyncapi.generator</groupId>
+                <artifactId>asyncapi-generator-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>resource-only</id>
+                        <phase>compile</phase>
+                        <goals><goal>generate</goal></goals>
+                        <configuration>
+                            <inputFile>${project.basedir}/src/main/resources/asyncapi.yaml</inputFile>
+                            <resourceOutputDirectory>${project.build.directory}/custom-resources</resourceOutputDirectory>
+                            <schemaPackage>com.example.avro</schemaPackage>
+                            <generatorName>kotlin</generatorName>
+                            <configOptions>
+                                <schema.type>avro</schema.type>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/asyncapi-generator-maven-plugin/src/test/it/resource-output-only/src/main/resources/asyncapi.yaml
+++ b/asyncapi-generator-maven-plugin/src/test/it/resource-output-only/src/main/resources/asyncapi.yaml
@@ -1,0 +1,22 @@
+asyncapi: 3.0.0
+info:
+  title: Resource Output Only
+  version: 1.0.0
+channels:
+  sample:
+    address: test.resource.v1
+    messages:
+      - $ref: '#/components/messages/SampleMessage'
+components:
+  messages:
+    SampleMessage:
+      name: SampleMessage
+      payload:
+        $ref: '#/components/schemas/SampleMessage'
+  schemas:
+    SampleMessage:
+      type: object
+      properties:
+        id:
+          type: string
+      required: [id]

--- a/asyncapi-generator-maven-plugin/src/test/it/resource-output-only/verify.groovy
+++ b/asyncapi-generator-maven-plugin/src/test/it/resource-output-only/verify.groovy
@@ -1,0 +1,6 @@
+def resourceBase = new File(basedir, "target/custom-resources")
+
+def schemaDir = new File(resourceBase, "com/example/avro")
+
+assert schemaDir.exists() : "Expected resource output directory to exist"
+assert schemaDir.list().length > 0 : "Expected Avro schema files in resource output"

--- a/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojoTest.kt
+++ b/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojoTest.kt
@@ -1,15 +1,16 @@
 package dev.banking.asyncapi.generator.maven.plugin
 
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.clientPackage
+import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.codegenOutputDirectory
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.configOptions
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.generatorName
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.inputPath
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.outputPath
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.inputFile
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.modelPackage
-import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.outputDir
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.outputFile
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.project
+import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.resourceOutputDirectory
 import dev.banking.asyncapi.generator.maven.plugin.MavenTestHelper.schemaPackage
 import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.project.MavenProject
@@ -25,7 +26,8 @@ class AsyncApiGeneratorMojoTest {
         AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(inputPath("asyncapi_valid_content_kotlin.yaml"))
-            outputDir(outputPath("target/generated-sources/asyncapi"))
+            codegenOutputDirectory(outputPath("target/generated-sources/asyncapi"))
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             modelPackage("com.example.model")
             generatorName("kotlin")
         }.execute()
@@ -39,7 +41,8 @@ class AsyncApiGeneratorMojoTest {
         AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(inputPath("asyncapi_kafka_complex.yaml"))
-            outputDir(outputPath("target/generated-sources/asyncapi"))
+            codegenOutputDirectory(outputPath("target/generated-sources/asyncapi"))
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             modelPackage("com.example.kafka.model")
             clientPackage("com.example.kafka.client")
             generatorName("kotlin")
@@ -58,7 +61,8 @@ class AsyncApiGeneratorMojoTest {
         AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(inputPath("asyncapi_kafka_complex.yaml"))
-            outputDir(outputPath("target/generated-sources/asyncapi"))
+            codegenOutputDirectory(outputPath("target/generated-sources/asyncapi"))
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             modelPackage("com.example.kafka.model")
             clientPackage("com.example.kafka.client")
             generatorName("java")
@@ -80,7 +84,8 @@ class AsyncApiGeneratorMojoTest {
         AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(inputPath("asyncapi_kafka_complex.yaml"))
-            outputDir(outputPath("target/generated-sources/asyncapi"))
+            codegenOutputDirectory(outputPath("target/generated-sources/asyncapi"))
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             outputFile(File("target/generated-sources/asyncapi/bundled/asyncapi.bundled.yaml"))
             modelPackage("com.example.bundled")
             generatorName("kotlin")
@@ -95,7 +100,8 @@ class AsyncApiGeneratorMojoTest {
         AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(inputPath("asyncapi_kafka_complex.yaml"))
-            outputDir(outputPath("target/generated-sources/asyncapi"))
+            codegenOutputDirectory(outputPath("target/generated-sources/asyncapi"))
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             modelPackage("com.example.avro.model")
             schemaPackage("com.example.avro.schema")
             generatorName("kotlin")
@@ -105,7 +111,7 @@ class AsyncApiGeneratorMojoTest {
                 )
             )
         }.execute()
-        val schemaDir = File("target/generated-sources/asyncapi/com/example/avro/schema")
+        val schemaDir = File("target/generated-resources/asyncapi/com/example/avro/schema")
         assertTrue(schemaDir.exists(), "Schema directory should exist")
     }
 
@@ -117,7 +123,8 @@ class AsyncApiGeneratorMojoTest {
         AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(inputPath("asyncapi_kafka_complex.yaml"))
-            outputDir(bundleOnlyOutputDir)
+            codegenOutputDirectory(bundleOnlyOutputDir)
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             outputFile(File("target/generated-sources/asyncapi/bundled/asyncapi.bundle-only.yaml"))
             generatorName("kotlin")
             // no modelPackage/clientPackage/schemaPackage set
@@ -133,7 +140,8 @@ class AsyncApiGeneratorMojoTest {
         val mojo = AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(File("src/test/resources/non_existent.yaml"))
-            outputDir(outputPath("target/should-fail"))
+            codegenOutputDirectory(outputPath("target/should-fail"))
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             modelPackage("com.fail")
         }
         assertThrows<MojoExecutionException> {
@@ -146,7 +154,8 @@ class AsyncApiGeneratorMojoTest {
         val mojo = AsyncApiGeneratorMojo().apply {
             project(MavenProject())
             inputFile(inputPath("asyncapi_valid_content_kotlin.yaml"))
-            outputDir(outputPath("target/should-fail-gen"))
+            codegenOutputDirectory(outputPath("target/should-fail-gen"))
+            resourceOutputDirectory(outputPath("target/generated-resources/asyncapi"))
             modelPackage("com.fail")
             generatorName("invalid-lang")
         }

--- a/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/MavenTestHelper.kt
+++ b/asyncapi-generator-maven-plugin/src/test/kotlin/dev/banking/asyncapi/generator/maven/plugin/MavenTestHelper.kt
@@ -25,8 +25,12 @@ object MavenTestHelper {
         writeField("outputFile", value)
     }
 
-    fun Mojo.outputDir(value: Any) {
-        writeField("outputDir", value)
+    fun Mojo.codegenOutputDirectory(value: Any) {
+        writeField("codegenOutputDirectory", value)
+    }
+
+    fun Mojo.resourceOutputDirectory(value: Any) {
+        writeField("resourceOutputDirectory", value)
     }
 
     fun Mojo.modelPackage(value: Any) {
@@ -44,6 +48,7 @@ object MavenTestHelper {
     fun Mojo.generatorName(value: String) {
         writeField("generatorName", value)
     }
+
     fun Mojo.configOptions(value: Map<String, String>) {
         writeField("configOptions", value)
     }


### PR DESCRIPTION
This PR completes the codegen/resources output split and aligns Maven/Gradle/CLI with the new `codegenOutputDirectory` + `resourceOutputDirectory` model.

## Core changes

- GeneratorOptions now has explicit codegenOutputDirectory and resourceOutputDirectory.
- Avro schema generation is routed to resourceOutputDirectory; Kotlin/Java + Spring Kafka remain in codegenOutputDirectory.
- Bundle output behaviour is unchanged: it only writes when outputFile is explicitly set.

## Maven

- Mojo now exposes codegenOutputDirectory and resourceOutputDirectory parameters (defaults: target/generated-sources/asyncapi and target/generated-resources/asyncapi).
- Tests updated to set resourceOutputDirectory explicitly (since unit tests bypass Maven default injection).
- Unit and IT checks updated to assert Avro output in generated-resources.

## Gradle

- Extension/task now use codegenOutputDirectory and resourceOutputDirectory.
- Removed the default modelPackage convention so bundle‑only runs without codegen.
- Tests updated to use new output directories and to validate Avro output under generated-resources.

## CLI

- Introduced explicit --codegen-output and --resource-output flags.
- Updated tests to use the new flags and verify Avro schema output in the resource directory.
New IT coverage
- Added separate Maven IT scenarios to validate:
  - codegen output directory customization
  - resource output directory customization

## Why

- Avro schemas are resources and should be produced in generated-resources by default.
- This split aligns with Maven/Gradle conventions and makes resource packaging easier and more explicit.