### PR TITLE
bugfix/several bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ replay_pid*
 
 # Kotlin Gradle plugin data, see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
 .kotlin/
+
+# local test files
+.local/

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiContext.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiContext.kt
@@ -13,7 +13,10 @@ class AsyncApiContext {
 
     val externalLoader = AsyncApiExternalContext(this)
 
-    fun register(model: Any, node: ParserNode) {
+    fun register(
+        model: Any,
+        node: ParserNode,
+    ) {
         modelRepository.register(model, node)
 
         if (model is Reference) {
@@ -21,31 +24,38 @@ class AsyncApiContext {
         }
     }
 
-    fun registerSource(file: File, content: String) {
+    fun registerSource(
+        file: File,
+        content: String,
+    ) {
         sourceRepository.registerSource(file, content)
     }
 
-    fun registerLine(path: String, line: Int) {
+    fun registerLine(
+        path: String,
+        line: Int,
+    ) {
         sourceRepository.registerLine(path, line)
     }
 
-    fun <R> getLine(model: Any, property: KProperty0<R>): Int? {
-        return modelRepository.getLine(model, property) ?: modelRepository.getLine(model)
-    }
+    fun <R> getLine(
+        model: Any,
+        property: KProperty0<R>,
+    ): Int? = modelRepository.getLine(model, property) ?: modelRepository.getLine(model)
 
-    fun pathSnippet(path: String, contextLines: Int = 3): String {
-        return sourceRepository.pathSnippet(path, contextLines)
-    }
+    fun pathSnippet(
+        path: String,
+        contextLines: Int = 3,
+    ): String = sourceRepository.pathSnippet(path, contextLines)
 
-    fun validatorSnippet(line: Int, contextLines: Int = 3): String {
-        return sourceRepository.lineSnippet(line, contextLines)
-    }
+    fun validatorSnippet(
+        line: Int,
+        contextLines: Int = 3,
+    ): String = sourceRepository.lineSnippet(line, contextLines)
 
-    fun findReference(reference: Reference): Any? {
-        return modelRepository.findByReference(reference)
-    }
+    fun findReference(reference: Reference): Any? = modelRepository.findByReference(reference)
 
-    fun getCurrentFile(): File {
-        return sourceRepository.getCurrentFile()
-    }
+    fun getCurrentFile(): File = sourceRepository.getCurrentFile()
+
+    fun findFileById(id: String): File? = sourceRepository.findFileById(id)
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiExternalContext.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiExternalContext.kt
@@ -9,8 +9,7 @@ import java.io.File
 class AsyncApiExternalContext(
     val context: AsyncApiContext,
 ) {
-
-    private val loadedFiles = mutableSetOf<String>()  // absolute paths
+    private val loadedFiles = mutableSetOf<String>() // absolute paths
 
     fun loadExternal(reference: Reference) {
         val clean = reference.ref.trim().trimStart('\'', '"', '|', '>')
@@ -24,7 +23,10 @@ class AsyncApiExternalContext(
         if (docPart.isEmpty()) {
             return
         }
-        val baseFile = context.getCurrentFile()
+        val baseFile =
+            reference.sourceId
+                ?.let(context::findFileById)
+                ?: context.getCurrentFile()
         val externalFile = File(baseFile.parentFile, docPart).canonicalFile
         val key = externalFile.absolutePath
         if (!loadedFiles.add(key)) {
@@ -41,7 +43,7 @@ class AsyncApiExternalContext(
         } else {
             ExternalFragmentProcessor(context).parseAndValidate(
                 rootNode = rootNode,
-                reference = reference
+                reference = reference,
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -68,27 +68,29 @@ class AsyncApiGenerator {
                     if (generatorOptions.kafkaTopicsPropertyPrefix.isBlank()) {
                         throw IllegalArgumentException("kafka.topics.property.prefix cannot be empty")
                     }
-                    val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
-                    if (headerSchemas.isNotEmpty()) {
-                        val headerContext = GeneratorContext(analyzedSchemas + headerSchemas)
-                        val headerFactory =
-                            KotlinGeneratorModelFactory(
-                                packageName = "${generatorOptions.clientPackage}.header",
-                                context = headerContext,
-                                polymorphicRelationships = polymorphic,
-                                annotation = null,
-                            )
-                        val headerModels =
-                            headerSchemas.mapNotNull { (name, schema) ->
-                                headerFactory.create(name, schema)
-                            }
-                        KotlinGenerator(
-                            packageName = "${generatorOptions.clientPackage}.header",
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            generationModel = headerModels,
-                        ).generate()
-                    }
                     val clientType = generatorOptions.configOptions["client.type"]
+                    if (clientType != "spring-kafka-simple") {
+                        val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
+                        if (headerSchemas.isNotEmpty()) {
+                            val headerContext = GeneratorContext(analyzedSchemas + headerSchemas)
+                            val headerFactory =
+                                KotlinGeneratorModelFactory(
+                                    packageName = "${generatorOptions.clientPackage}.header",
+                                    context = headerContext,
+                                    polymorphicRelationships = polymorphic,
+                                    annotation = null,
+                                )
+                            val headerModels =
+                                headerSchemas.mapNotNull { (name, schema) ->
+                                    headerFactory.create(name, schema)
+                                }
+                            KotlinGenerator(
+                                packageName = "${generatorOptions.clientPackage}.header",
+                                outputDir = generatorOptions.codegenOutputDirectory,
+                                generationModel = headerModels,
+                            ).generate()
+                        }
+                    }
                     if (clientType == "spring-kafka-simple") {
                         val kafkaGenerator =
                             KotlinSpringKafkaSimpleGenerator(
@@ -134,26 +136,28 @@ class AsyncApiGenerator {
                     if (generatorOptions.kafkaTopicsPropertyPrefix.isBlank()) {
                         throw IllegalArgumentException("kafka.topics.property.prefix cannot be empty")
                     }
-                    val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
-                    if (headerSchemas.isNotEmpty()) {
-                        val headerContext = GeneratorContext(analyzedSchemas + headerSchemas)
-                        val headerFactory =
-                            JavaGeneratorModelFactory(
-                                packageName = "${generatorOptions.clientPackage}.header",
-                                context = headerContext,
-                                polymorphicRelationships = polymorphic,
-                            )
-                        val headerModels =
-                            headerSchemas.mapNotNull { (name, schema) ->
-                                headerFactory.create(name, schema)
-                            }
-                        JavaGenerator(
-                            packageName = "${generatorOptions.clientPackage}.header",
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            generationModel = headerModels,
-                        ).generate()
-                    }
                     val clientType = generatorOptions.configOptions["client.type"]
+                    if (clientType != "spring-kafka-simple") {
+                        val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
+                        if (headerSchemas.isNotEmpty()) {
+                            val headerContext = GeneratorContext(analyzedSchemas + headerSchemas)
+                            val headerFactory =
+                                JavaGeneratorModelFactory(
+                                    packageName = "${generatorOptions.clientPackage}.header",
+                                    context = headerContext,
+                                    polymorphicRelationships = polymorphic,
+                                )
+                            val headerModels =
+                                headerSchemas.mapNotNull { (name, schema) ->
+                                    headerFactory.create(name, schema)
+                                }
+                            JavaGenerator(
+                                packageName = "${generatorOptions.clientPackage}.header",
+                                outputDir = generatorOptions.codegenOutputDirectory,
+                                generationModel = headerModels,
+                            ).generate()
+                        }
+                    }
                     if (clientType == "spring-kafka-simple") {
                         val kafkaGenerator =
                             JavaSpringKafkaSimpleGenerator(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaGeneratorModelFactory.kt
@@ -4,6 +4,8 @@ import dev.banking.asyncapi.generator.core.generator.context.GeneratorContext
 import dev.banking.asyncapi.generator.core.generator.java.model.GeneratorItem
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.InvalidJavaEnumLiteral
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.JavaEnumLiteralCollision
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import kotlin.text.trimStart
@@ -14,6 +16,7 @@ class JavaGeneratorModelFactory(
     val polymorphicRelationships: Map<String, List<String>>,
 ) {
     private val propertyFactory = PropertyFactory(context)
+    private val javaEnumIdentifierRegex = Regex("^[A-Z_][A-Z0-9_]*$")
 
     fun create(
         name: String,
@@ -27,43 +30,49 @@ class JavaGeneratorModelFactory(
         val description = DocumentationUtils.toJavaDocLines(schema.description)
 
         return when {
-            isEnum -> GeneratorItem.EnumModel(
-                name = name,
-                packageName = packageName,
-                description = description,
-                values = schema.enum.map {
-                    it.toString().trimStart('"', '\'', '|', '>').removeSurrounding("\"").uppercase()
-                }
-            )
+            isEnum ->
+                GeneratorItem.EnumModel(
+                    name = name,
+                    packageName = packageName,
+                    description = description,
+                    values = validateAndNormalizeEnumValues(name, schema.enum),
+                )
             isUnionType -> {
                 val discriminatorPropertyName = schema.discriminator
 
-                val subTypes = (schema.oneOf ?: schema.anyOf ?: emptyList())
-                    .mapNotNull { ref ->
-                        if (ref is SchemaInterface.SchemaReference) {
-                            val childSchemaName = ref.reference.ref.substringAfterLast('/')
-                            val childSchema = context.findSchemaByName(childSchemaName)
+                val subTypes =
+                    (schema.oneOf ?: schema.anyOf ?: emptyList())
+                        .mapNotNull { ref ->
+                            if (ref is SchemaInterface.SchemaReference) {
+                                val childSchemaName = ref.reference.ref.substringAfterLast('/')
+                                val childSchema = context.findSchemaByName(childSchemaName)
 
-                            // Attempt to find the discriminator value in the child schema
-                            val discriminatorValue = childSchema?.properties?.get(discriminatorPropertyName)
-                                ?.let {
-                                    when (it) {
-                                        is SchemaInterface.SchemaInline -> it.schema.const?.toString()
-                                            ?: it.schema.enum?.firstOrNull()?.toString()
-                                        else -> null
-                                    }
-                                }?.removeSurrounding("\"")
+                                // Attempt to find the discriminator value in the child schema
+                                val discriminatorValue =
+                                    childSchema
+                                        ?.properties
+                                        ?.get(discriminatorPropertyName)
+                                        ?.let {
+                                            when (it) {
+                                                is SchemaInterface.SchemaInline ->
+                                                    it.schema.const?.toString()
+                                                        ?: it.schema.enum
+                                                            ?.firstOrNull()
+                                                            ?.toString()
+                                                else -> null
+                                            }
+                                        }?.removeSurrounding("\"")
 
-                            if (discriminatorValue != null) {
-                                GeneratorItem.InterfaceModel.SubType(name = discriminatorValue, type = childSchemaName)
+                                if (discriminatorValue != null) {
+                                    GeneratorItem.InterfaceModel.SubType(name = discriminatorValue, type = childSchemaName)
+                                } else {
+                                    // Fallback if discriminator value not found, use schema name
+                                    GeneratorItem.InterfaceModel.SubType(name = childSchemaName, type = childSchemaName)
+                                }
                             } else {
-                                // Fallback if discriminator value not found, use schema name
-                                GeneratorItem.InterfaceModel.SubType(name = childSchemaName, type = childSchemaName)
+                                null // Non-reference schemas for oneOf are not directly supported as subtypes here
                             }
-                        } else {
-                            null // Non-reference schemas for oneOf are not directly supported as subtypes here
                         }
-                    }
 
                 GeneratorItem.InterfaceModel(
                     name = name,
@@ -116,4 +125,47 @@ class JavaGeneratorModelFactory(
             else -> false
         }
     }
+
+    private fun validateAndNormalizeEnumValues(
+        schemaName: String,
+        rawValues: List<Any?>,
+    ): List<String> {
+        val normalizedToOriginals = linkedMapOf<String, MutableList<String>>()
+        val normalizedValues =
+            rawValues.map { raw ->
+                val original = raw.toEnumLiteral()
+                val normalized = normalizeEnumLiteral(original)
+                if (!javaEnumIdentifierRegex.matches(normalized)) {
+                    throw InvalidJavaEnumLiteral(
+                        schemaName = schemaName,
+                        literal = original,
+                        normalized = normalized,
+                        packageName = packageName,
+                    )
+                }
+                normalizedToOriginals.getOrPut(normalized) { mutableListOf() }.add(original)
+                normalized
+            }
+
+        normalizedToOriginals.forEach { (normalized, originals) ->
+            if (originals.size > 1) {
+                throw JavaEnumLiteralCollision(
+                    schemaName = schemaName,
+                    originals = originals,
+                    normalized = normalized,
+                    packageName = packageName,
+                )
+            }
+        }
+
+        return normalizedValues
+    }
+
+    private fun Any?.toEnumLiteral(): String =
+        this
+            .toString()
+            .trimStart('"', '\'', '|', '>')
+            .removeSurrounding("\"")
+
+    private fun normalizeEnumLiteral(value: String): String = value.uppercase()
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/JavaGeneratorModelFactory.kt
@@ -4,8 +4,8 @@ import dev.banking.asyncapi.generator.core.generator.context.GeneratorContext
 import dev.banking.asyncapi.generator.core.generator.java.model.GeneratorItem
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
-import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.InvalidJavaEnumLiteral
-import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.JavaEnumLiteralCollision
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.EnumLiteralCollision
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.InvalidEnum
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import kotlin.text.trimStart
@@ -136,10 +136,9 @@ class JavaGeneratorModelFactory(
                 val original = raw.toEnumLiteral()
                 val normalized = normalizeEnumLiteral(original)
                 if (!javaEnumIdentifierRegex.matches(normalized)) {
-                    throw InvalidJavaEnumLiteral(
+                    throw InvalidEnum(
                         schemaName = schemaName,
                         literal = original,
-                        normalized = normalized,
                         packageName = packageName,
                     )
                 }
@@ -149,7 +148,7 @@ class JavaGeneratorModelFactory(
 
         normalizedToOriginals.forEach { (normalized, originals) ->
             if (originals.size > 1) {
-                throw JavaEnumLiteralCollision(
+                throw EnumLiteralCollision(
                     schemaName = schemaName,
                     originals = originals,
                     normalized = normalized,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/PropertyFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/factory/PropertyFactory.kt
@@ -6,15 +6,15 @@ import dev.banking.asyncapi.generator.core.generator.java.mapper.JavaTypeMapper
 import dev.banking.asyncapi.generator.core.generator.java.model.PropertyModel
 import dev.banking.asyncapi.generator.core.generator.java.serialization.SerializationAnnotationMapper
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
+import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.isTypeNullable
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 class PropertyFactory(
     val context: GeneratorContext,
-    val serializationFramework: String = "jackson"
+    val serializationFramework: String = "jackson",
 ) {
-
     private val typeMapper = JavaTypeMapper(context)
     private val constraintMapper = ConstraintMapper()
     private val serializationAnnotationMapper = SerializationAnnotationMapper(serializationFramework)
@@ -25,9 +25,8 @@ class PropertyFactory(
     fun createProperty(
         propertyName: String,
         propSchemaInterface: SchemaInterface,
-        requiredProperties: List<String>
+        requiredProperties: List<String>,
     ): PropertyModel {
-
         val (finalPropSchema, baseJavaType) = resolveTypeAndSchema(propertyName, propSchemaInterface)
 
         val isRequired = requiredProperties.contains(propertyName)
@@ -55,23 +54,29 @@ class PropertyFactory(
             typeName = baseJavaType,
             getterName = getterName,
             setterName = setterName,
-            annotations = annotations
+            annotations = annotations,
         )
     }
 
     private fun resolveTypeAndSchema(
         propertyName: String,
-        propSchemaInterface: SchemaInterface
-    ): Pair<Schema?, String> {
-        return when (propSchemaInterface) {
+        propSchemaInterface: SchemaInterface,
+    ): Pair<Schema?, String> =
+        when (propSchemaInterface) {
             is SchemaInterface.SchemaInline -> {
                 val schema = propSchemaInterface.schema
                 val type = typeMapper.mapJavaType(propertyName, schema)
                 schema to type
             }
             is SchemaInterface.SchemaReference -> {
-                val type = typeMapper.typeNameFromRef(propSchemaInterface.reference)
-                val schema = context.findSchemaByName(type)
+                val referencedTypeName = typeMapper.typeNameFromRef(propSchemaInterface.reference)
+                val schema = context.findSchemaByName(referencedTypeName)
+                val type =
+                    if (shouldInlineReferencedSchema(schema)) {
+                        typeMapper.mapJavaType(propertyName, schema)
+                    } else {
+                        referencedTypeName
+                    }
                 schema to type
             }
             is SchemaInterface.BooleanSchema -> {
@@ -80,6 +85,15 @@ class PropertyFactory(
             else -> {
                 null to "Object"
             }
+        }
+
+    private fun shouldInlineReferencedSchema(schema: Schema?): Boolean {
+        if (schema == null) return false
+        if (!schema.enum.isNullOrEmpty()) return false
+
+        return when (schema.type.getPrimaryType()) {
+            "string", "number", "integer", "boolean" -> true
+            else -> false
         }
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
@@ -4,6 +4,8 @@ import dev.banking.asyncapi.generator.core.generator.context.GeneratorContext
 import dev.banking.asyncapi.generator.core.generator.kotlin.model.GeneratorItem
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.InvalidKotlinEnumLiteral
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.KotlinEnumLiteralCollision
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
@@ -14,6 +16,7 @@ class KotlinGeneratorModelFactory(
     val annotation: String? = null,
 ) {
     private val propertyFactory = PropertyFactory(context)
+    private val kotlinEnumIdentifierRegex = Regex("^[A-Z_][A-Z0-9_]*$")
 
     fun create(
         name: String,
@@ -32,14 +35,7 @@ class KotlinGeneratorModelFactory(
                     name = name,
                     packageName = packageName,
                     description = description,
-                    values =
-                        schema.enum.map {
-                            it
-                                .toString()
-                                .trimStart('"', '\'', '|', '>')
-                                .removeSurrounding("\"")
-                                .uppercase()
-                        },
+                    values = validateAndNormalizeEnumValues(name, schema.enum),
                 )
             isUnionType ->
                 GeneratorItem.SealedInterfaceModel(
@@ -101,4 +97,44 @@ class KotlinGeneratorModelFactory(
             else -> false
         }
     }
+
+    private fun validateAndNormalizeEnumValues(
+        schemaName: String,
+        rawValues: List<Any?>,
+    ): List<String> {
+        val normalizedToOriginals = linkedMapOf<String, MutableList<String>>()
+        val normalizedValues =
+            rawValues.map { raw ->
+                val original = raw.toEnumLiteral()
+                val normalized = normalizeEnumLiteral(original)
+                if (!kotlinEnumIdentifierRegex.matches(normalized)) {
+                    throw InvalidKotlinEnumLiteral(
+                        schemaName = schemaName,
+                        literal = original,
+                        normalized = normalized,
+                        packageName = packageName,
+                    )
+                }
+                normalizedToOriginals.getOrPut(normalized) { mutableListOf() }.add(original)
+                normalized
+            }
+        normalizedToOriginals.forEach { (normalized, originals) ->
+            if (originals.size > 1) {
+                throw KotlinEnumLiteralCollision(
+                    schemaName = schemaName,
+                    originals = originals,
+                    normalized = normalized,
+                    packageName = packageName,
+                )
+            }
+        }
+        return normalizedValues
+    }
+    private fun Any?.toEnumLiteral(): String =
+        this
+            .toString()
+            .trimStart('"', '\'', '|', '>')
+            .removeSurrounding("\"")
+    private fun normalizeEnumLiteral(value: String): String =
+        value.uppercase()
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/KotlinGeneratorModelFactory.kt
@@ -4,8 +4,8 @@ import dev.banking.asyncapi.generator.core.generator.context.GeneratorContext
 import dev.banking.asyncapi.generator.core.generator.kotlin.model.GeneratorItem
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
-import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.InvalidKotlinEnumLiteral
-import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.KotlinEnumLiteralCollision
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.InvalidEnum
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.EnumLiteralCollision
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
@@ -108,10 +108,9 @@ class KotlinGeneratorModelFactory(
                 val original = raw.toEnumLiteral()
                 val normalized = normalizeEnumLiteral(original)
                 if (!kotlinEnumIdentifierRegex.matches(normalized)) {
-                    throw InvalidKotlinEnumLiteral(
+                    throw InvalidEnum(
                         schemaName = schemaName,
                         literal = original,
-                        normalized = normalized,
                         packageName = packageName,
                     )
                 }
@@ -120,7 +119,7 @@ class KotlinGeneratorModelFactory(
             }
         normalizedToOriginals.forEach { (normalized, originals) ->
             if (originals.size > 1) {
-                throw KotlinEnumLiteralCollision(
+                throw EnumLiteralCollision(
                     schemaName = schemaName,
                     originals = originals,
                     normalized = normalized,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/PropertyFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/factory/PropertyFactory.kt
@@ -6,15 +6,15 @@ import dev.banking.asyncapi.generator.core.generator.kotlin.mapper.KotlinTypeMap
 import dev.banking.asyncapi.generator.core.generator.kotlin.model.PropertyModel
 import dev.banking.asyncapi.generator.core.generator.kotlin.serialization.SerializationAnnotationMapper
 import dev.banking.asyncapi.generator.core.generator.util.DocumentationUtils
+import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.getPrimaryType
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil.isTypeNullable
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 class PropertyFactory(
     val context: GeneratorContext,
-    val serializationFramework: String = "jackson"
+    val serializationFramework: String = "jackson",
 ) {
-
     private val constraintMapper = ConstraintMapper()
     private val serializationAnnotationMapper = SerializationAnnotationMapper(serializationFramework)
     private val defaultValueFactory = DefaultValueFactory(context)
@@ -24,9 +24,8 @@ class PropertyFactory(
     fun createProperty(
         propertyName: String,
         propSchemaInterface: SchemaInterface,
-        requiredProperties: List<String>
+        requiredProperties: List<String>,
     ): PropertyModel {
-
         val (finalPropSchema, baseKotlinType) = resolveTypeAndSchema(propertyName, propSchemaInterface)
 
         val isExplicitlyNullableFromSchema = finalPropSchema?.let { it.nullable == true || it.type.isTypeNullable() } ?: false
@@ -40,11 +39,12 @@ class PropertyFactory(
         if (validationDetector.needsCascadedValidation(baseKotlinType)) {
             annotations.add("@field:Valid")
         }
-        val defaultValue = if (finalPropSchema != null) {
-            defaultValueFactory.createDefaultValue(finalPropSchema, baseKotlinType, isNullable)
-        } else {
-            if (isNullable) "null" else null
-        }
+        val defaultValue =
+            if (finalPropSchema != null) {
+                defaultValueFactory.createDefaultValue(finalPropSchema, baseKotlinType, isNullable)
+            } else {
+                if (isNullable) "null" else null
+            }
         val description = DocumentationUtils.toKDocLines(finalPropSchema?.description)
 
         return PropertyModel(
@@ -52,23 +52,29 @@ class PropertyFactory(
             description = description,
             typeName = if (isNullable) "$baseKotlinType?" else baseKotlinType,
             defaultValue = defaultValue,
-            annotations = annotations
+            annotations = annotations,
         )
     }
 
     private fun resolveTypeAndSchema(
         propertyName: String,
-        propSchemaInterface: SchemaInterface
-    ): Pair<Schema?, String> {
-        return when (propSchemaInterface) {
+        propSchemaInterface: SchemaInterface,
+    ): Pair<Schema?, String> =
+        when (propSchemaInterface) {
             is SchemaInterface.SchemaInline -> {
                 val schema = propSchemaInterface.schema
                 val type = typeMapper.mapKotlinType(propertyName, schema)
                 schema to type
             }
             is SchemaInterface.SchemaReference -> {
-                val type = typeMapper.typeNameFromRef(propSchemaInterface.reference)
-                val schema = context.findSchemaByName(type)
+                val referencedTypeName = typeMapper.typeNameFromRef(propSchemaInterface.reference)
+                val schema = context.findSchemaByName(referencedTypeName)
+                val type =
+                    if (shouldInlineReferencedSchema(schema)) {
+                        typeMapper.mapKotlinType(propertyName, schema)
+                    } else {
+                        referencedTypeName
+                    }
                 schema to type
             }
             is SchemaInterface.BooleanSchema -> {
@@ -77,6 +83,15 @@ class PropertyFactory(
             else -> {
                 null to "Any"
             }
+        }
+
+    private fun shouldInlineReferencedSchema(schema: Schema?): Boolean {
+        if (schema == null) return false
+        if (!schema.enum.isNullOrEmpty()) return false
+
+        return when (schema.type.getPrimaryType()) {
+            "string", "number", "integer", "boolean" -> true
+            else -> false
         }
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
@@ -1,14 +1,15 @@
 package dev.banking.asyncapi.generator.core.model.exceptions
 
-sealed class AsyncApiGeneratorException(message: String) : Exception(message) {
-    class EmptyLanguageList :
-        AsyncApiGeneratorException("The language list cannot be empty")
+sealed class AsyncApiGeneratorException(
+    message: String,
+) : Exception(message) {
+    class EmptyLanguageList : AsyncApiGeneratorException("The language list cannot be empty")
 
-    class NullComponents :
-        AsyncApiGeneratorException("The Components object cannot be null")
+    class NullComponents : AsyncApiGeneratorException("The Components object cannot be null")
 
-    class UnsupportedLanguage(language: String) :
-        AsyncApiGeneratorException("The language $language is not supported")
+    class UnsupportedLanguage(
+        language: String,
+    ) : AsyncApiGeneratorException("The language $language is not supported")
 
     class InvalidKotlinEnumLiteral(
         schemaName: String,
@@ -16,29 +17,61 @@ sealed class AsyncApiGeneratorException(message: String) : Exception(message) {
         normalized: String,
         packageName: String,
     ) : AsyncApiGeneratorException(
-        buildString {
-            appendLine("Kotlin enum generation failed for schema '$schemaName'")
-            appendLine("Invalid enum literal: '$literal'")
-            appendLine("Would generate invalid enum constant: '$normalized'")
-            appendLine("Rule: Kotlin enum constants must match [A-Z_][A-Z0-9_]*")
-            appendLine("Target output: $packageName.$schemaName.kt")
-        }.trimEnd()
-    )
+            buildString {
+                appendLine("Kotlin enum generation failed for schema '$schemaName'")
+                appendLine("Invalid enum literal: '$literal'")
+                appendLine("Would generate invalid enum constant: '$normalized'")
+                appendLine("Rule: Kotlin enum constants must match [A-Z_][A-Z0-9_]*")
+                appendLine("Target output: $packageName.$schemaName.kt")
+            }.trimEnd(),
+        )
+
     class KotlinEnumLiteralCollision(
         schemaName: String,
         originals: List<String>,
         normalized: String,
         packageName: String,
     ) : AsyncApiGeneratorException(
-        buildString {
-            appendLine("Kotlin enum generation failed for schema '$schemaName'")
-            appendLine("Enum literals collide after normalization: ${formatOriginals(originals)} -> '$normalized'")
-            appendLine("Target output: $packageName.$schemaName.kt")
-        }.trimEnd()
-    ) {
+            buildString {
+                appendLine("Kotlin enum generation failed for schema '$schemaName'")
+                appendLine("Enum literals collide after normalization: ${formatOriginals(originals)} -> '$normalized'")
+                appendLine("Target output: $packageName.$schemaName.kt")
+            }.trimEnd(),
+        ) {
         companion object {
-            private fun formatOriginals(values: List<String>): String =
-                values.joinToString(prefix = "[", postfix = "]") { "'$it'" }
+            private fun formatOriginals(values: List<String>): String = values.joinToString(prefix = "[", postfix = "]") { "'$it'" }
+        }
+    }
+
+    class InvalidJavaEnumLiteral(
+        schemaName: String,
+        literal: String,
+        normalized: String,
+        packageName: String,
+    ) : AsyncApiGeneratorException(
+            buildString {
+                appendLine("Java enum generation failed for schema '$schemaName'")
+                appendLine("Invalid enum literal: '$literal'")
+                appendLine("Would generate invalid enum constant: '$normalized'")
+                appendLine("Rule: Java enum constants must match [A-Z_][A-Z0-9_]*")
+                appendLine("Target output: $packageName.$schemaName.java")
+            }.trimEnd(),
+        )
+
+    class JavaEnumLiteralCollision(
+        schemaName: String,
+        originals: List<String>,
+        normalized: String,
+        packageName: String,
+    ) : AsyncApiGeneratorException(
+            buildString {
+                appendLine("Java enum generation failed for schema '$schemaName'")
+                appendLine("Enum literals collide after normalization: ${formatOriginals(originals)} -> '$normalized'")
+                appendLine("Target output: $packageName.$schemaName.java")
+            }.trimEnd(),
+        ) {
+        companion object {
+            private fun formatOriginals(values: List<String>): String = values.joinToString(prefix = "[", postfix = "]") { "'$it'" }
         }
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
@@ -9,4 +9,36 @@ sealed class AsyncApiGeneratorException(message: String) : Exception(message) {
 
     class UnsupportedLanguage(language: String) :
         AsyncApiGeneratorException("The language $language is not supported")
+
+    class InvalidKotlinEnumLiteral(
+        schemaName: String,
+        literal: String,
+        normalized: String,
+        packageName: String,
+    ) : AsyncApiGeneratorException(
+        buildString {
+            appendLine("Kotlin enum generation failed for schema '$schemaName'")
+            appendLine("Invalid enum literal: '$literal'")
+            appendLine("Would generate invalid enum constant: '$normalized'")
+            appendLine("Rule: Kotlin enum constants must match [A-Z_][A-Z0-9_]*")
+            appendLine("Target output: $packageName.$schemaName.kt")
+        }.trimEnd()
+    )
+    class KotlinEnumLiteralCollision(
+        schemaName: String,
+        originals: List<String>,
+        normalized: String,
+        packageName: String,
+    ) : AsyncApiGeneratorException(
+        buildString {
+            appendLine("Kotlin enum generation failed for schema '$schemaName'")
+            appendLine("Enum literals collide after normalization: ${formatOriginals(originals)} -> '$normalized'")
+            appendLine("Target output: $packageName.$schemaName.kt")
+        }.trimEnd()
+    ) {
+        companion object {
+            private fun formatOriginals(values: List<String>): String =
+                values.joinToString(prefix = "[", postfix = "]") { "'$it'" }
+        }
+    }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
@@ -11,63 +11,30 @@ sealed class AsyncApiGeneratorException(
         language: String,
     ) : AsyncApiGeneratorException("The language $language is not supported")
 
-    class InvalidKotlinEnumLiteral(
+    class InvalidEnum(
         schemaName: String,
         literal: String,
-        normalized: String,
         packageName: String,
     ) : AsyncApiGeneratorException(
             buildString {
-                appendLine("Kotlin enum generation failed for schema '$schemaName'")
-                appendLine("Invalid enum literal: '$literal'")
-                appendLine("Would generate invalid enum constant: '$normalized'")
-                appendLine("Rule: Kotlin enum constants must match [A-Z_][A-Z0-9_]*")
-                appendLine("Target output: $packageName.$schemaName.kt")
+                appendLine()
+                appendLine("Enum generation failed for schema '$schemaName'. Invalid enum literal: '$literal'")
+                appendLine("Enum constants must match [A-Z_][A-Z0-9_]*. Target output: $packageName.$schemaName.kt")
+                appendLine()
             }.trimEnd(),
         )
 
-    class KotlinEnumLiteralCollision(
+    class EnumLiteralCollision(
         schemaName: String,
         originals: List<String>,
         normalized: String,
         packageName: String,
     ) : AsyncApiGeneratorException(
             buildString {
-                appendLine("Kotlin enum generation failed for schema '$schemaName'")
+                appendLine()
+                appendLine("Enum generation failed for schema '$schemaName'. Target output: $packageName.$schemaName.kt")
                 appendLine("Enum literals collide after normalization: ${formatOriginals(originals)} -> '$normalized'")
-                appendLine("Target output: $packageName.$schemaName.kt")
-            }.trimEnd(),
-        ) {
-        companion object {
-            private fun formatOriginals(values: List<String>): String = values.joinToString(prefix = "[", postfix = "]") { "'$it'" }
-        }
-    }
-
-    class InvalidJavaEnumLiteral(
-        schemaName: String,
-        literal: String,
-        normalized: String,
-        packageName: String,
-    ) : AsyncApiGeneratorException(
-            buildString {
-                appendLine("Java enum generation failed for schema '$schemaName'")
-                appendLine("Invalid enum literal: '$literal'")
-                appendLine("Would generate invalid enum constant: '$normalized'")
-                appendLine("Rule: Java enum constants must match [A-Z_][A-Z0-9_]*")
-                appendLine("Target output: $packageName.$schemaName.java")
-            }.trimEnd(),
-        )
-
-    class JavaEnumLiteralCollision(
-        schemaName: String,
-        originals: List<String>,
-        normalized: String,
-        packageName: String,
-    ) : AsyncApiGeneratorException(
-            buildString {
-                appendLine("Java enum generation failed for schema '$schemaName'")
-                appendLine("Enum literals collide after normalization: ${formatOriginals(originals)} -> '$normalized'")
-                appendLine("Target output: $packageName.$schemaName.java")
+                appendLine()
             }.trimEnd(),
         ) {
         companion object {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/SourceRepository.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/SourceRepository.kt
@@ -5,11 +5,10 @@ import kotlin.math.max
 import kotlin.math.min
 
 class SourceRepository {
-
     data class Source(
         val file: File,
         val id: String,
-        val lines: List<String>
+        val lines: List<String>,
     )
 
     // Map of file absolute path → Source
@@ -20,21 +19,31 @@ class SourceRepository {
 
     private lateinit var current: Source
 
-    fun registerSource(file: File, content: String) {
+    fun registerSource(
+        file: File,
+        content: String,
+    ) {
         val id = file.nameWithoutExtension.replace(Regex("[^A-Za-z0-9_]"), "_")
         val src = Source(file = file, id = id, lines = content.lines())
         sources[file.absolutePath] = src
         current = src
     }
 
-    fun registerLine(path: String, line: Int) {
+    fun registerLine(
+        path: String,
+        line: Int,
+    ) {
         lineMap[path] = line
     }
 
     fun getLine(path: String): Int? = lineMap[path]
 
     fun getCurrentFile(): File = current.file
+
+    fun findFileById(id: String): File? = sources.values.firstOrNull { it.id == id }?.file
+
     fun getAllSources(): Collection<Source> = sources.values
+
     fun getAllLines(): Map<String, Int> = lineMap.toMap()
 
     fun fileIdForName(name: String): String? {
@@ -57,20 +66,32 @@ class SourceRepository {
         }
     }
 
-    fun pathSnippet(path: String, contextLines: Int = 3): String {
+    fun pathSnippet(
+        path: String,
+        contextLines: Int = 3,
+    ): String {
         val source = current
         val lines = source.lines
         val line = findNearestLine(path) ?: return "(no line found for $path)"
         return buildSnippet(lines, source.file.name, line, contextLines, path)
     }
 
-    fun lineSnippet(line: Int, contextLines: Int = 3): String {
+    fun lineSnippet(
+        line: Int,
+        contextLines: Int = 3,
+    ): String {
         val source = current
         val lines = source.lines
         return buildSnippet(lines, source.file.name, line, contextLines, "line $line")
     }
 
-    private fun buildSnippet(lines: List<String>, fileName: String, center: Int, context: Int, label: String): String {
+    private fun buildSnippet(
+        lines: List<String>,
+        fileName: String,
+        center: Int,
+        context: Int,
+        label: String,
+    ): String {
         val start = max(0, center - context - 1)
         val end = min(lines.size, center + context)
         return buildString {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/enumvalue/GenerateEnumStrictValidationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/enumvalue/GenerateEnumStrictValidationTest.kt
@@ -11,7 +11,7 @@ class GenerateEnumStrictValidationTest : AbstractJavaGeneratorClass() {
     @Test
     fun `fails when enum literal contains invalid Java identifier character`() {
         val ex =
-            assertThrows<AsyncApiGeneratorException.InvalidJavaEnumLiteral> {
+            assertThrows<AsyncApiGeneratorException.InvalidEnum> {
                 generateElement(
                     yaml = File("src/test/resources/generator/asyncapi_enum_invalid_symbol.yaml"),
                     generated = "MyField.java",
@@ -21,13 +21,12 @@ class GenerateEnumStrictValidationTest : AbstractJavaGeneratorClass() {
         assertTrue(ex.message!!.contains("MyField"))
         assertTrue(ex.message!!.contains("SECOND_VALUE?"))
         assertTrue(ex.message!!.contains("[A-Z_][A-Z0-9_]*"))
-        assertTrue(ex.message!!.contains("MyField.java"))
     }
 
     @Test
     fun `fails when enum literals collide after normalization`() {
         val ex =
-            assertThrows<AsyncApiGeneratorException.JavaEnumLiteralCollision> {
+            assertThrows<AsyncApiGeneratorException.EnumLiteralCollision> {
                 generateElement(
                     yaml = File("src/test/resources/generator/asyncapi_enum_collision_case.yaml"),
                     generated = "MyField.java",
@@ -37,6 +36,5 @@ class GenerateEnumStrictValidationTest : AbstractJavaGeneratorClass() {
         assertTrue(ex.message!!.contains("MyField"))
         assertTrue(ex.message!!.contains("OPEN"))
         assertTrue(ex.message!!.contains("open"))
-        assertTrue(ex.message!!.contains("MyField.java"))
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/enumvalue/GenerateEnumStrictValidationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/enumvalue/GenerateEnumStrictValidationTest.kt
@@ -1,0 +1,42 @@
+package dev.banking.asyncapi.generator.core.generator.java.enumvalue
+
+import dev.banking.asyncapi.generator.core.generator.AbstractJavaGeneratorClass
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.File
+import kotlin.test.assertTrue
+
+class GenerateEnumStrictValidationTest : AbstractJavaGeneratorClass() {
+    @Test
+    fun `fails when enum literal contains invalid Java identifier character`() {
+        val ex =
+            assertThrows<AsyncApiGeneratorException.InvalidJavaEnumLiteral> {
+                generateElement(
+                    yaml = File("src/test/resources/generator/asyncapi_enum_invalid_symbol.yaml"),
+                    generated = "MyField.java",
+                    modelPackage = "dev.banking.asyncapi.generator.core.model.generated.enumstrict",
+                )
+            }
+        assertTrue(ex.message!!.contains("MyField"))
+        assertTrue(ex.message!!.contains("SECOND_VALUE?"))
+        assertTrue(ex.message!!.contains("[A-Z_][A-Z0-9_]*"))
+        assertTrue(ex.message!!.contains("MyField.java"))
+    }
+
+    @Test
+    fun `fails when enum literals collide after normalization`() {
+        val ex =
+            assertThrows<AsyncApiGeneratorException.JavaEnumLiteralCollision> {
+                generateElement(
+                    yaml = File("src/test/resources/generator/asyncapi_enum_collision_case.yaml"),
+                    generated = "MyField.java",
+                    modelPackage = "dev.banking.asyncapi.generator.core.model.generated.enumstrict",
+                )
+            }
+        assertTrue(ex.message!!.contains("MyField"))
+        assertTrue(ex.message!!.contains("OPEN"))
+        assertTrue(ex.message!!.contains("open"))
+        assertTrue(ex.message!!.contains("MyField.java"))
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaSimpleTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/kafka/GenerateJavaSpringKafkaSimpleTest.kt
@@ -3,6 +3,7 @@ package dev.banking.asyncapi.generator.core.generator.java.kafka
 import dev.banking.asyncapi.generator.core.generator.AbstractJavaGeneratorClass
 import org.junit.jupiter.api.Test
 import java.io.File
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class GenerateJavaSpringKafkaSimpleTest : AbstractJavaGeneratorClass() {
@@ -41,5 +42,25 @@ class GenerateJavaSpringKafkaSimpleTest : AbstractJavaGeneratorClass() {
         assertTrue(consumerContent.contains("default void onUserSignedUp"))
         assertTrue(consumerContent.contains("ConsumerRecord<String, UserSignedUpPayload>"))
         assertTrue(!consumerContent.contains("@KafkaListener"), "Simple consumer should not be annotated")
+    }
+
+    @Test
+    fun `should not generate header classes for spring kafka simple client in Java`() {
+        val yaml = File("src/test/resources/generator/asyncapi_message_headers.yaml")
+        val modelPackage = "dev.banking.test.userservice.v1.model"
+        val clientPackage = "dev.banking.test.userservice.v1.client"
+
+        generateElement(
+            yaml = yaml,
+            modelPackage = modelPackage,
+            clientPackage = clientPackage,
+            generateModels = true,
+            generateSpringKafkaClient = true,
+            configOptions = mapOf("client.type" to "spring-kafka-simple"),
+        )
+
+        val outputDir = File("target/generated-sources/asyncapi")
+        val headerDir = outputDir.resolve("dev/banking/test/userservice/v1/client/header")
+        assertFalse(headerDir.exists(), "Simple spring kafka client should not generate header classes")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/ref/GenerateReferencedPrimitiveTypeTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/ref/GenerateReferencedPrimitiveTypeTest.kt
@@ -1,0 +1,27 @@
+package dev.banking.asyncapi.generator.core.generator.java.ref
+
+import dev.banking.asyncapi.generator.core.generator.AbstractJavaGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GenerateReferencedPrimitiveTypeTest : AbstractJavaGeneratorClass() {
+    @Test
+    fun `primitive refs should map to primitive java types while enum and object refs stay named`() {
+        val modelPackage = "dev.banking.asyncapi.generator.core.model.generated.reftyping"
+        val generated =
+            generateElement(
+                yaml = File("src/test/resources/generator/asyncapi_ref_primitive_typing.yaml"),
+                generated = "MyPayload.java",
+                modelPackage = modelPackage,
+            )
+
+        assertTrue(generated.contains("private String myField;"), "Expected primitive ref type for myField")
+        assertTrue(generated.contains("@Pattern(regexp = \"^[0-9]{4,35}$\")"), "Expected constraints from referenced primitive schema")
+        assertFalse(generated.contains("import $modelPackage.MyField;"), "Primitive ref should not import model type MyField")
+
+        assertTrue(generated.contains("private MyEnum myEnum;"), "Enum ref should stay named")
+        assertTrue(generated.contains("private MyObject myObject;"), "Object ref should stay named")
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/enumvalue/GenerateEnumStrictValidationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/enumvalue/GenerateEnumStrictValidationTest.kt
@@ -8,10 +8,11 @@ import java.io.File
 import kotlin.test.assertTrue
 
 class GenerateEnumStrictValidationTest : AbstractKotlinGeneratorClass() {
+
     @Test
     fun `fails when enum literal contains invalid Kotlin identifier character`() {
         val ex =
-            assertThrows<AsyncApiGeneratorException.InvalidKotlinEnumLiteral> {
+            assertThrows<AsyncApiGeneratorException.InvalidEnum> {
                 generateElement(
                     yaml = File("src/test/resources/generator/asyncapi_enum_invalid_symbol.yaml"),
                     generated = "MyField.kt",
@@ -21,10 +22,11 @@ class GenerateEnumStrictValidationTest : AbstractKotlinGeneratorClass() {
         assertTrue(ex.message!!.contains("MyField"))
         assertTrue(ex.message!!.contains("SECOND_VALUE?"))
     }
+
     @Test
     fun `fails when enum literals collide after normalization`() {
         val ex =
-            assertThrows<AsyncApiGeneratorException.KotlinEnumLiteralCollision> {
+            assertThrows<AsyncApiGeneratorException.EnumLiteralCollision> {
                 generateElement(
                     yaml = File("src/test/resources/generator/asyncapi_enum_collision_case.yaml"),
                     generated = "MyField.kt",

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/enumvalue/GenerateEnumStrictValidationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/enumvalue/GenerateEnumStrictValidationTest.kt
@@ -1,0 +1,38 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin.enumvalue
+
+import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.File
+import kotlin.test.assertTrue
+
+class GenerateEnumStrictValidationTest : AbstractKotlinGeneratorClass() {
+    @Test
+    fun `fails when enum literal contains invalid Kotlin identifier character`() {
+        val ex =
+            assertThrows<AsyncApiGeneratorException.InvalidKotlinEnumLiteral> {
+                generateElement(
+                    yaml = File("src/test/resources/generator/asyncapi_enum_invalid_symbol.yaml"),
+                    generated = "MyField.kt",
+                    modelPackage = "dev.banking.asyncapi.generator.core.model.generated.enumstrict",
+                )
+            }
+        assertTrue(ex.message!!.contains("MyField"))
+        assertTrue(ex.message!!.contains("SECOND_VALUE?"))
+    }
+    @Test
+    fun `fails when enum literals collide after normalization`() {
+        val ex =
+            assertThrows<AsyncApiGeneratorException.KotlinEnumLiteralCollision> {
+                generateElement(
+                    yaml = File("src/test/resources/generator/asyncapi_enum_collision_case.yaml"),
+                    generated = "MyField.kt",
+                    modelPackage = "dev.banking.asyncapi.generator.core.model.generated.enumstrict",
+                )
+            }
+        assertTrue(ex.message!!.contains("MyField"))
+        assertTrue(ex.message!!.contains("OPEN"))
+        assertTrue(ex.message!!.contains("open"))
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaSimpleTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/kafka/GenerateKotlinSpringKafkaSimpleTest.kt
@@ -3,6 +3,7 @@ package dev.banking.asyncapi.generator.core.generator.kotlin.kafka
 import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
 import org.junit.jupiter.api.Test
 import java.io.File
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class GenerateKotlinSpringKafkaSimpleTest : AbstractKotlinGeneratorClass() {
@@ -41,5 +42,25 @@ class GenerateKotlinSpringKafkaSimpleTest : AbstractKotlinGeneratorClass() {
         assertTrue(consumerContent.contains("fun onUserSignedUp"))
         assertTrue(consumerContent.contains("ConsumerRecord<String, UserSignedUpPayload>"))
         assertTrue(!consumerContent.contains("@KafkaListener"), "Simple consumer should not be annotated")
+    }
+
+    @Test
+    fun `should not generate header classes for spring kafka simple client`() {
+        val yaml = File("src/test/resources/generator/asyncapi_message_headers.yaml")
+        val modelPackage = "dev.banking.test.userservice.v1.model"
+        val clientPackage = "dev.banking.test.userservice.v1.client"
+
+        generateElement(
+            yaml = yaml,
+            modelPackage = modelPackage,
+            clientPackage = clientPackage,
+            generateModels = true,
+            generateSpringKafkaClient = true,
+            configOptions = mapOf("client.type" to "spring-kafka-simple"),
+        )
+
+        val outputDir = File("target/generated-sources/asyncapi")
+        val headerDir = outputDir.resolve("dev/banking/test/userservice/v1/client/header")
+        assertFalse(headerDir.exists(), "Simple spring kafka client should not generate header classes")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/ref/GenerateReferencedPrimitiveTypeTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/ref/GenerateReferencedPrimitiveTypeTest.kt
@@ -1,0 +1,30 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin.ref
+
+import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GenerateReferencedPrimitiveTypeTest : AbstractKotlinGeneratorClass() {
+    @Test
+    fun `primitive refs should map to primitive kotlin types while enum and object refs stay named`() {
+        val modelPackage = "dev.banking.asyncapi.generator.core.model.generated.reftyping"
+        val generated =
+            generateElement(
+                yaml = File("src/test/resources/generator/asyncapi_ref_primitive_typing.yaml"),
+                generated = "MyPayload.kt",
+                modelPackage = modelPackage,
+            )
+
+        assertTrue(generated.contains("val myField: String"), "Expected primitive ref type for myField")
+        assertTrue(
+            generated.contains("@field:Pattern(regexp = \"^[0-9]{4,35}$\")"),
+            "Expected constraints from referenced primitive schema",
+        )
+        assertFalse(generated.contains("import $modelPackage.MyField"), "Primitive ref should not import model type MyField")
+
+        assertTrue(generated.contains("val myEnum: MyEnum"), "Enum ref should stay named")
+        assertTrue(generated.contains("val myObject: MyObject"), "Object ref should stay named")
+    }
+}

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_enum_collision_case.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_enum_collision_case.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Enum Collision Case Test
+  version: 1.0.0
+components:
+  schemas:
+    MyField:
+      type: string
+      enum:
+        - OPEN
+        - open

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_enum_invalid_symbol.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_enum_invalid_symbol.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Enum Invalid Symbol Test
+  version: 1.0.0
+components:
+  schemas:
+    MyField:
+      type: string
+      enum:
+        - FIRST_VALUE
+        - SECOND_VALUE?

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_ref_primitive_typing.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_ref_primitive_typing.yaml
@@ -1,0 +1,34 @@
+asyncapi: 3.0.0
+info:
+  title: Ref Primitive Typing Test
+  version: 1.0.0
+components:
+  schemas:
+    MyField:
+      type: string
+      pattern: "^[0-9]{4,35}$"
+    MyEnum:
+      type: string
+      enum:
+        - OPEN
+        - CLOSED
+    MyObject:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+    MyPayload:
+      type: object
+      required:
+        - myField
+        - myEnum
+        - myObject
+      properties:
+        myField:
+          $ref: "#/components/schemas/MyField"
+        myEnum:
+          $ref: "#/components/schemas/MyEnum"
+        myObject:
+          $ref: "#/components/schemas/MyObject"

--- a/asyncapi-generator-maven-plugin/src/main/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojo.kt
+++ b/asyncapi-generator-maven-plugin/src/main/kotlin/dev/banking/asyncapi/generator/maven/plugin/AsyncApiGeneratorMojo.kt
@@ -62,83 +62,77 @@ class AsyncApiGeneratorMojo : AbstractMojo() {
     private val generator = AsyncApiGenerator()
 
     override fun execute() {
-        log.info("asyncapi-generator-maven-plugin started")
-
-        if (!inputFile.exists()) {
-            throw MojoExecutionException("Input file not found: $inputFile")
-        }
-
-        val root = AsyncApiRegistry.readYaml(inputFile, context)
-        val asyncApiParsed = parser.parse(root)
-
-        val validationErrors = validator.validate(asyncApiParsed)
-        validationErrors.logWarnings()
-        validationErrors.throwErrors()
-
-        val bundled = bundler.bundle(asyncApiParsed)
-
-        outputFile?.let { file ->
-            log.info("Writing bundled AsyncAPI specification to: ${file.absolutePath}")
-            AsyncApiRegistry.writeYaml(file, bundled)
-        }
-
-        val targetLanguage =
-            try {
-                GeneratorName.valueOf(generatorName.uppercase(Locale.getDefault()))
-            } catch (_: IllegalArgumentException) {
-                throw MojoExecutionException(
-                    "Invalid generatorName '$generatorName'. Supported values: ${GeneratorName.entries.joinToString(", ")}",
-                )
+        try {
+            log.info("asyncapi-generator-maven-plugin started")
+            if (!inputFile.exists()) {
+                throw MojoExecutionException("Input file not found: $inputFile")
             }
-        val clientType = configOptions["client.type"]
-        val schemaType = configOptions["schema.type"]
-        val modelAnnotation = configOptions["model.annotation"]
-        val prefixOverride = configOptions["kafka.topics.property.prefix"]
-
-        val hasModelPackage = modelPackage != null
-        val hasClientPackage = clientPackage != null
-        val hasSchemaPackage = schemaPackage != null
-
-        if (clientType != null && !hasClientPackage) {
-            throw MojoExecutionException("client.type requires clientPackage")
+            val root = AsyncApiRegistry.readYaml(inputFile, context)
+            val asyncApiParsed = parser.parse(root)
+            val validationErrors = validator.validate(asyncApiParsed)
+            validationErrors.logWarnings()
+            validationErrors.throwErrors()
+            val bundled = bundler.bundle(asyncApiParsed)
+            outputFile?.let { file ->
+                log.info("Writing bundled AsyncAPI specification to: ${file.absolutePath}")
+                AsyncApiRegistry.writeYaml(file, bundled)
+            }
+            val targetLanguage =
+                try {
+                    GeneratorName.valueOf(generatorName.uppercase(Locale.getDefault()))
+                } catch (_: IllegalArgumentException) {
+                    throw MojoExecutionException(
+                        "Invalid generatorName '$generatorName'. Supported values: ${
+                            GeneratorName.entries.joinToString(
+                                ", "
+                            )
+                        }",
+                    )
+                }
+            val clientType = configOptions["client.type"]
+            val schemaType = configOptions["schema.type"]
+            val modelAnnotation = configOptions["model.annotation"]
+            val prefixOverride = configOptions["kafka.topics.property.prefix"]
+            val hasModelPackage = modelPackage != null
+            val hasClientPackage = clientPackage != null
+            val hasSchemaPackage = schemaPackage != null
+            if (clientType != null && !hasClientPackage) {
+                throw MojoExecutionException("client.type requires clientPackage")
+            }
+            if (schemaType != null && !hasSchemaPackage) {
+                throw MojoExecutionException("schema.type requires schemaPackage")
+            }
+            if (modelAnnotation != null && !hasModelPackage) {
+                throw MojoExecutionException("model.annotation requires modelPackage")
+            }
+            if (prefixOverride != null && prefixOverride.isBlank()) {
+                throw MojoExecutionException("kafka.topics.property.prefix cannot be empty")
+            }
+            if (hasModelPackage || hasClientPackage || hasSchemaPackage) {
+                val effectiveModelPackage = modelPackage ?: "unused"
+                val effectiveClientPackage = clientPackage ?: "unused"
+                val effectiveSchemaPackage = schemaPackage ?: "unused"
+                val options =
+                    GeneratorOptions(
+                        generatorName = targetLanguage,
+                        modelPackage = effectiveModelPackage,
+                        clientPackage = effectiveClientPackage,
+                        schemaPackage = effectiveSchemaPackage,
+                        codegenOutputDirectory = codegenOutputDirectory,
+                        resourceOutputDirectory = resourceOutputDirectory,
+                        kafkaTopicsPropertyPrefix = prefixOverride ?: "kafka.topics",
+                        generateModels = hasModelPackage,
+                        generateSpringKafkaClient = hasClientPackage && (clientType == "spring-kafka" || clientType == "spring-kafka-simple"),
+                        generateQuarkusKafkaClient = hasClientPackage && clientType == "quarkus-kafka",
+                        generateAvroSchema = hasSchemaPackage && schemaType == "avro",
+                        configOptions = configOptions,
+                    )
+                generator.generate(bundled, options)
+            }
+            project.addCompileSourceRoot(codegenOutputDirectory.absolutePath)
+            log.info("asyncapi-generator-maven-plugin completed successfully")
+        } catch (e: Exception) {
+            throw MojoExecutionException(e)
         }
-
-        if (schemaType != null && !hasSchemaPackage) {
-            throw MojoExecutionException("schema.type requires schemaPackage")
-        }
-
-        if (modelAnnotation != null && !hasModelPackage) {
-            throw MojoExecutionException("model.annotation requires modelPackage")
-        }
-
-        if (prefixOverride != null && prefixOverride.isBlank()) {
-            throw MojoExecutionException("kafka.topics.property.prefix cannot be empty")
-        }
-
-        if (hasModelPackage || hasClientPackage || hasSchemaPackage) {
-            val effectiveModelPackage = modelPackage ?: "unused"
-            val effectiveClientPackage = clientPackage ?: "unused"
-            val effectiveSchemaPackage = schemaPackage ?: "unused"
-
-            val options =
-                GeneratorOptions(
-                    generatorName = targetLanguage,
-                    modelPackage = effectiveModelPackage,
-                    clientPackage = effectiveClientPackage,
-                    schemaPackage = effectiveSchemaPackage,
-                    codegenOutputDirectory = codegenOutputDirectory,
-                    resourceOutputDirectory = resourceOutputDirectory,
-                    kafkaTopicsPropertyPrefix = prefixOverride ?: "kafka.topics",
-                    generateModels = hasModelPackage,
-                    generateSpringKafkaClient = hasClientPackage && (clientType == "spring-kafka" || clientType == "spring-kafka-simple"),
-                    generateQuarkusKafkaClient = hasClientPackage && clientType == "quarkus-kafka",
-                    generateAvroSchema = hasSchemaPackage && schemaType == "avro",
-                    configOptions = configOptions,
-                )
-            generator.generate(bundled, options)
-        }
-
-        project.addCompileSourceRoot(codegenOutputDirectory.absolutePath)
-        log.info("asyncapi-generator-maven-plugin completed successfully")
     }
 }

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/pom.xml
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dev.banking.asyncapi.generator.it</groupId>
+    <artifactId>bundle-multifile-schema-separate-directory</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>dev.banking.asyncapi.generator</groupId>
+                <artifactId>asyncapi-generator-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>bundle-multifile-schema-separate-directory</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputFile>${project.basedir}/src/main/resources/main.yaml</inputFile>
+                            <outputFile>${project.build.directory}/bundled.yaml</outputFile>
+                            <generatorName>kotlin</generatorName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/src/main/resources/main.yaml
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/src/main/resources/main.yaml
@@ -1,0 +1,25 @@
+asyncapi: 3.0.0
+info:
+  title: Multi File Schema Fragment IT
+  version: 1.0.0
+channels:
+  schemaFragmentChannel:
+    address: "example.schema.fragment"
+    messages:
+      userMessage:
+        name: "userMessage"
+        payload:
+          $ref: '#/components/schemas/User'
+components:
+  schemas:
+    User:
+      title: User
+      type: object
+      required:
+        - id
+        - username
+      properties:
+        id:
+          $ref: 'properties/properties.yaml#/id'
+        username:
+          $ref: 'properties/properties.yaml#/username'

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/src/main/resources/properties/properties.yaml
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/src/main/resources/properties/properties.yaml
@@ -1,0 +1,9 @@
+id:
+  type: integer
+  description: The unique identifier of the user
+
+username:
+  type: string
+  minLength: 3
+  maxLength: 20
+  description: Username between 3 and 20 characters

--- a/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/verify.groovy
+++ b/asyncapi-generator-maven-plugin/src/test/it/bundle-multifile-schema-separate-directory/verify.groovy
@@ -1,0 +1,12 @@
+def bundled = new File(basedir, "target/bundled.yaml")
+assert bundled.exists() : "Expected bundled.yaml to exist"
+assert bundled.length() > 0 : "Expected bundled.yaml to be non-empty"
+
+def content = bundled.getText("UTF-8")
+assert content.contains("schemaFragmentChannel:") : "Expected bundled channel from main spec"
+assert content.contains("description: The unique identifier of the user") : "Expected external properties fragment to be inlined"
+assert !content.contains("properties.yaml#") : "Did not expect external properties ref in bundled output"
+assert !content.contains("defaultSet:") : "Did not expect internal technical fields in bundled output"
+
+def generatedDir = new File(basedir, "target/generated-sources/asyncapi")
+assert !generatedDir.exists() : "Did not expect any generated code when no packages are set"


### PR DESCRIPTION
This PR fixes multiple real-world correctness gaps across parsing/generation, plus one Spring Kafka simple-client behaviour refinement.

## Why

We hit several production-facing inconsistencies:

- External multi-file `$ref` resolution could use the wrong base file after nested loads, causing duplicated paths like `properties/properties/properties.yaml`.
- Enum literals valid in spec but invalid as language enum constants (for example PARTNER?) produced uncompilable Kotlin/Java output instead of failing early.
- Primitive schema refs used as properties (for example `$ref: "#/components/schemas/MyField"` where MyField is type: string) were typed as named models (MyField) without generated declarations, creating dangling imports/types.
- `spring-kafka-simple` was generating header classes even though simple templates do not consume them.

## Key changes

1) Fix multi-file external `$ref` base-path resolution
- External refs now resolve relative to the file where the ref was declared (origin/source id), not mutable global current-file state.
- Prevents duplicated directory path construction in nested multi-file layouts.

2) Enforce strict enum compile-safety in Kotlin and Java generation
- Added fail-fast enum validation in generator model factories.
- Invalid identifier literals (for example `MY_ENUM?`) now fail generation with actionable diagnostics.
- Added normalization-collision detection (for example OPEN vs open -> same constant).

3) Correct primitive `$ref` property typing (common-mode behaviour)
- If a referenced schema is primitive-like (string, number, integer, boolean, incl nullable combos), property type now maps to primitive language type.
- Enum/object refs remain named model types.
- Preserves constraints/annotations from referenced schema.
- Removes dangling primitive-ref model imports.

4) Do not generate header classes for `spring-kafka-simple`
- Header class generation is now skipped when `client.type = spring-kafka-simple`.
- Header class generation remains enabled for full `spring-kafka`.

## Simple examples

- Multifile refs
  - Before: could resolve to `.../properties/properties/properties.yaml`
  - Now: resolves correctly from original declaring file.
- Enum strictness
  - Input enum: ["FIRST_VALUE", "SECOND_VALUE?"]
  - Now: generation fails early with clear message instead of emitting invalid enum constant.
- Primitive refs
  - `myField: { $ref: "#/components/schemas/MyField" }` + `MyField.type: string`
  - Before: `myField: MyField` (unresolved type risk)
  - Now: `myField: String` (Kotlin/Java equivalent), constraints preserved.
- Spring simple client
  - `client.type: spring-kafka-simple`
  - Now: no auto-generated ...client/header/... classes.
  
## Validation

Targeted regression suites were added/updated and passed, including:

- Multi-file invoker IT for separate-directory schema refs.
- Kotlin + Java strict enum tests (invalid symbol + collision).
- Kotlin + Java primitive-ref typing tests.
- Kotlin + Java `spring-kafka-simple` tests asserting no header class generation.

## Practical outcome

Generation is now more deterministic and compile-safe across common real-world contracts:

- external refs resolve reliably,
- invalid enum constants fail early with clear diagnostics,
- primitive refs map to expected primitive types,
- simple Spring Kafka client output is lean and aligned with actual template usage.
