### PR TITLE
feature/header ref schemas exclusion

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoader.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoader.kt
@@ -2,28 +2,35 @@ package dev.banking.asyncapi.generator.core.generator.loader
 
 import dev.banking.asyncapi.generator.core.generator.util.MapperUtil
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+import dev.banking.asyncapi.generator.core.model.channels.Channel
 import dev.banking.asyncapi.generator.core.model.channels.ChannelInterface
 import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
+import dev.banking.asyncapi.generator.core.model.messages.Message
 import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
+import dev.banking.asyncapi.generator.core.model.messages.MessageTrait
+import dev.banking.asyncapi.generator.core.model.messages.MessageTraitInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
 object AsyncApiSchemaLoader {
+
     fun load(asyncApiDocument: AsyncApiDocument): Map<String, Schema> {
         val collectedSchemas = mutableMapOf<String, Schema>()
-        val componentNode =
-            (asyncApiDocument.components as? ComponentInterface.ComponentInline)?.component
-
+        val componentNode = (asyncApiDocument.components as? ComponentInterface.ComponentInline)?.component
+        val usageIndex = collectSchemaUsage(asyncApiDocument)
         componentNode?.schemas?.forEach { (name, schemaInterface) ->
             if (schemaInterface is SchemaInterface.SchemaInline) {
                 val schemaName = MapperUtil.toPascalCase(name)
-                collectedSchemas[schemaName] = schemaInterface.schema
+                if (!usageIndex.isHeaderOnly(schemaName)) {
+                    collectedSchemas[schemaName] = schemaInterface.schema
+                }
             }
         }
 
+        // keep existing inline payload promotion from components.messages
         componentNode?.messages?.forEach { (messageKey, messageInterface) ->
             val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
-
             if (message.payload is SchemaInterface.SchemaInline) {
                 val inlinePayload = message.payload.schema
                 val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: messageKey)
@@ -34,12 +41,12 @@ object AsyncApiSchemaLoader {
             }
         }
 
+        // keep existing inline payload promotion from channels
         asyncApiDocument.channels?.forEach { (_, channelInterface) ->
             val channel = (channelInterface as? ChannelInterface.ChannelInline)?.channel ?: return@forEach
             channel.messages?.forEach { (messageKey, messageInterface) ->
                 val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
                 val inlinePayload = message.payload as? SchemaInterface.SchemaInline ?: return@forEach
-
                 val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: messageKey)
                 val schemaName = if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
                 if (!collectedSchemas.containsKey(schemaName)) {
@@ -47,7 +54,87 @@ object AsyncApiSchemaLoader {
                 }
             }
         }
-
         return collectedSchemas
+    }
+
+    private data class SchemaUsageIndex(
+        val payloadSchemaNames: Set<String>,
+        val headerSchemaNames: Set<String>,
+    ) {
+        fun isHeaderOnly(schemaName: String): Boolean =
+            schemaName in headerSchemaNames && schemaName !in payloadSchemaNames
+    }
+
+    private fun collectSchemaUsage(asyncApiDocument: AsyncApiDocument): SchemaUsageIndex {
+        val payloadNames = mutableSetOf<String>()
+        val headerNames = mutableSetOf<String>()
+        asyncApiDocument.channels?.values?.forEach { channelInterface ->
+            val channel =
+                when (channelInterface) {
+                    is ChannelInterface.ChannelInline -> channelInterface.channel
+                    is ChannelInterface.ChannelReference -> channelInterface.reference.model as? Channel
+                } ?: return@forEach
+            channel.messages?.values?.forEach { messageInterface ->
+                val message =
+                    when (messageInterface) {
+                        is MessageInterface.MessageInline -> messageInterface.message
+                        is MessageInterface.MessageReference -> messageInterface.reference.model as? Message
+                    } ?: return@forEach
+                message.payload?.let { collectFromSchemaInterface(it, payloadNames, mutableSetOf()) }
+                message.headers?.let { collectFromSchemaInterface(it, headerNames, mutableSetOf()) }
+                message.traits?.forEach { traitInterface ->
+                    val trait =
+                        when (traitInterface) {
+                            is MessageTraitInterface.InlineMessageTrait -> traitInterface.trait
+                            is MessageTraitInterface.ReferenceMessageTrait -> traitInterface.reference.model as? MessageTrait
+                        } ?: return@forEach
+                    trait.headers?.let { collectFromSchemaInterface(it, headerNames, mutableSetOf()) }
+                }
+            }
+        }
+        return SchemaUsageIndex(
+            payloadSchemaNames = payloadNames,
+            headerSchemaNames = headerNames,
+        )
+    }
+
+    private fun collectFromSchemaInterface(
+        schemaInterface: SchemaInterface,
+        sink: MutableSet<String>,
+        visitedRefs: MutableSet<String>,
+    ) {
+        when (schemaInterface) {
+            is SchemaInterface.SchemaInline -> collectFromSchema(schemaInterface.schema, sink, visitedRefs)
+            is SchemaInterface.SchemaReference -> {
+                collectFromReference(schemaInterface.reference, sink, visitedRefs)
+                (schemaInterface.reference.model as? Schema)?.let { collectFromSchema(it, sink, visitedRefs) }
+            }
+            else -> Unit
+        }
+    }
+
+    private fun collectFromReference(
+        reference: Reference,
+        sink: MutableSet<String>,
+        visitedRefs: MutableSet<String>,
+    ) {
+        val rawName = reference.ref.substringAfterLast('/')
+        val schemaName = MapperUtil.toPascalCase(rawName)
+        if (schemaName.isBlank() || !visitedRefs.add(schemaName)) return
+        sink.add(schemaName)
+    }
+
+    private fun collectFromSchema(
+        schema: Schema,
+        sink: MutableSet<String>,
+        visitedRefs: MutableSet<String>,
+    ) {
+        schema.properties?.values?.forEach { collectFromSchemaInterface(it, sink, visitedRefs) }
+        schema.items?.let { collectFromSchemaInterface(it, sink, visitedRefs) }
+        schema.additionalProperties?.let { collectFromSchemaInterface(it, sink, visitedRefs) }
+        schema.oneOf?.forEach { collectFromSchemaInterface(it, sink, visitedRefs) }
+        schema.anyOf?.forEach { collectFromSchemaInterface(it, sink, visitedRefs) }
+        schema.allOf?.forEach { collectFromSchemaInterface(it, sink, visitedRefs) }
+        schema.not?.let { collectFromSchemaInterface(it, sink, visitedRefs) }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/headers/GenerateHeaderOnlySchemaExclusionTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/headers/GenerateHeaderOnlySchemaExclusionTest.kt
@@ -18,7 +18,7 @@ class GenerateHeaderOnlySchemaExclusionTest : AbstractJavaGeneratorClass() {
         )
         val outputDir = File("target/generated-sources/asyncapi")
         val modelDir = outputDir.resolve(modelPackage.replace('.', '/'))
-        assertTrue(modelDir.resolve("AccountUpdatedPayload.java").exists(), "Payload model should be generated")
-        assertFalse(modelDir.resolve("DefaultHeaders.java").exists(), "Header-only schema should not be generated as model")
+        assertTrue(modelDir.resolve("GenericMessagePayload.java").exists(), "Payload model should be generated")
+        assertFalse(modelDir.resolve("CommonHeaders.java").exists(), "Header-only schema should not be generated as model")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/headers/GenerateHeaderOnlySchemaExclusionTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/headers/GenerateHeaderOnlySchemaExclusionTest.kt
@@ -1,0 +1,24 @@
+package dev.banking.asyncapi.generator.core.generator.java.headers
+
+import dev.banking.asyncapi.generator.core.generator.AbstractJavaGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GenerateHeaderOnlySchemaExclusionTest : AbstractJavaGeneratorClass() {
+
+    @Test
+    fun `should not generate java model class for schema used only in message headers`() {
+        val modelPackage = "dev.banking.asyncapi.generator.core.model.generated.headerexclusion"
+        generateElement(
+            yaml = File("src/test/resources/generator/asyncapi_header_only_ref_exclusion.yaml"),
+            modelPackage = modelPackage,
+            generateModels = true,
+        )
+        val outputDir = File("target/generated-sources/asyncapi")
+        val modelDir = outputDir.resolve(modelPackage.replace('.', '/'))
+        assertTrue(modelDir.resolve("AccountUpdatedPayload.java").exists(), "Payload model should be generated")
+        assertFalse(modelDir.resolve("DefaultHeaders.java").exists(), "Header-only schema should not be generated as model")
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/headers/GenerateHeaderOnlySchemaExclusionTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/headers/GenerateHeaderOnlySchemaExclusionTest.kt
@@ -1,0 +1,24 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin.headers
+
+import dev.banking.asyncapi.generator.core.generator.AbstractKotlinGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GenerateHeaderOnlySchemaExclusionTest : AbstractKotlinGeneratorClass() {
+
+    @Test
+    fun `should not generate model class for schema used only in message headers`() {
+        val modelPackage = "dev.banking.asyncapi.generator.core.model.generated.headerexclusion"
+        generateElement(
+            yaml = File("src/test/resources/generator/asyncapi_header_only_ref_exclusion.yaml"),
+            modelPackage = modelPackage,
+            generateModels = true,
+        )
+        val outputDir = File("target/generated-sources/asyncapi")
+        val modelDir = outputDir.resolve(modelPackage.replace('.', '/'))
+        assertTrue(modelDir.resolve("AccountUpdatedPayload.kt").exists(), "Payload model should be generated")
+        assertFalse(modelDir.resolve("DefaultHeaders.kt").exists(), "Header-only schema should not be generated as model")
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/headers/GenerateHeaderOnlySchemaExclusionTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/headers/GenerateHeaderOnlySchemaExclusionTest.kt
@@ -18,7 +18,7 @@ class GenerateHeaderOnlySchemaExclusionTest : AbstractKotlinGeneratorClass() {
         )
         val outputDir = File("target/generated-sources/asyncapi")
         val modelDir = outputDir.resolve(modelPackage.replace('.', '/'))
-        assertTrue(modelDir.resolve("AccountUpdatedPayload.kt").exists(), "Payload model should be generated")
-        assertFalse(modelDir.resolve("DefaultHeaders.kt").exists(), "Header-only schema should not be generated as model")
+        assertTrue(modelDir.resolve("GenericMessagePayload.kt").exists(), "Payload model should be generated")
+        assertFalse(modelDir.resolve("CommonHeaders.kt").exists(), "Header-only schema should not be generated as model")
     }
 }

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_header_only_ref_exclusion.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_header_only_ref_exclusion.yaml
@@ -1,0 +1,30 @@
+asyncapi: 3.0.0
+info:
+  title: Header-only schema exclusion
+  version: 1.0.0
+channels:
+  genericEvents:
+    address: generic.events.v1
+    messages:
+      GenericMessageCreated:
+        name: GenericMessageCreated
+        headers:
+          $ref: "#/components/schemas/CommonHeaders"
+        payload:
+          $ref: "#/components/schemas/GenericMessagePayload"
+components:
+  schemas:
+    CommonHeaders:
+      type: object
+      required:
+        - requestId
+      properties:
+        requestId:
+          type: string
+    GenericMessagePayload:
+      type: object
+      required:
+        - itemId
+      properties:
+        itemId:
+          type: string


### PR DESCRIPTION
This PR aligns header generation semantics so transport headers and domain payload models are treated consistently across model/codegen flows.

## Why

We found an inconsistency in model generation behavior:

- Inline `messages.headers` did not create model classes.
- But referenced headers under `components.schemas` (for example CommonHeaders) could still be generated as regular domain model classes.
- In parallel, `spring-kafka-simple` was generating header classes even though simple client templates do not consume them.

This created confusing output and mixed transport metadata with domain models.

## Key changes

1) Exclude header-only schemas from model-package generation
- `AsyncApiSchemaLoader` now classifies schema usage inside loader flow (payload-used vs header-used).
- Schemas referenced only from `messages.headers` / `messageTrait.headers` are excluded from model generation.
- Schemas used by payload remain generated.
- Schemas used by both payload and headers remain generated.

2) Keep inline payload model behaviour unchanged
- Existing inline payload promotion logic remains intact.
- Payload-focused model generation still behaves as before.

3) Skip header DTO generation for `spring-kafka-simple`
- Header package generation is now disabled for `client.type = spring-kafka-simple`.
- Full `spring-kafka` still generates header classes in `clientPackage.header`. This is considered and `opt-in` together with `spring-kafka`. Can we considered a separate opt-in later.

4) Add/adjust regression coverage for both Kotlin and Java
- Header-only schema exclusion from model package.
- Simple `spring-kafka` clients do not generate header package classes.

### Simple examples

With this contract pattern:

- Headers reference:
  - `headers: { $ref: "#/components/schemas/CommonHeaders" }`
- Payload reference:
  - `payload: { $ref: "#/components/schemas/GenericMessagePayload" }`

Expected output now:
- `GenericMessagePayload` model class is generated.
- `CommonHeaders` is not generated in model package if header-only.
- In full `spring-kafka`, header classes are generated under clientPackage.header.
- In `spring-kafka-simple`, header classes are not generated.

## Validation

Targeted Kotlin/Java generator tests were updated/added for:
- header-only schema exclusion from model generation,
- no header class generation in `spring-kafka-simple`.

Existing simple-client regression suites pass.

## Practical outcome

Generation output is now semantically cleaner:
- Domain models stay domain-focused (payload-driven),
- Header metadata no longer leaks into model package as header-only classes,
- Simple clients generate only what they actually use.