### PR TITLE
fix bug with inline header schemas in message and messagetrait

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidator.kt
@@ -63,6 +63,9 @@ class MessageTraitValidator(
 
     private fun validateHeaders(node: MessageTrait, contextString: String, results: ValidationResults) {
         val headersSchema = node.headers ?: return
+        if (headersSchema is SchemaInterface.SchemaReference) {
+            referenceResolver.resolve(headersSchema.reference, "$contextString Headers", results)
+        }
         val headers = extractHeaderProperties(headersSchema)
         headers.forEach { (schemaName, schemaInterface) ->
             val contextString = "$contextString Header Schema '$schemaName'"

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageValidator.kt
@@ -52,6 +52,9 @@ class MessageValidator(
 
     private fun validateHeaders(node: Message, contextString: String, results: ValidationResults) {
         val headersSchema = node.headers ?: return
+        if (headersSchema is SchemaInterface.SchemaReference) {
+            referenceResolver.resolve(headersSchema.reference, "$contextString Headers", results)
+        }
         val headers = extractHeaderProperties(headersSchema)
         headers.forEach { (headerName, schemaInterface) ->
             val contextString = "$contextString Header '$headerName'"

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidatorTest.kt
@@ -6,6 +6,7 @@ import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MessageTraitValidatorTest : AbstractValidatorTest() {
@@ -21,5 +22,23 @@ class MessageTraitValidatorTest : AbstractValidatorTest() {
         }
         assertEquals(1, exception.errors.size, "Expected 1 error (content type).")
         assertTrue(results.hasWarnings(), "Should have warnings.")
+    }
+
+    @Test
+    fun `message trait headers ref to component schema passes validation`() {
+        val document = parse("src/test/resources/validator/messages/asyncapi_validator_messagetrait_headers_ref_valid.yaml")
+        val results = asyncApiValidator.validate(document)
+        assertFalse(results.hasErrors(), "Expected no errors for valid message trait headers ref.")
+        assertFalse(results.hasWarnings(), "Expected no warnings for valid message trait headers ref.")
+    }
+
+    @Test
+    fun `message trait headers broken ref triggers validation error`() {
+        val document = parse("src/test/resources/validator/messages/asyncapi_validator_messagetrait_headers_ref_invalid.yaml")
+        val results = asyncApiValidator.validate(document)
+        val exception = assertFailsWith<AsyncApiValidateException.ValidateError> {
+            results.throwErrors()
+        }
+        assertEquals(1, exception.errors.size, "Expected 1 error for unresolved message trait headers ref.")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageValidatorTest.kt
@@ -1,0 +1,32 @@
+package dev.banking.asyncapi.generator.core.validator.messages
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
+import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class MessageValidatorTest : AbstractValidatorTest() {
+
+    private val asyncApiValidator = AsyncApiValidator(asyncApiContext)
+
+    @Test
+    fun `message headers ref to component schema passes validation`() {
+        val document = parse("src/test/resources/validator/messages/asyncapi_validator_message_headers_ref_valid.yaml")
+        val results = asyncApiValidator.validate(document)
+        assertFalse(results.hasErrors(), "Expected no errors for valid message headers ref.")
+        assertFalse(results.hasWarnings(), "Expected no warnings for valid message headers ref.")
+    }
+
+    @Test
+    fun `message headers broken ref triggers validation error`() {
+        val document = parse("src/test/resources/validator/messages/asyncapi_validator_message_headers_ref_invalid.yaml")
+        val results = asyncApiValidator.validate(document)
+        val exception = assertFailsWith<AsyncApiValidateException.ValidateError> {
+            results.throwErrors()
+        }
+        assertEquals(1, exception.errors.size, "Expected 1 error for unresolved message headers ref.")
+    }
+}

--- a/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_message_headers_ref_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_message_headers_ref_invalid.yaml
@@ -1,0 +1,21 @@
+asyncapi: 3.0.0
+info:
+  title: Message Headers Ref Invalid
+  version: 1.0.0
+components:
+  messages:
+    UserSignup:
+      name: UserSignup
+      headers:
+        $ref: "#/components/schemas/MissingHeaders"
+      payload:
+        type: object
+        properties:
+          userId:
+            type: string
+  schemas:
+    DefaultHeaders:
+      type: object
+      properties:
+        traceparent:
+          type: string

--- a/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_message_headers_ref_valid.yaml
+++ b/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_message_headers_ref_valid.yaml
@@ -1,0 +1,24 @@
+asyncapi: 3.0.0
+info:
+  title: Message Headers Ref Valid
+  version: 1.0.0
+components:
+  messages:
+    UserSignup:
+      name: UserSignup
+      headers:
+        $ref: "#/components/schemas/DefaultHeaders"
+      payload:
+        type: object
+        properties:
+          userId:
+            type: string
+  schemas:
+    DefaultHeaders:
+      type: object
+      required:
+        - traceparent
+      properties:
+        traceparent:
+          type: string
+          description: Trace context identifier

--- a/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_messagetrait_headers_ref_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_messagetrait_headers_ref_invalid.yaml
@@ -1,0 +1,15 @@
+asyncapi: 3.0.0
+info:
+  title: Message Trait Headers Ref Invalid
+  version: 1.0.0
+components:
+  messageTraits:
+    DefaultKafkaHeaders:
+      headers:
+        $ref: "#/components/schemas/MissingHeaders"
+  schemas:
+    DefaultHeaders:
+      type: object
+      properties:
+        traceparent:
+          type: string

--- a/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_messagetrait_headers_ref_valid.yaml
+++ b/asyncapi-generator-core/src/test/resources/validator/messages/asyncapi_validator_messagetrait_headers_ref_valid.yaml
@@ -1,0 +1,18 @@
+asyncapi: 3.0.0
+info:
+  title: Message Trait Headers Ref Valid
+  version: 1.0.0
+components:
+  messageTraits:
+    DefaultKafkaHeaders:
+      headers:
+        $ref: "#/components/schemas/DefaultHeaders"
+  schemas:
+    DefaultHeaders:
+      type: object
+      required:
+        - traceparent
+      properties:
+        traceparent:
+          type: string
+          description: Trace context identifier


### PR DESCRIPTION
This PR fixes headers: $ref handling in message validation so referenced header schemas resolve reliably before downstream processing.

## Why

We found a real-world mismatch between inline and referenced message headers:

- Inline headers worked:
  - headers: { type: object, properties: { traceparent: { type: string } } }
- Referenced headers could fail later in generation:
  - headers: { $ref: "#/components/schemas/DefaultHeaders" }
  
The issue was that top-level headers references in Message and MessageTrait were not explicitly resolved before header-property extraction. That could leave unresolved models and surface as runtime failures later (instead of clean validation errors).

## Key changes

1) Resolve top-level Message.headers refs before extraction
- In MessageValidator, headers now resolves first when it is a SchemaReference.
- Then header properties are extracted/validated as usual.

2) Resolve top-level MessageTrait.headers refs before extraction
- Same fix applied in MessageTraitValidator.
- Keeps behavior consistent between message-level and trait-level headers.

3) Keep existing validation semantics intact
- Inline header behavior is unchanged.
- Broken refs now fail early/cleanly through validator/resolver flow, rather than surfacing later in bundling/generation paths.

## Simple examples

Now supported consistently:

- Inline:
  - headers: { type: object, properties: { traceparent: { type: string } } }
- Ref:
  - headers: { $ref: "#/components/schemas/DefaultHeaders" }

And broken refs are reported as validation errors:
- headers: { $ref: "#/components/schemas/MissingHeaders" }

## Validation

Targeted validator tests were added/updated for both Message and MessageTrait header refs (valid and invalid cases), and pass successfully.

## Practical outcome

Header schemas now behave consistently whether declared inline or by $ref, with early and predictable validation for invalid references.