### PR TITLE
feature/dlq open payload any

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/AnalyzedMessage.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/AnalyzedMessage.kt
@@ -3,7 +3,8 @@ package dev.banking.asyncapi.generator.core.generator.analyzer
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 
 data class AnalyzedMessage(
-    val name: String, // The class name (e.g. "UserSignedUp")
+    val messageName: String, // The message name (e.g. "UserSignedUp")
+    val payloadTypeName: String, // The payload type name (e.g. "UserSignedUpPayload")
     val schema: Schema, // The payload schema
-    val keySchema: Schema? = null // Optional Kafka Key schema
+    val keySchema: Schema? = null, // Optional Kafka Key schema
 )

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/ChannelAnalyzer.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/ChannelAnalyzer.kt
@@ -12,7 +12,6 @@ import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 class ChannelAnalyzer {
-
     private data class ChannelUsage(
         var isProducer: Boolean = false,
         var isConsumer: Boolean = false,
@@ -26,20 +25,23 @@ class ChannelAnalyzer {
         channels.keys.forEach { name -> channelUsage[name] = ChannelUsage() }
 
         operations.values.forEach { opInterface ->
-            val op = when (opInterface) {
-                is OperationInterface.OperationInline -> opInterface.operation
-                is OperationInterface.OperationReference -> opInterface.reference.model as? Operation
-            } ?: return@forEach
+            val op =
+                when (opInterface) {
+                    is OperationInterface.OperationInline -> opInterface.operation
+                    is OperationInterface.OperationReference -> opInterface.reference.model as? Operation
+                } ?: return@forEach
             val channelRef = op.channel ?: return@forEach
-            val targetChannelName = channels.entries.find { (_, chInterface) ->
-                val ch =
-                    if (chInterface is ChannelInterface.ChannelInline){
-                        chInterface.channel
-                    } else {
-                        (chInterface as ChannelInterface.ChannelReference).reference.model
-                    }
-                ch === channelRef.model
-            }?.key ?: return@forEach
+            val targetChannelName =
+                channels.entries
+                    .find { (_, chInterface) ->
+                        val ch =
+                            if (chInterface is ChannelInterface.ChannelInline) {
+                                chInterface.channel
+                            } else {
+                                (chInterface as ChannelInterface.ChannelReference).reference.model
+                            }
+                        ch === channelRef.model
+                    }?.key ?: return@forEach
 
             val usage = channelUsage[targetChannelName]!!
             if (op.action == "send") {
@@ -49,24 +51,26 @@ class ChannelAnalyzer {
             }
         }
 
-        val analyzedChannels = channels.mapNotNull { (name, chInterface) ->
-            val channel = when (chInterface) {
-                is ChannelInterface.ChannelInline -> chInterface.channel
-                is ChannelInterface.ChannelReference -> chInterface.reference.model as? Channel
-            } ?: return@mapNotNull null
+        val analyzedChannels =
+            channels.mapNotNull { (name, chInterface) ->
+                val channel =
+                    when (chInterface) {
+                        is ChannelInterface.ChannelInline -> chInterface.channel
+                        is ChannelInterface.ChannelReference -> chInterface.reference.model as? Channel
+                    } ?: return@mapNotNull null
 
-            val usage = channelUsage[name]!!
-            val finalProducer = if (!usage.isProducer && !usage.isConsumer) true else usage.isProducer
-            val finalConsumer = if (!usage.isProducer && !usage.isConsumer) true else usage.isConsumer
+                val usage = channelUsage[name]!!
+                val finalProducer = if (!usage.isProducer && !usage.isConsumer) true else usage.isProducer
+                val finalConsumer = if (!usage.isProducer && !usage.isConsumer) true else usage.isConsumer
 
-            AnalyzedChannel(
-                channelName = name,
-                topic = channel.address ?: name, // Fallback if address missing
-                isProducer = finalProducer,
-                isConsumer = finalConsumer,
-                messages = resolveMessages(channel.messages)
-            )
-        }
+                AnalyzedChannel(
+                    channelName = name,
+                    topic = channel.address ?: name, // Fallback if address missing
+                    isProducer = finalProducer,
+                    isConsumer = finalConsumer,
+                    messages = resolveMessages(channel.messages),
+                )
+            }
 
         return ChannelAnalysisResult(analyzedChannels)
     }
@@ -74,18 +78,21 @@ class ChannelAnalyzer {
     private fun resolveMessages(messages: Map<String, MessageInterface>?): List<AnalyzedMessage> {
         if (messages.isNullOrEmpty()) return emptyList()
         return messages.mapNotNull { (name, msgInterface) ->
-            val message = when (msgInterface) {
-                is MessageInterface.MessageInline -> msgInterface.message
-                is MessageInterface.MessageReference -> msgInterface.reference.model as? Message
-            } ?: return@mapNotNull null
+            val message =
+                when (msgInterface) {
+                    is MessageInterface.MessageInline -> msgInterface.message
+                    is MessageInterface.MessageReference -> msgInterface.reference.model as? Message
+                } ?: return@mapNotNull null
 
             var payloadSchema: Schema? = null
             var typeName: String? = null
+            val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: name)
+            val inlinePayloadTypeName = if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
 
             when (val p = message.payload) {
                 is SchemaInterface.SchemaInline -> {
                     payloadSchema = p.schema
-                    typeName = MapperUtil.toPascalCase(message.name ?: message.title ?: name)
+                    typeName = inlinePayloadTypeName
                 }
                 is SchemaInterface.SchemaReference -> {
                     payloadSchema = p.reference.model as? Schema
@@ -97,8 +104,9 @@ class ChannelAnalyzer {
             if (payloadSchema == null || typeName == null) return@mapNotNull null
 
             AnalyzedMessage(
-                name = typeName,
-                schema = payloadSchema
+                messageName = baseName,
+                payloadTypeName = typeName,
+                schema = payloadSchema,
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaGeneratorModelFactory.kt
@@ -11,14 +11,18 @@ import kotlin.text.trimStart
 class JavaGeneratorModelFactory(
     val packageName: String,
     val context: GeneratorContext,
-    val polymorphicRelationships: Map<String, List<String>>
+    val polymorphicRelationships: Map<String, List<String>>,
 ) {
     private val propertyFactory = PropertyFactory(context)
 
-    fun create(name: String, schema: Schema): GeneratorItem? {
+    fun create(
+        name: String,
+        schema: Schema,
+    ): GeneratorItem? {
         val isUnionType = !schema.oneOf.isNullOrEmpty() || !schema.anyOf.isNullOrEmpty()
         val isEnum = schema.type.getPrimaryType() == "string" && !schema.enum.isNullOrEmpty()
         val isObject = schema.type.getPrimaryType() == "object"
+        val isOpenPayload = isOpenPayloadSchema(schema)
 
         val description = DocumentationUtils.toJavaDocLines(schema.description)
 
@@ -66,23 +70,50 @@ class JavaGeneratorModelFactory(
                     packageName = packageName,
                     description = description,
                     discriminator = discriminatorPropertyName,
-                    subTypes = subTypes
+                    subTypes = subTypes,
                 )
             }
+
+            isOpenPayload -> null
             isObject -> {
-                val properties = schema.properties?.map { (propName, propSchema) ->
-                    propertyFactory.createProperty(propName, propSchema, schema.required ?: emptyList())
-                } ?: emptyList()
+                val properties =
+                    schema.properties?.map { (propName, propSchema) ->
+                        propertyFactory.createProperty(propName, propSchema, schema.required ?: emptyList())
+                    } ?: emptyList()
                 val interfaces = (polymorphicRelationships[name] ?: emptyList()) + "Serializable"
                 GeneratorItem.ClassModel(
                     name = name,
                     packageName = packageName,
                     description = description,
                     properties = properties,
-                    implementsInterfaces = interfaces
+                    implementsInterfaces = interfaces,
                 )
             }
+
             else -> null
+        }
+    }
+
+    private fun isOpenPayloadSchema(schema: Schema): Boolean {
+        if (schema.type == null) {
+            return schema.properties.isNullOrEmpty() &&
+                schema.additionalProperties == null &&
+                schema.enum.isNullOrEmpty() &&
+                schema.oneOf.isNullOrEmpty() &&
+                schema.anyOf.isNullOrEmpty() &&
+                schema.allOf.isNullOrEmpty()
+        }
+        if (schema.type.getPrimaryType() != "object") return false
+        if (!schema.properties.isNullOrEmpty()) return false
+        return when (val additional = schema.additionalProperties) {
+            null -> true
+            is SchemaInterface.BooleanSchema -> additional.value
+            is SchemaInterface.SchemaInline ->
+                additional.schema.type == null &&
+                    additional.schema.properties.isNullOrEmpty() &&
+                    additional.schema.additionalProperties == null
+
+            else -> false
         }
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaKafkaGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaKafkaGeneratorModelFactory.kt
@@ -6,6 +6,8 @@ import dev.banking.asyncapi.generator.core.generator.java.model.GeneratorItem
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 class JavaKafkaGeneratorModelFactory(
     private val packageName: String,
@@ -105,13 +107,40 @@ class JavaKafkaGeneratorModelFactory(
     private fun topicPropertyKey(channelName: String): String = "$topicPropertyPrefix.$channelName"
 
     private fun resolvePayloadType(msg: AnalyzedMessage): String =
-        when (msg.schema.type.getPrimaryType()) {
-            "string" -> "String"
-            "integer" -> "Integer"
-            "number" -> "java.math.BigDecimal"
-            "boolean" -> "Boolean"
-            else -> msg.payloadTypeName
+        if (isOpenPayloadSchema(msg.schema)) {
+            "Object"
+        } else {
+            when (msg.schema.type.getPrimaryType()) {
+                "string" -> "String"
+                "integer" -> "Integer"
+                "number" -> "java.math.BigDecimal"
+                "boolean" -> "Boolean"
+                else -> msg.payloadTypeName
+            }
         }
 
-    private fun isPrimitive(type: String): Boolean = type in setOf("String", "Integer", "Long", "Boolean", "Double", "java.math.BigDecimal")
+    private fun isOpenPayloadSchema(schema: Schema): Boolean {
+        if (schema.type == null) {
+            return schema.properties.isNullOrEmpty() &&
+                schema.additionalProperties == null &&
+                schema.enum.isNullOrEmpty() &&
+                schema.oneOf.isNullOrEmpty() &&
+                schema.anyOf.isNullOrEmpty() &&
+                schema.allOf.isNullOrEmpty()
+        }
+        if (schema.type.getPrimaryType() != "object") return false
+        if (!schema.properties.isNullOrEmpty()) return false
+        return when (val additional = schema.additionalProperties) {
+            null -> true
+            is SchemaInterface.BooleanSchema -> additional.value
+            is SchemaInterface.SchemaInline ->
+                additional.schema.type == null &&
+                    additional.schema.properties.isNullOrEmpty() &&
+                    additional.schema.additionalProperties == null
+            else -> false
+        }
+    }
+
+    private fun isPrimitive(type: String): Boolean =
+        type in setOf("String", "Integer", "Long", "Boolean", "Double", "java.math.BigDecimal", "Object")
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaKafkaGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaKafkaGeneratorModelFactory.kt
@@ -38,8 +38,8 @@ class JavaKafkaGeneratorModelFactory(
             val topicPrefix = "Topic$baseName"
             channel.messages.forEach { msg ->
                 val payloadType = resolvePayloadType(msg)
-                val methodName = "on${msg.name}"
-                val handlerName = "${topicPrefix}Handler${msg.name}"
+                val methodName = "on${msg.messageName}"
+                val handlerName = "${topicPrefix}Handler${msg.messageName}"
                 items.add(
                     GeneratorItem.KafkaHandlerInterface(
                         name = handlerName,
@@ -55,7 +55,7 @@ class JavaKafkaGeneratorModelFactory(
                         imports = imports,
                     ),
                 )
-                val listenerName = "${topicPrefix}Listener${msg.name}"
+                val listenerName = "${topicPrefix}Listener${msg.messageName}"
                 val listenerImports = (imports + "$handlerPackage.$handlerName").distinct().sorted()
                 items.add(
                     GeneratorItem.KafkaListenerClass(
@@ -81,10 +81,10 @@ class JavaKafkaGeneratorModelFactory(
                 val payloadType = resolvePayloadType(msg)
                 val sendMethod =
                     GeneratorItem.SendMethod(
-                        methodName = "send${msg.name}",
+                        methodName = "send${msg.messageName}",
                         payloadType = payloadType,
                     )
-                val producerName = "${topicPrefix}Producer${msg.name}"
+                val producerName = "${topicPrefix}Producer${msg.messageName}"
                 items.add(
                     GeneratorItem.KafkaProducerClass(
                         name = producerName,
@@ -110,7 +110,7 @@ class JavaKafkaGeneratorModelFactory(
             "integer" -> "Integer"
             "number" -> "java.math.BigDecimal"
             "boolean" -> "Boolean"
-            else -> msg.name
+            else -> msg.payloadTypeName
         }
 
     private fun isPrimitive(type: String): Boolean = type in setOf("String", "Integer", "Long", "Boolean", "Double", "java.math.BigDecimal")

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaSpringKafkaSimpleModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaSpringKafkaSimpleModelFactory.kt
@@ -33,7 +33,7 @@ class JavaSpringKafkaSimpleModelFactory(
             val methods =
                 channel.messages.map { msg ->
                     GeneratorItem.HandlerMethod(
-                        methodName = "on${msg.name}",
+                        methodName = "on${msg.messageName}",
                         payloadType = resolvePayloadType(msg),
                     )
                 }
@@ -57,10 +57,10 @@ class JavaSpringKafkaSimpleModelFactory(
                 val payloadType = resolvePayloadType(msg)
                 val sendMethod =
                     GeneratorItem.SendMethod(
-                        methodName = "send${msg.name}",
+                        methodName = "send${msg.messageName}",
                         payloadType = payloadType,
                     )
-                val producerName = "${baseName}Producer${msg.name}"
+                val producerName = "${baseName}Producer${msg.messageName}"
                 items.add(
                     GeneratorItem.KafkaProducerClass(
                         name = producerName,
@@ -85,7 +85,7 @@ class JavaSpringKafkaSimpleModelFactory(
             "integer" -> "Integer"
             "number" -> "java.math.BigDecimal"
             "boolean" -> "Boolean"
-            else -> msg.name
+            else -> msg.payloadTypeName
         }
 
     private fun isPrimitive(type: String): Boolean = type in setOf("String", "Integer", "Long", "Boolean", "Double", "java.math.BigDecimal")

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaSpringKafkaSimpleModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaSpringKafkaSimpleModelFactory.kt
@@ -6,6 +6,8 @@ import dev.banking.asyncapi.generator.core.generator.java.model.GeneratorItem
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 class JavaSpringKafkaSimpleModelFactory(
     private val clientPackage: String,
@@ -80,13 +82,40 @@ class JavaSpringKafkaSimpleModelFactory(
     }
 
     private fun resolvePayloadType(msg: AnalyzedMessage): String =
-        when (msg.schema.type.getPrimaryType()) {
-            "string" -> "String"
-            "integer" -> "Integer"
-            "number" -> "java.math.BigDecimal"
-            "boolean" -> "Boolean"
-            else -> msg.payloadTypeName
+        if (isOpenPayloadSchema(msg.schema)) {
+            "Object"
+        } else {
+            when (msg.schema.type.getPrimaryType()) {
+                "string" -> "String"
+                "integer" -> "Integer"
+                "number" -> "java.math.BigDecimal"
+                "boolean" -> "Boolean"
+                else -> msg.payloadTypeName
+            }
         }
 
-    private fun isPrimitive(type: String): Boolean = type in setOf("String", "Integer", "Long", "Boolean", "Double", "java.math.BigDecimal")
+    private fun isOpenPayloadSchema(schema: Schema): Boolean {
+        if (schema.type == null) {
+            return schema.properties.isNullOrEmpty() &&
+                schema.additionalProperties == null &&
+                schema.enum.isNullOrEmpty() &&
+                schema.oneOf.isNullOrEmpty() &&
+                schema.anyOf.isNullOrEmpty() &&
+                schema.allOf.isNullOrEmpty()
+        }
+        if (schema.type.getPrimaryType() != "object") return false
+        if (!schema.properties.isNullOrEmpty()) return false
+        return when (val additional = schema.additionalProperties) {
+            null -> true
+            is SchemaInterface.BooleanSchema -> additional.value
+            is SchemaInterface.SchemaInline ->
+                additional.schema.type == null &&
+                    additional.schema.properties.isNullOrEmpty() &&
+                    additional.schema.additionalProperties == null
+            else -> false
+        }
+    }
+
+    private fun isPrimitive(type: String): Boolean =
+        type in setOf("String", "Integer", "Long", "Boolean", "Double", "java.math.BigDecimal", "Object")
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinGenerator.kt
@@ -6,7 +6,7 @@ import java.io.File
 class KotlinGenerator(
     private val packageName: String,
     private val outputDir: File,
-    private val generationModel: List<GeneratorItem>
+    private val generationModel: List<GeneratorItem>,
 ) {
     private val dataClassGenerator: KotlinDataClassGenerator by lazy {
         KotlinDataClassGenerator(outputDir, packageName)
@@ -17,6 +17,9 @@ class KotlinGenerator(
     private val enumGenerator: KotlinEnumGenerator by lazy {
         KotlinEnumGenerator(outputDir)
     }
+    private val typeAliasGenerator: KotlinTypeAliasGenerator by lazy {
+        KotlinTypeAliasGenerator(outputDir, packageName)
+    }
 
     fun generate() {
         generationModel.forEach { item ->
@@ -24,6 +27,7 @@ class KotlinGenerator(
                 is GeneratorItem.DataClassModel -> dataClassGenerator.generate(item)
                 is GeneratorItem.EnumClassModel -> enumGenerator.generate(item)
                 is GeneratorItem.SealedInterfaceModel -> sealedInterfaceGenerator.generate(item)
+                is GeneratorItem.TypeAliasModel -> typeAliasGenerator.generate(item)
                 else -> { /* Ignore other types if mixed */ }
             }
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinTypeAliasGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinTypeAliasGenerator.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin
+
+import com.github.mustachejava.DefaultMustacheFactory
+import dev.banking.asyncapi.generator.core.generator.kotlin.model.GeneratorItem
+import dev.banking.asyncapi.generator.core.generator.util.FileUtil
+import java.io.File
+import java.io.StringWriter
+
+class KotlinTypeAliasGenerator(
+    private val outputDir: File,
+    private val packageName: String,
+) {
+    private val mustacheFactory = DefaultMustacheFactory("kotlin")
+
+    fun generate(model: GeneratorItem.TypeAliasModel) {
+        val template = mustacheFactory.compile("typeAlias.mustache")
+
+        val data =
+            mapOf(
+                "packageName" to model.packageName,
+                "name" to model.name,
+                "aliasType" to model.aliasType,
+                "imports" to model.imports,
+            )
+
+        val writer = StringWriter()
+        template.execute(writer, data).flush()
+
+        val packageDir = FileUtil.packageDirectory(outputDir, model.packageName)
+        val outputFile = File(packageDir, "${model.name}.kt")
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText(writer.toString())
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
@@ -5,6 +5,7 @@ import dev.banking.asyncapi.generator.core.generator.kotlin.model.GeneratorItem
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 class KotlinGeneratorModelFactory(
     val packageName: String,
@@ -14,37 +15,57 @@ class KotlinGeneratorModelFactory(
 ) {
     private val propertyFactory = PropertyFactory(context)
 
-    fun create(name: String, schema: Schema): GeneratorItem? {
+    fun create(
+        name: String,
+        schema: Schema,
+    ): GeneratorItem? {
         val isUnionType = !schema.oneOf.isNullOrEmpty() || !schema.anyOf.isNullOrEmpty()
         val isEnum = schema.type.getPrimaryType() == "string" && !schema.enum.isNullOrEmpty()
         val isObject = schema.type.getPrimaryType() == "object"
+        val isOpenPayload = isOpenPayloadSchema(schema)
 
         val description = DocumentationUtils.toKDocLines(schema.description)
 
         return when {
-            isEnum -> GeneratorItem.EnumClassModel(
-                name = name,
-                packageName = packageName,
-                description = description,
-                values = schema.enum.map {
-                    it.toString().trimStart('"', '\'', '|', '>').removeSurrounding("\"").uppercase()
-                }
-            )
-            isUnionType -> GeneratorItem.SealedInterfaceModel(
-                name = name,
-                packageName = packageName,
-                description = description
-            )
+            isEnum ->
+                GeneratorItem.EnumClassModel(
+                    name = name,
+                    packageName = packageName,
+                    description = description,
+                    values =
+                        schema.enum.map {
+                            it
+                                .toString()
+                                .trimStart('"', '\'', '|', '>')
+                                .removeSurrounding("\"")
+                                .uppercase()
+                        },
+                )
+            isUnionType ->
+                GeneratorItem.SealedInterfaceModel(
+                    name = name,
+                    packageName = packageName,
+                    description = description,
+                )
+            isOpenPayload ->
+                GeneratorItem.TypeAliasModel(
+                    name = name,
+                    packageName = packageName,
+                    description = description,
+                    aliasType = "Any",
+                )
             isObject -> {
-                val properties = schema.properties?.map { (propName, propSchema) ->
-                    propertyFactory.createProperty(propName, propSchema, schema.required ?: emptyList())
-                } ?: emptyList()
-                val (classAnnotations, classAnnotationImports) = if (annotation.isNullOrBlank()) {
-                    emptyList<String>() to emptyList()
-                } else {
-                    val shortName = annotation.substringAfterLast(".")
-                    listOf("@$shortName") to listOf(annotation)
-                }
+                val properties =
+                    schema.properties?.map { (propName, propSchema) ->
+                        propertyFactory.createProperty(propName, propSchema, schema.required ?: emptyList())
+                    } ?: emptyList()
+                val (classAnnotations, classAnnotationImports) =
+                    if (annotation.isNullOrBlank()) {
+                        emptyList<String>() to emptyList()
+                    } else {
+                        val shortName = annotation.substringAfterLast(".")
+                        listOf("@$shortName") to listOf(annotation)
+                    }
                 GeneratorItem.DataClassModel(
                     name = name,
                     packageName = packageName,
@@ -52,10 +73,32 @@ class KotlinGeneratorModelFactory(
                     properties = properties,
                     parentInterfaces = polymorphicRelationships[name] ?: emptyList(),
                     classAnnotations = classAnnotations,
-                    classAnnotationImports = classAnnotationImports
+                    classAnnotationImports = classAnnotationImports,
                 )
             }
             else -> null // This schema type does not result in its own generated file (e.g., a primitive type alias)
+        }
+    }
+
+    private fun isOpenPayloadSchema(schema: Schema): Boolean {
+        if (schema.type == null) {
+            return schema.properties.isNullOrEmpty() &&
+                schema.additionalProperties == null &&
+                schema.enum.isNullOrEmpty() &&
+                schema.oneOf.isNullOrEmpty() &&
+                schema.anyOf.isNullOrEmpty() &&
+                schema.allOf.isNullOrEmpty()
+        }
+        if (schema.type.getPrimaryType() != "object") return false
+        if (!schema.properties.isNullOrEmpty()) return false
+        return when (val additional = schema.additionalProperties) {
+            null -> true
+            is SchemaInterface.BooleanSchema -> additional.value
+            is SchemaInterface.SchemaInline ->
+                additional.schema.type == null &&
+                    additional.schema.properties.isNullOrEmpty() &&
+                    additional.schema.additionalProperties == null
+            else -> false
         }
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinKafkaGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinKafkaGeneratorModelFactory.kt
@@ -38,8 +38,8 @@ class KotlinKafkaGeneratorModelFactory(
             val topicPrefix = "Topic$baseName"
             channel.messages.forEach { msg ->
                 val payloadType = resolvePayloadType(msg)
-                val methodName = "on${msg.name}"
-                val handlerName = "${topicPrefix}Handler${msg.name}"
+                val methodName = "on${msg.messageName}"
+                val handlerName = "${topicPrefix}Handler${msg.messageName}"
                 items.add(
                     GeneratorItem.KafkaHandlerInterface(
                         name = handlerName,
@@ -56,7 +56,7 @@ class KotlinKafkaGeneratorModelFactory(
                         imports = imports,
                     ),
                 )
-                val listenerName = "${topicPrefix}Listener${msg.name}"
+                val listenerName = "${topicPrefix}Listener${msg.messageName}"
                 val listenerImports = (imports + "$handlerPackage.$handlerName").distinct().sorted()
                 items.add(
                     GeneratorItem.KafkaListenerClass(
@@ -82,11 +82,11 @@ class KotlinKafkaGeneratorModelFactory(
                 val payloadType = resolvePayloadType(msg)
                 val sendMethod =
                     GeneratorItem.SendMethod(
-                        methodName = "send${msg.name}",
+                        methodName = "send${msg.messageName}",
                         payloadType = payloadType,
                         keyType = "String",
                     )
-                val producerName = "${topicPrefix}Producer${msg.name}"
+                val producerName = "${topicPrefix}Producer${msg.messageName}"
                 items.add(
                     GeneratorItem.KafkaProducerClass(
                         name = producerName,
@@ -112,7 +112,7 @@ class KotlinKafkaGeneratorModelFactory(
             "integer" -> "Int" // Simplified, could check format for Long
             "number" -> "java.math.BigDecimal"
             "boolean" -> "Boolean"
-            else -> msg.name // Object types use the Class Name
+            else -> msg.payloadTypeName // Object types use the Class Name
         }
 
     private fun isPrimitive(type: String): Boolean = type in setOf("String", "Int", "Long", "Boolean", "java.math.BigDecimal")

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinSpringKafkaSimpleModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinSpringKafkaSimpleModelFactory.kt
@@ -33,7 +33,7 @@ class KotlinSpringKafkaSimpleModelFactory(
             val methods =
                 channel.messages.map { msg ->
                     GeneratorItem.HandlerMethod(
-                        methodName = "on${msg.name}",
+                        methodName = "on${msg.messageName}",
                         payloadType = resolvePayloadType(msg),
                         keyType = "String?",
                     )
@@ -58,11 +58,11 @@ class KotlinSpringKafkaSimpleModelFactory(
                 val payloadType = resolvePayloadType(msg)
                 val sendMethod =
                     GeneratorItem.SendMethod(
-                        methodName = "send${msg.name}",
+                        methodName = "send${msg.messageName}",
                         payloadType = payloadType,
                         keyType = "String",
                     )
-                val producerName = "${baseName}Producer${msg.name}"
+                val producerName = "${baseName}Producer${msg.messageName}"
                 items.add(
                     GeneratorItem.KafkaProducerClass(
                         name = producerName,
@@ -87,7 +87,7 @@ class KotlinSpringKafkaSimpleModelFactory(
             "integer" -> "Int"
             "number" -> "java.math.BigDecimal"
             "boolean" -> "Boolean"
-            else -> msg.name
+            else -> msg.payloadTypeName
         }
 
     private fun isPrimitive(type: String): Boolean = type in setOf("String", "Int", "Long", "Boolean", "java.math.BigDecimal")

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/model/GeneratorItem.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/model/GeneratorItem.kt
@@ -5,6 +5,14 @@ sealed interface GeneratorItem {
     val packageName: String
     val description: List<String>
 
+    data class TypeAliasModel(
+        override val name: String,
+        override val packageName: String,
+        override val description: List<String>,
+        val aliasType: String,
+        val imports: List<String> = emptyList(),
+    ) : GeneratorItem
+
     data class DataClassModel(
         override val name: String,
         override val packageName: String,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoader.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoader.kt
@@ -2,32 +2,48 @@ package dev.banking.asyncapi.generator.core.generator.loader
 
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+import dev.banking.asyncapi.generator.core.model.channels.ChannelInterface
 import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
 import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 object AsyncApiSchemaLoader {
-
     fun load(asyncApiDocument: AsyncApiDocument): Map<String, Schema> {
         val collectedSchemas = mutableMapOf<String, Schema>()
-        val componentNode = (asyncApiDocument.components as? ComponentInterface.ComponentInline)?.component
-            ?: return emptyMap()
+        val componentNode =
+            (asyncApiDocument.components as? ComponentInterface.ComponentInline)?.component
 
-        componentNode.schemas?.forEach { (name, schemaInterface) ->
+        componentNode?.schemas?.forEach { (name, schemaInterface) ->
             if (schemaInterface is SchemaInterface.SchemaInline) {
-                collectedSchemas[name] = schemaInterface.schema
+                val schemaName = MapperUtil.toPascalCase(name)
+                collectedSchemas[schemaName] = schemaInterface.schema
             }
         }
 
-        componentNode.messages?.forEach { (messageName, messageInterface) ->
+        componentNode?.messages?.forEach { (messageKey, messageInterface) ->
             val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
 
             if (message.payload is SchemaInterface.SchemaInline) {
                 val inlinePayload = message.payload.schema
-                val schemaName = MapperUtil.toPascalCase(messageName)
+                val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: messageKey)
+                val schemaName = if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
                 if (!collectedSchemas.containsKey(schemaName)) {
                     collectedSchemas[schemaName] = inlinePayload
+                }
+            }
+        }
+
+        asyncApiDocument.channels?.forEach { (_, channelInterface) ->
+            val channel = (channelInterface as? ChannelInterface.ChannelInline)?.channel ?: return@forEach
+            channel.messages?.forEach { (messageKey, messageInterface) ->
+                val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
+                val inlinePayload = message.payload as? SchemaInterface.SchemaInline ?: return@forEach
+
+                val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: messageKey)
+                val schemaName = if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
+                if (!collectedSchemas.containsKey(schemaName)) {
+                    collectedSchemas[schemaName] = inlinePayload.schema
                 }
             }
         }

--- a/asyncapi-generator-core/src/main/resources/kotlin/typeAlias.mustache
+++ b/asyncapi-generator-core/src/main/resources/kotlin/typeAlias.mustache
@@ -1,0 +1,6 @@
+package {{packageName}}
+{{#imports}}
+import {{.}}
+{{/imports}}
+
+typealias {{name}} = {{{aliasType}}}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaPrimitivePayloadTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaPrimitivePayloadTest.kt
@@ -9,6 +9,7 @@ import java.io.File
 import kotlin.test.assertTrue
 
 class GenerateJavaPrimitivePayloadTest {
+
     @Test
     fun `should generate typed KafkaTemplate for single string payload`() {
         val outputDir = File("target/generated-sources/asyncapi")
@@ -22,7 +23,11 @@ class GenerateJavaPrimitivePayloadTest {
                 isConsumer = true,
                 messages =
                     listOf(
-                        AnalyzedMessage("SimpleStringMessage", stringSchema),
+                        AnalyzedMessage(
+                            messageName = "SimpleStringMessage",
+                            payloadTypeName = "SimpleStringMessagePayload",
+                            schema = stringSchema
+                        )
                     ),
             )
         val generator =
@@ -35,7 +40,12 @@ class GenerateJavaPrimitivePayloadTest {
             )
         generator.generate(listOf(channel))
         val producerFile =
-            outputDir.resolve(packageName.replace('.', '/') + "/producer/TopicSimpleTopicProducerSimpleStringMessage.java")
+            outputDir.resolve(
+                packageName.replace(
+                    '.',
+                    '/'
+                ) + "/producer/TopicSimpleTopicProducerSimpleStringMessage.java"
+            )
         assertTrue(producerFile.exists(), "Producer should be generated")
         val producerContent = producerFile.readText()
         assertTrue(
@@ -58,8 +68,16 @@ class GenerateJavaPrimitivePayloadTest {
                 isConsumer = true,
                 messages =
                     listOf(
-                        AnalyzedMessage("StringMessage", stringSchema),
-                        AnalyzedMessage("IntMessage", intSchema),
+                        AnalyzedMessage(
+                            messageName = "StringMessage",
+                            payloadTypeName = "StringMessagePayload",
+                            schema = stringSchema,
+                        ),
+                        AnalyzedMessage(
+                            messageName = "IntMessage",
+                            payloadTypeName = "IntMessagePayload",
+                            schema = intSchema,
+                        ),
                     ),
             )
         val generator =

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaClientTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaClientTest.kt
@@ -25,8 +25,8 @@ class GenerateJavaSpringKafkaClientTest : AbstractJavaGeneratorClass() {
         val clientPath = "dev/banking/test/userservice/v1/client"
 
         val modelDir = outputDir.resolve(modelPath)
-        assertTrue(modelDir.resolve("UserSignedUp.java").exists(), "Model UserSignedUp missing")
-        assertTrue(modelDir.resolve("UserLoggedIn.java").exists(), "Model UserLoggedIn missing")
+        assertTrue(modelDir.resolve("UserSignedUpPayload.java").exists(), "Model UserSignedUpPayload missing")
+        assertTrue(modelDir.resolve("UserLoggedInPayload.java").exists(), "Model UserLoggedInPayload missing")
 
         val clientDir = outputDir.resolve(clientPath)
         val autoconfigDir = clientDir.resolve("config")
@@ -53,10 +53,10 @@ class GenerateJavaSpringKafkaClientTest : AbstractJavaGeneratorClass() {
         assertTrue(producerDir.resolve("TopicUserEventsProducerUserLoggedIn.java").exists(), "UserLoggedIn Producer missing")
         val userSignedUpListenerContent = listenerDir.resolve("TopicUserEventsListenerUserSignedUp.java").readText()
         assertTrue(
-            userSignedUpListenerContent.contains("ConsumerRecord<String, UserSignedUp>"),
+            userSignedUpListenerContent.contains("ConsumerRecord<String, UserSignedUpPayload>"),
             "Listener should be typed to UserSignedUp",
         )
-        assertTrue(userSignedUpListenerContent.contains("import $modelPackage.UserSignedUp;"), "Import missing")
+        assertTrue(userSignedUpListenerContent.contains("import $modelPackage.UserSignedUpPayload;"), "Import missing")
         assertTrue(
             userSignedUpListenerContent.contains("import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;"),
             "Missing ConditionalOnBean import",

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaOpenPayloadClientTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaOpenPayloadClientTest.kt
@@ -1,0 +1,76 @@
+package dev.banking.asyncapi.generator.core.generator.java.kafka
+
+import dev.banking.asyncapi.generator.core.generator.AbstractJavaGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GenerateJavaSpringKafkaOpenPayloadClientTest : AbstractJavaGeneratorClass() {
+
+    @Test
+    fun `should use Object for open payload in spring kafka clients`() {
+        val yaml = File("src/test/resources/generator/asyncapi_open_payload_kafka_inline.yaml")
+        val modelPackage = "dev.banking.test.dlq.model"
+        val clientPackage = "dev.banking.test.dlq.client"
+
+        generateElement(
+            yaml = yaml,
+            modelPackage = modelPackage,
+            clientPackage = clientPackage,
+            generateModels = true,
+            generateSpringKafkaClient = true,
+        )
+
+        val outputDir = File("target/generated-sources/asyncapi")
+        val modelDir = outputDir.resolve("dev/banking/test/dlq/model")
+        val handlerDir = outputDir.resolve("dev/banking/test/dlq/client/handler")
+        val listenerDir = outputDir.resolve("dev/banking/test/dlq/client/listener")
+        val producerDir = outputDir.resolve("dev/banking/test/dlq/client/producer")
+
+        val modelFile = modelDir.resolve("DeadLetterQueueEventPayload.java")
+        assertFalse(modelFile.exists(), "Open payload should not generate a model class")
+
+        val handlerContent = handlerDir.resolve("TopicUserDlqHandlerDeadLetterQueueEvent.java").readText()
+        assertTrue(handlerContent.contains("ConsumerRecord<String, Object>"))
+
+        val listenerContent = listenerDir.resolve("TopicUserDlqListenerDeadLetterQueueEvent.java").readText()
+        assertTrue(listenerContent.contains("ConsumerRecord<String, Object>"))
+
+        val producerContent = producerDir.resolve("TopicUserDlqProducerDeadLetterQueueEvent.java").readText()
+        assertTrue(producerContent.contains("KafkaTemplate<String, Object>"))
+        assertTrue(producerContent.contains("void sendDeadLetterQueueEvent"))
+    }
+
+    @Test
+    fun `should use Object for open payload in spring kafka simple clients`() {
+        val yaml = File("src/test/resources/generator/asyncapi_open_payload_kafka_inline.yaml")
+        val modelPackage = "dev.banking.test.dlq.model"
+        val clientPackage = "dev.banking.test.dlq.client"
+
+        generateElement(
+            yaml = yaml,
+            modelPackage = modelPackage,
+            clientPackage = clientPackage,
+            generateModels = true,
+            generateSpringKafkaClient = true,
+            configOptions = mapOf("client.type" to "spring-kafka-simple"),
+        )
+
+        val outputDir = File("target/generated-sources/asyncapi")
+        val modelDir = outputDir.resolve("dev/banking/test/dlq/model")
+        val producerDir = outputDir.resolve("dev/banking/test/dlq/client/producer")
+        val consumerDir = outputDir.resolve("dev/banking/test/dlq/client/consumer")
+
+        val modelFile = modelDir.resolve("DeadLetterQueueEventPayload.java")
+        assertFalse(modelFile.exists(), "Open payload should not generate a model class")
+
+        val producerContent = producerDir.resolve("UserDlqProducerDeadLetterQueueEvent.java").readText()
+        assertTrue(producerContent.contains("KafkaTemplate<String, Object>"))
+        assertTrue(producerContent.contains("void sendDeadLetterQueueEvent"))
+
+        val consumerContent = consumerDir.resolve("UserDlqConsumer.java").readText()
+        assertTrue(consumerContent.contains("ConsumerRecord<String, Object>"))
+        assertTrue(consumerContent.contains("void onDeadLetterQueueEvent"))
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaSimpleTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaSimpleTest.kt
@@ -30,7 +30,7 @@ class GenerateJavaSpringKafkaSimpleTest : AbstractJavaGeneratorClass() {
         assertTrue(producerFile.exists(), "Simple producer should be generated")
         val producerContent = producerFile.readText()
         assertTrue(producerContent.contains("class UserEventsProducerUserSignedUp"))
-        assertTrue(producerContent.contains("KafkaTemplate<String, UserSignedUp>"))
+        assertTrue(producerContent.contains("KafkaTemplate<String, UserSignedUpPayload>"))
         assertTrue(producerContent.contains("sendUserSignedUp"))
         assertTrue(!producerContent.contains("@Component"), "Simple producer should not be annotated")
 
@@ -39,7 +39,7 @@ class GenerateJavaSpringKafkaSimpleTest : AbstractJavaGeneratorClass() {
         val consumerContent = consumerFile.readText()
         assertTrue(consumerContent.contains("interface UserEventsConsumer"))
         assertTrue(consumerContent.contains("default void onUserSignedUp"))
-        assertTrue(consumerContent.contains("ConsumerRecord<String, UserSignedUp>"))
+        assertTrue(consumerContent.contains("ConsumerRecord<String, UserSignedUpPayload>"))
         assertTrue(!consumerContent.contains("@KafkaListener"), "Simple consumer should not be annotated")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/inlinepayload/GenerateInlineMessagePayloadTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/inlinepayload/GenerateInlineMessagePayloadTest.kt
@@ -11,14 +11,14 @@ class GenerateInlineMessagePayloadTest : AbstractKotlinGeneratorClass() {
         val generated =
             generateElement(
                 yaml = File("src/test/resources/generator/asyncapi_inline_message_payload_properties.yaml"),
-                generated = "UserSignup.kt",
+                generated = "UserSignupPayload.kt",
                 modelPackage = "dev.banking.asyncapi.generator.core.model.generated.inlinepayload",
             )
         val dataClass = extractElement(generated)
 
         val expected =
             """
-            data class UserSignup(
+            data class UserSignupPayload(
 
                 @field:Valid
                 val user: UserCreate? = null,

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/inlinepayload/GenerateInlineMessagePayloadTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/inlinepayload/GenerateInlineMessagePayloadTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin.inlinepayload
+
+import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+class GenerateInlineMessagePayloadTest : AbstractKotlinGeneratorClass() {
+    @Test
+    fun generate_data_class_for_inline_payload_with_properties() {
+        val generated =
+            generateElement(
+                yaml = File("src/test/resources/generator/asyncapi_inline_message_payload_properties.yaml"),
+                generated = "UserSignup.kt",
+                modelPackage = "dev.banking.asyncapi.generator.core.model.generated.inlinepayload",
+            )
+        val dataClass = extractElement(generated)
+
+        val expected =
+            """
+            data class UserSignup(
+
+                @field:Valid
+                val user: UserCreate? = null,
+
+                @field:Valid
+                val signup: Signup? = null
+            ) {
+            }
+            """.trimIndent()
+
+        assertEquals(expected, dataClass)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaOpenPayloadClientTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaOpenPayloadClientTest.kt
@@ -27,21 +27,21 @@ class GenerateKotlinSpringKafkaOpenPayloadClientTest : AbstractKotlinGeneratorCl
         val listenerDir = outputDir.resolve("dev/banking/test/dlq/client/listener")
         val producerDir = outputDir.resolve("dev/banking/test/dlq/client/producer")
 
-        val modelFile = modelDir.resolve("DlqPayload.kt")
-        assertTrue(modelFile.exists(), "DlqPayload typealias should be generated")
+        val modelFile = modelDir.resolve("DeadLetterQueueEvent.kt")
+        assertTrue(modelFile.exists(), "DeadLetterQueueEvent typealias should be generated")
 
-        val handlerContent = handlerDir.resolve("TopicUserDlqHandlerDlqPayload.kt").readText()
-        assertTrue(handlerContent.contains("ConsumerRecord<String, DlqPayload>"))
-        assertTrue(handlerContent.contains("import $modelPackage.DlqPayload"))
+        val handlerContent = handlerDir.resolve("TopicUserDlqHandlerDeadLetterQueueEvent.kt").readText()
+        assertTrue(handlerContent.contains("ConsumerRecord<String, DeadLetterQueueEvent>"))
+        assertTrue(handlerContent.contains("import $modelPackage.DeadLetterQueueEvent"))
 
-        val listenerContent = listenerDir.resolve("TopicUserDlqListenerDlqPayload.kt").readText()
-        assertTrue(listenerContent.contains("ConsumerRecord<String, DlqPayload>"))
-        assertTrue(listenerContent.contains("import $modelPackage.DlqPayload"))
+        val listenerContent = listenerDir.resolve("TopicUserDlqListenerDeadLetterQueueEvent.kt").readText()
+        assertTrue(listenerContent.contains("ConsumerRecord<String, DeadLetterQueueEvent>"))
+        assertTrue(listenerContent.contains("import $modelPackage.DeadLetterQueueEvent"))
 
-        val producerContent = producerDir.resolve("TopicUserDlqProducerDlqPayload.kt").readText()
-        assertTrue(producerContent.contains("KafkaTemplate<String, DlqPayload>"))
-        assertTrue(producerContent.contains("fun sendDlqPayload"))
-        assertTrue(producerContent.contains("import $modelPackage.DlqPayload"))
+        val producerContent = producerDir.resolve("TopicUserDlqProducerDeadLetterQueueEvent.kt").readText()
+        assertTrue(producerContent.contains("KafkaTemplate<String, DeadLetterQueueEvent>"))
+        assertTrue(producerContent.contains("fun sendDeadLetterQueueEvent"))
+        assertTrue(producerContent.contains("import $modelPackage.DeadLetterQueueEvent"))
     }
 
     @Test
@@ -64,17 +64,51 @@ class GenerateKotlinSpringKafkaOpenPayloadClientTest : AbstractKotlinGeneratorCl
         val producerDir = outputDir.resolve("dev/banking/test/dlq/client/producer")
         val consumerDir = outputDir.resolve("dev/banking/test/dlq/client/consumer")
 
-        val modelFile = modelDir.resolve("DlqPayload.kt")
-        assertTrue(modelFile.exists(), "DlqPayload typealias should be generated")
+        val modelFile = modelDir.resolve("DeadLetterQueueEvent.kt")
+        assertTrue(modelFile.exists(), "DeadLetterQueueEvent typealias should be generated")
 
-        val producerContent = producerDir.resolve("UserDlqProducerDlqPayload.kt").readText()
-        assertTrue(producerContent.contains("KafkaTemplate<String, DlqPayload>"))
-        assertTrue(producerContent.contains("fun sendDlqPayload"))
-        assertTrue(producerContent.contains("import $modelPackage.DlqPayload"))
+        val producerContent = producerDir.resolve("UserDlqProducerDeadLetterQueueEvent.kt").readText()
+        assertTrue(producerContent.contains("KafkaTemplate<String, DeadLetterQueueEvent>"))
+        assertTrue(producerContent.contains("fun sendDeadLetterQueueEvent"))
+        assertTrue(producerContent.contains("import $modelPackage.DeadLetterQueueEvent"))
 
         val consumerContent = consumerDir.resolve("UserDlqConsumer.kt").readText()
-        assertTrue(consumerContent.contains("ConsumerRecord<String, DlqPayload>"))
-        assertTrue(consumerContent.contains("fun onDlqPayload"))
-        assertTrue(consumerContent.contains("import $modelPackage.DlqPayload"))
+        assertTrue(consumerContent.contains("ConsumerRecord<String, DeadLetterQueueEvent>"))
+        assertTrue(consumerContent.contains("fun onDeadLetterQueueEvent"))
+        assertTrue(consumerContent.contains("import $modelPackage.DeadLetterQueueEvent"))
+    }
+
+    @Test
+    fun `should use typealias for open payload inline in spring kafka simple clients`() {
+        val yaml = File("src/test/resources/generator/asyncapi_open_payload_kafka_inline.yaml")
+        val modelPackage = "dev.banking.test.dlq.model"
+        val clientPackage = "dev.banking.test.dlq.client"
+
+        generateElement(
+            yaml = yaml,
+            modelPackage = modelPackage,
+            clientPackage = clientPackage,
+            generateModels = true,
+            generateSpringKafkaClient = true,
+            configOptions = mapOf("client.type" to "spring-kafka-simple"),
+        )
+
+        val outputDir = File("target/generated-sources/asyncapi")
+        val modelDir = outputDir.resolve("dev/banking/test/dlq/model")
+        val producerDir = outputDir.resolve("dev/banking/test/dlq/client/producer")
+        val consumerDir = outputDir.resolve("dev/banking/test/dlq/client/consumer")
+
+        val modelFile = modelDir.resolve("DeadLetterQueueEventPayload.kt")
+        assertTrue(modelFile.exists(), "DeadLetterQueueEventPayload typealias should be generated")
+
+        val producerContent = producerDir.resolve("UserDlqProducerDeadLetterQueueEvent.kt").readText()
+        assertTrue(producerContent.contains("KafkaTemplate<String, DeadLetterQueueEventPayload>"))
+        assertTrue(producerContent.contains("fun sendDeadLetterQueueEvent"))
+        assertTrue(producerContent.contains("import $modelPackage.DeadLetterQueueEventPayload"))
+
+        val consumerContent = consumerDir.resolve("UserDlqConsumer.kt").readText()
+        assertTrue(consumerContent.contains("ConsumerRecord<String, DeadLetterQueueEventPayload>"))
+        assertTrue(consumerContent.contains("fun onDeadLetterQueueEvent"))
+        assertTrue(consumerContent.contains("import $modelPackage.DeadLetterQueueEventPayload"))
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaOpenPayloadClientTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaOpenPayloadClientTest.kt
@@ -1,0 +1,80 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin.kafka
+
+import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertTrue
+
+class GenerateKotlinSpringKafkaOpenPayloadClientTest : AbstractKotlinGeneratorClass() {
+
+    @Test
+    fun `should use typealias for open payload in spring kafka clients`() {
+        val yaml = File("src/test/resources/generator/asyncapi_open_payload_kafka.yaml")
+        val modelPackage = "dev.banking.test.dlq.model"
+        val clientPackage = "dev.banking.test.dlq.client"
+
+        generateElement(
+            yaml = yaml,
+            modelPackage = modelPackage,
+            clientPackage = clientPackage,
+            generateModels = true,
+            generateSpringKafkaClient = true,
+        )
+
+        val outputDir = File("target/generated-sources/asyncapi")
+        val modelDir = outputDir.resolve("dev/banking/test/dlq/model")
+        val handlerDir = outputDir.resolve("dev/banking/test/dlq/client/handler")
+        val listenerDir = outputDir.resolve("dev/banking/test/dlq/client/listener")
+        val producerDir = outputDir.resolve("dev/banking/test/dlq/client/producer")
+
+        val modelFile = modelDir.resolve("DlqPayload.kt")
+        assertTrue(modelFile.exists(), "DlqPayload typealias should be generated")
+
+        val handlerContent = handlerDir.resolve("TopicUserDlqHandlerDlqPayload.kt").readText()
+        assertTrue(handlerContent.contains("ConsumerRecord<String, DlqPayload>"))
+        assertTrue(handlerContent.contains("import $modelPackage.DlqPayload"))
+
+        val listenerContent = listenerDir.resolve("TopicUserDlqListenerDlqPayload.kt").readText()
+        assertTrue(listenerContent.contains("ConsumerRecord<String, DlqPayload>"))
+        assertTrue(listenerContent.contains("import $modelPackage.DlqPayload"))
+
+        val producerContent = producerDir.resolve("TopicUserDlqProducerDlqPayload.kt").readText()
+        assertTrue(producerContent.contains("KafkaTemplate<String, DlqPayload>"))
+        assertTrue(producerContent.contains("fun sendDlqPayload"))
+        assertTrue(producerContent.contains("import $modelPackage.DlqPayload"))
+    }
+
+    @Test
+    fun `should use typealias for open payload in spring kafka simple clients`() {
+        val yaml = File("src/test/resources/generator/asyncapi_open_payload_kafka.yaml")
+        val modelPackage = "dev.banking.test.dlq.model"
+        val clientPackage = "dev.banking.test.dlq.client"
+
+        generateElement(
+            yaml = yaml,
+            modelPackage = modelPackage,
+            clientPackage = clientPackage,
+            generateModels = true,
+            generateSpringKafkaClient = true,
+            configOptions = mapOf("client.type" to "spring-kafka-simple"),
+        )
+
+        val outputDir = File("target/generated-sources/asyncapi")
+        val modelDir = outputDir.resolve("dev/banking/test/dlq/model")
+        val producerDir = outputDir.resolve("dev/banking/test/dlq/client/producer")
+        val consumerDir = outputDir.resolve("dev/banking/test/dlq/client/consumer")
+
+        val modelFile = modelDir.resolve("DlqPayload.kt")
+        assertTrue(modelFile.exists(), "DlqPayload typealias should be generated")
+
+        val producerContent = producerDir.resolve("UserDlqProducerDlqPayload.kt").readText()
+        assertTrue(producerContent.contains("KafkaTemplate<String, DlqPayload>"))
+        assertTrue(producerContent.contains("fun sendDlqPayload"))
+        assertTrue(producerContent.contains("import $modelPackage.DlqPayload"))
+
+        val consumerContent = consumerDir.resolve("UserDlqConsumer.kt").readText()
+        assertTrue(consumerContent.contains("ConsumerRecord<String, DlqPayload>"))
+        assertTrue(consumerContent.contains("fun onDlqPayload"))
+        assertTrue(consumerContent.contains("import $modelPackage.DlqPayload"))
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaOperationsTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaOperationsTest.kt
@@ -12,7 +12,13 @@ import kotlin.test.assertTrue
 class GenerateKotlinSpringKafkaOperationsTest {
     private val outputDir = File("target/test-output/kafka-ops")
     private val packageName = "com.example.kafka"
-    private val dummyMessage = AnalyzedMessage("TestEvent", Schema(type = "string"))
+    private val dummyMessage = AnalyzedMessage(
+        messageName = "TestEvent",
+        payloadTypeName = "TestEventPayload",
+        schema = Schema(
+            type = "string",
+        )
+    )
 
     @Test
     fun `should generate ONLY producer when isProducer=true`() {
@@ -38,9 +44,18 @@ class GenerateKotlinSpringKafkaOperationsTest {
         generator.generate(listOf(channel))
 
         val packagePath = packageName.replace('.', '/')
-        assertTrue(outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(), "Producer should exist")
-        assertFalse(outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(), "Listener should NOT exist")
-        assertFalse(outputDir.resolve("$packagePath/handler/TopicEventsHandlerTestEvent.kt").exists(), "Handler should NOT exist")
+        assertTrue(
+            outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(),
+            "Producer should exist"
+        )
+        assertFalse(
+            outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(),
+            "Listener should NOT exist"
+        )
+        assertFalse(
+            outputDir.resolve("$packagePath/handler/TopicEventsHandlerTestEvent.kt").exists(),
+            "Handler should NOT exist"
+        )
     }
 
     @Test
@@ -67,9 +82,18 @@ class GenerateKotlinSpringKafkaOperationsTest {
         generator.generate(listOf(channel))
 
         val packagePath = packageName.replace('.', '/')
-        assertFalse(outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(), "Producer should NOT exist")
-        assertTrue(outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(), "Listener should exist")
-        assertTrue(outputDir.resolve("$packagePath/handler/TopicEventsHandlerTestEvent.kt").exists(), "Handler should exist")
+        assertFalse(
+            outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(),
+            "Producer should NOT exist"
+        )
+        assertTrue(
+            outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(),
+            "Listener should exist"
+        )
+        assertTrue(
+            outputDir.resolve("$packagePath/handler/TopicEventsHandlerTestEvent.kt").exists(),
+            "Handler should exist"
+        )
     }
 
     @Test
@@ -96,8 +120,14 @@ class GenerateKotlinSpringKafkaOperationsTest {
         generator.generate(listOf(channel))
 
         val packagePath = packageName.replace('.', '/')
-        assertTrue(outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(), "Producer should exist")
-        assertTrue(outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(), "Listener should exist")
+        assertTrue(
+            outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(),
+            "Producer should exist"
+        )
+        assertTrue(
+            outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(),
+            "Listener should exist"
+        )
     }
 
     @Test
@@ -124,7 +154,13 @@ class GenerateKotlinSpringKafkaOperationsTest {
         generator.generate(listOf(channel))
 
         val packagePath = packageName.replace('.', '/')
-        assertFalse(outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(), "Producer should NOT exist")
-        assertFalse(outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(), "Listener should NOT exist")
+        assertFalse(
+            outputDir.resolve("$packagePath/producer/TopicEventsProducerTestEvent.kt").exists(),
+            "Producer should NOT exist"
+        )
+        assertFalse(
+            outputDir.resolve("$packagePath/listener/TopicEventsListenerTestEvent.kt").exists(),
+            "Listener should NOT exist"
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaSimpleTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaSimpleTest.kt
@@ -30,7 +30,7 @@ class GenerateKotlinSpringKafkaSimpleTest : AbstractKotlinGeneratorClass() {
         assertTrue(producerFile.exists(), "Simple producer should be generated")
         val producerContent = producerFile.readText()
         assertTrue(producerContent.contains("class UserEventsProducerUserSignedUp"))
-        assertTrue(producerContent.contains("KafkaTemplate<String, UserSignedUp>"))
+        assertTrue(producerContent.contains("KafkaTemplate<String, UserSignedUpPayload>"))
         assertTrue(producerContent.contains("sendUserSignedUp"))
         assertTrue(!producerContent.contains("@Component"), "Simple producer should not be annotated")
 
@@ -39,7 +39,7 @@ class GenerateKotlinSpringKafkaSimpleTest : AbstractKotlinGeneratorClass() {
         val consumerContent = consumerFile.readText()
         assertTrue(consumerContent.contains("interface UserEventsConsumer"))
         assertTrue(consumerContent.contains("fun onUserSignedUp"))
-        assertTrue(consumerContent.contains("ConsumerRecord<String, UserSignedUp>"))
+        assertTrue(consumerContent.contains("ConsumerRecord<String, UserSignedUpPayload>"))
         assertTrue(!consumerContent.contains("@KafkaListener"), "Simple consumer should not be annotated")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaTest.kt
@@ -25,8 +25,8 @@ class GenerateKotlinSpringKafkaTest : AbstractKotlinGeneratorClass() {
         val clientPath = "dev/banking/test/userservice/v1/client"
 
         val modelDir = outputDir.resolve(modelPath)
-        assertTrue(modelDir.resolve("UserSignedUp.kt").exists(), "UserSignedUp model missing")
-        assertTrue(modelDir.resolve("UserLoggedIn.kt").exists(), "UserLoggedIn model missing")
+        assertTrue(modelDir.resolve("UserSignedUpPayload.kt").exists(), "UserSignedUpPayload model missing")
+        assertTrue(modelDir.resolve("UserLoggedInPayload.kt").exists(), "UserLoggedInPayload model missing")
 
         val clientDir = outputDir.resolve(clientPath)
         val autoconfigDir = clientDir.resolve("config")
@@ -47,7 +47,7 @@ class GenerateKotlinSpringKafkaTest : AbstractKotlinGeneratorClass() {
         assertTrue(producerDir.resolve("TopicUserEventsProducerUserLoggedIn.kt").exists(), "UserLoggedIn Producer missing")
         val userSignedUpListenerContent = listenerDir.resolve("TopicUserEventsListenerUserSignedUp.kt").readText()
         assertTrue(
-            userSignedUpListenerContent.contains("ConsumerRecord<String, UserSignedUp>"),
+            userSignedUpListenerContent.contains("ConsumerRecord<String, UserSignedUpPayload>"),
             "Listener should be typed to UserSignedUp",
         )
         assertTrue(

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GeneratePrimitivePayloadTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GeneratePrimitivePayloadTest.kt
@@ -23,7 +23,11 @@ class GeneratePrimitivePayloadTest : AbstractKotlinGeneratorClass() {
                 isConsumer = true,
                 messages =
                     listOf(
-                        AnalyzedMessage("SimpleStringMessage", stringSchema),
+                        AnalyzedMessage(
+                            messageName = "SimpleStringMessage",
+                            payloadTypeName = "SimpleStringMessagePayload",
+                            schema = stringSchema,
+                        ),
                     ),
             )
         val generator =
@@ -45,7 +49,12 @@ class GeneratePrimitivePayloadTest : AbstractKotlinGeneratorClass() {
             "Should use ConsumerRecord with String payload",
         )
         val producerFile =
-            outputDir.resolve(packageName.replace('.', '/') + "/producer/TopicSimpleTopicProducerSimpleStringMessage.kt")
+            outputDir.resolve(
+                packageName.replace(
+                    '.',
+                    '/'
+                ) + "/producer/TopicSimpleTopicProducerSimpleStringMessage.kt"
+            )
         assertTrue(producerFile.exists(), "Producer should be generated")
         val producerContent = producerFile.readText()
         assertTrue(
@@ -68,8 +77,16 @@ class GeneratePrimitivePayloadTest : AbstractKotlinGeneratorClass() {
                 isConsumer = true,
                 messages =
                     listOf(
-                        AnalyzedMessage("StringMessage", stringSchema),
-                        AnalyzedMessage("IntMessage", intSchema),
+                        AnalyzedMessage(
+                            messageName = "StringMessage",
+                            payloadTypeName = "StringMessagePayload",
+                            schema = stringSchema,
+                        ),
+                        AnalyzedMessage(
+                            messageName = "IntMessage",
+                            payloadTypeName = "IntMessagePayload",
+                            schema = intSchema,
+                        ),
                     ),
             )
         val generator =

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/openpayload/GenerateOpenPayloadTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/openpayload/GenerateOpenPayloadTest.kt
@@ -1,0 +1,48 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin.openpayload
+
+import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+class GenerateOpenPayloadTest : AbstractKotlinGeneratorClass() {
+    @Test
+    fun generate_typealias_for_empty_schema_payload() {
+        val generated =
+            generateElement(
+                yaml = File("src/test/resources/generator/asyncapi_open_payload_empty_schema.yaml"),
+                generated = "DlqPayload.kt",
+                modelPackage = "dev.banking.asyncapi.generator.core.model.generated.openpayload",
+            )
+        val typeAlias = extractElement(generated)
+
+        val expected =
+            """
+            package dev.banking.asyncapi.generator.core.model.generated.openpayload
+
+            typealias DlqPayload = Any
+            """.trimIndent()
+
+        assertEquals(expected, typeAlias)
+    }
+
+    @Test
+    fun generate_typealias_for_open_object_payload() {
+        val generated =
+            generateElement(
+                yaml = File("src/test/resources/generator/asyncapi_open_payload_additional_properties.yaml"),
+                generated = "DlqPayload.kt",
+                modelPackage = "dev.banking.asyncapi.generator.core.model.generated.openpayload",
+            )
+        val typeAlias = extractElement(generated)
+
+        val expected =
+            """
+            package dev.banking.asyncapi.generator.core.model.generated.openpayload
+
+            typealias DlqPayload = Any
+            """.trimIndent()
+
+        assertEquals(expected, typeAlias)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoaderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoaderTest.kt
@@ -37,7 +37,7 @@ class AsyncApiSchemaLoaderTest {
         )
         val doc = docWithComponents(components)
         val loaded = AsyncApiSchemaLoader.load(doc)
-        assertTrue(loaded.containsKey("UserSignedUp"))
+        assertTrue(loaded.containsKey("UserSignedUpPayload"))
     }
 
     private fun docWithComponents(component: Component): AsyncApiDocument {

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_inline_message_payload_properties.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_inline_message_payload_properties.yaml
@@ -1,0 +1,44 @@
+asyncapi: 3.0.0
+info:
+  title: Inline Message Payload Properties
+  version: 1.0.0
+channels:
+  user.signup:
+    messages:
+      UserSignup:
+        name: UserSignup
+        title: User signup
+        summary: Action to sign a user up.
+        description: A longer description
+        contentType: application/json
+        headers:
+          type: object
+          properties:
+            correlationId:
+              description: Correlation ID set by application
+              type: string
+            applicationInstanceId:
+              description: Unique identifier for a given instance of the publishing application
+              type: string
+        payload:
+          type: object
+          properties:
+            user:
+              $ref: "#/components/schemas/userCreate"
+            signup:
+              $ref: "#/components/schemas/signup"
+        correlationId:
+          description: Default Correlation ID
+          location: $message.header#/correlationId
+components:
+  schemas:
+    userCreate:
+      type: object
+      properties:
+        someUserKey:
+          type: string
+    signup:
+      type: object
+      properties:
+        someSignupKey:
+          type: string

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_additional_properties.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_additional_properties.yaml
@@ -1,0 +1,9 @@
+asyncapi: 3.0.0
+info:
+  title: Open Payload Additional Properties
+  version: 1.0.0
+components:
+  schemas:
+    DlqPayload:
+      type: object
+      additionalProperties: true

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_empty_schema.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_empty_schema.yaml
@@ -1,0 +1,7 @@
+asyncapi: 3.0.0
+info:
+  title: Open Payload Empty Schema
+  version: 1.0.0
+components:
+  schemas:
+    DlqPayload: {}

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_kafka.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_kafka.yaml
@@ -1,0 +1,16 @@
+asyncapi: 3.0.0
+info:
+  title: Open Payload Kafka
+  version: 1.0.0
+channels:
+  user.dlq:
+    messages:
+      DlqEvent:
+        name: DlqPayload
+        payload:
+          $ref: '#/components/schemas/DlqPayload'
+components:
+  schemas:
+    DlqPayload:
+      type: object
+      additionalProperties: true

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_kafka_inline.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_open_payload_kafka_inline.yaml
@@ -8,9 +8,5 @@ channels:
       DlqEvent:
         name: Dead Letter Queue Event
         payload:
-          $ref: '#/components/schemas/DeadLetterQueueEvent'
-components:
-  schemas:
-    DeadLetterQueueEvent:
-      type: object
-      additionalProperties: true
+          type: object
+          additionalProperties: true


### PR DESCRIPTION
This PR fixes default‑null handling, adds open‑payload support with Payload naming for inline schemas, and aligns Kotlin/Java client generation for DLQ‑style contracts.

## Key changes

1) Default value handling (default: null)  
- YAML parsing now preserves explicit null scalars so they’re not turned into the string "null".  
- Validation fails when a required field specifies default: null, preventing invalid Kotlin output.  
- String "null" remains supported and is emitted as a string literal.
2) Open payloads and inline payload naming  
- Inline message payloads (including channel‑level payloads) are promoted into schemas, even when components is missing.  
- Inline payloads are now named ${MessageName}Payload (avoids name ambiguity and gives consistent model types).  
- AnalyzedMessage now splits messageName vs payloadTypeName to keep method names stable while types use the payload suffix.  
- Component schema keys are normalized to PascalCase (BETA‑safe breaking change).
3) Kotlin support for open payloads  
- Open payload schemas (payload: {} or type: object + additionalProperties: true) generate a Kotlin typealias to Any.  
- Added a new Kotlin typealias generator + template.
4) Java support for open payloads  
- Open payload schemas do not generate Java model classes.  
- Java client payload types resolve to Object (no extra imports).

## Examples

Default null (invalid on required)

```yaml
userId:
  type: string
  default: null
required: [userId]
```

`Validation error: property 'userId' is required but has default: null.`

Inline payload naming  

Message:

```yaml
messages:
  UserSignup:
    name: UserSignup
    payload:
      type: object
      properties: ...
```

Generated Kotlin model:

```kotlin
data class UserSignupPayload(...)
```

Open payload (DLQ)

```yaml
payload:
  type: object
  additionalProperties: true
```

Kotlin model:

```kotlin
typealias DeadLetterQueueEventPayload = Any
```

Java clients:

```java
ConsumerRecord<String, Object>
```

```java
KafkaTemplate<String, Object>
```

## Tests

- New Kotlin tests for open payload typealias (empty schema + additionalProperties).  
- New Kotlin client tests for open payload usage in spring‑kafka + spring‑kafka‑simple.  
- New Java client tests for open payload usage (Object type).  
- Updated inline payload test to expect ${MessageName}Payload.  
- Existing generator tests updated to use messageName/payloadTypeName split.

## Notes

- Inline channel payloads are now promoted even when components is absent.  
- Method names remain unchanged (onUserSignup, sendUserSignup) while payload types use UserSignupPayload.