### PR TITLE
added avro map parsing

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/avro/mapper/AvroTypeMapper.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/avro/mapper/AvroTypeMapper.kt
@@ -41,6 +41,8 @@ class AvroTypeMapper(
         val baseType = resolveBaseType(schema)
         val finalType = if (schema.type.getPrimaryType() == "integer" && schema.format == "int64") {
             "\"long\""
+        } else if (schema.type.getPrimaryType() == "object") {
+            "{\"type\":\"map\", \"values\":\"${resolveMapValuesType(schema)}\"}"
         } else {
             baseType
         }
@@ -48,6 +50,17 @@ class AvroTypeMapper(
             "[\"null\", $finalType]"
         } else {
             finalType
+        }
+    }
+
+    private fun resolveMapValuesType(schema: Schema): String {
+        try {
+            val defaultSchema = "\"string\"";
+            if (schema.additionalProperties == null)
+                return defaultSchema
+            return (schema.additionalProperties as SchemaInterface.SchemaInline).schema.type.getPrimaryType() ?: defaultSchema
+        }catch (e:Exception){
+            throw RuntimeException("Error while resolving map values $schema")
         }
     }
 
@@ -61,19 +74,23 @@ class AvroTypeMapper(
                     else -> "\"string\""
                 }
             }
+
             "integer" -> {
                 if (schema.format == "date") "{\"type\": \"int\", \"logicalType\": \"date\"}"
                 else "\"int\""
             }
+
             "number" -> "\"double\""
             "boolean" -> "\"boolean\""
             "long" -> {
                 if (schema.format == "date-time") "{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}"
                 else "\"long\""
             }
+
             "array" -> {
                 "{\"type\": \"array\", \"items\": \"string\"}"
             }
+
             else -> "\"string\""
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/complexorder/GenerateComplexOrderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/complexorder/GenerateComplexOrderTest.kt
@@ -145,204 +145,228 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
         )
         val classBody = extractClassBody(generated)
         val expected = """
-               public class ComplexOrderPayloadType implements Serializable {
-
-                   @NotNull
-                   private UUID orderId;
-
-                   @NotNull
-                   private OffsetDateTime createdAt;
-
-                   @Size(min = 3, max = 30)
-                   @NotNull
-                   private String status;
-
-                   @NotNull
-                   @Valid
-                   private CustomerWithContacts customer;
-
-                   @NotNull
-                   @Valid
-                   private List<OrderLineType> orderLines;
-
-                   @Size(max = 2000)
-                   private String notes;
-
-                   public ComplexOrderPayloadType() {
-                       // Default constructor
-                   }
-
-                   // All-args constructor
-                   public ComplexOrderPayloadType(
-                       UUID orderId,
-                       OffsetDateTime createdAt,
-                       String status,
-                       CustomerWithContacts customer,
-                       List<OrderLineType> orderLines,
-                       String notes
-                   ) {
-                       this.orderId = orderId;
-                       this.createdAt = createdAt;
-                       this.status = status;
-                       this.customer = customer;
-                       this.orderLines = orderLines;
-                       this.notes = notes;
-                   }
-
-                   /**
-                    * Get orderId.
-                    * Unique identifier for the order.
-                    * @return UUID
-                    */
-                   public UUID getOrderId() {
-                       return orderId;
-                   }
-
-                   /**
-                    * Set orderId.
-                    * @param orderId Unique identifier for the order.
-                    */
-                   public void setOrderId(UUID orderId) {
-                       this.orderId = orderId;
-                   }
-
-                   /**
-                    * Get createdAt.
-                    * Timestamp for when the order was created.
-                    * @return OffsetDateTime
-                    */
-                   public OffsetDateTime getCreatedAt() {
-                       return createdAt;
-                   }
-
-                   /**
-                    * Set createdAt.
-                    * @param createdAt Timestamp for when the order was created.
-                    */
-                   public void setCreatedAt(OffsetDateTime createdAt) {
-                       this.createdAt = createdAt;
-                   }
-
-                   /**
-                    * Get status.
-                    * Current status of the order. Valid values include:
-                    * * `NEW`
-                    * * `PROCESSING`
-                    * * `COMPLETED`
-                    * * `CANCELLED`
-                    * @return String
-                    */
-                   public String getStatus() {
-                       return status;
-                   }
-
-                   /**
-                    * Set status.
-                    * @param status Current status of the order. Valid values include:
-                    */
-                   public void setStatus(String status) {
-                       this.status = status;
-                   }
-
-                   /**
-                    * Get customer.
-                    * Customer object with nested contact points and primitive lists.
-                    * @return CustomerWithContacts
-                    */
-                   public CustomerWithContacts getCustomer() {
-                       return customer;
-                   }
-
-                   /**
-                    * Set customer.
-                    * @param customer Customer object with nested contact points and primitive lists.
-                    */
-                   public void setCustomer(CustomerWithContacts customer) {
-                       this.customer = customer;
-                   }
-
-                   /**
-                    * Get orderLines.
-                    * One or more order lines included in the order.
-                    * @return List<OrderLineType>
-                    */
-                   public List<OrderLineType> getOrderLines() {
-                       return orderLines;
-                   }
-
-                   /**
-                    * Set orderLines.
-                    * @param orderLines One or more order lines included in the order.
-                    */
-                   public void setOrderLines(List<OrderLineType> orderLines) {
-                       this.orderLines = orderLines;
-                   }
-
-                   /**
-                    * Get notes.
-                    * Optional free-text notes attached to the order.
-                    * @return String
-                    */
-                   public String getNotes() {
-                       return notes;
-                   }
-
-                   /**
-                    * Set notes.
-                    * @param notes Optional free-text notes attached to the order.
-                    */
-                   public void setNotes(String notes) {
-                       this.notes = notes;
-                   }
-
-                   @Override
-                   public boolean equals(Object o) {
-                       if (this == o) return true;
-                       if (o == null || getClass() != o.getClass()) return false;
-                       ComplexOrderPayloadType that = (ComplexOrderPayloadType) o;
-                       return
-                           Objects.equals(orderId, that.orderId) &&
-
-                           Objects.equals(createdAt, that.createdAt) &&
-
-                           Objects.equals(status, that.status) &&
-
-                           Objects.equals(customer, that.customer) &&
-
-                           Objects.equals(orderLines, that.orderLines) &&
-
-                           Objects.equals(notes, that.notes)
-               ;
-                   }
-
-                   @Override
-                   public int hashCode() {
-                       return Objects.hash(
-               
-                           orderId,
-                           createdAt,
-                           status,
-                           customer,
-                           orderLines,
-                           notes
-                       );
-                   }
-
-                   @Override
-                   public String toString() {
-                       StringBuilder sb = new StringBuilder();
-                       sb.append("class ComplexOrderPayloadType {\n");
-                       sb.append("    orderId: ").append(orderId).append("\n");
-                       sb.append("    createdAt: ").append(createdAt).append("\n");
-                       sb.append("    status: ").append(status).append("\n");
-                       sb.append("    customer: ").append(customer).append("\n");
-                       sb.append("    orderLines: ").append(orderLines).append("\n");
-                       sb.append("    notes: ").append(notes).append("\n");
-                       sb.append("}");
-                       return sb.toString();
-                   }
-               }
-           """.trimIndent()
+            public class ComplexOrderPayloadType implements Serializable {
+            
+                private Map<String, String> metadata;
+            
+                @NotNull
+                private UUID orderId;
+            
+                @NotNull
+                private OffsetDateTime createdAt;
+            
+                @Size(min = 3, max = 30)
+                @NotNull
+                private String status;
+            
+                @NotNull
+                @Valid
+                private CustomerWithContacts customer;
+            
+                @NotNull
+                @Valid
+                private List<OrderLineType> orderLines;
+            
+                @Size(max = 2000)
+                private String notes;
+            
+                public ComplexOrderPayloadType() {
+                    // Default constructor
+                }
+            
+                // All-args constructor
+                public ComplexOrderPayloadType(
+                    Map<String, String> metadata,
+                    UUID orderId,
+                    OffsetDateTime createdAt,
+                    String status,
+                    CustomerWithContacts customer,
+                    List<OrderLineType> orderLines,
+                    String notes
+                ) {
+                    this.metadata = metadata;
+                    this.orderId = orderId;
+                    this.createdAt = createdAt;
+                    this.status = status;
+                    this.customer = customer;
+                    this.orderLines = orderLines;
+                    this.notes = notes;
+                }
+            
+                /**
+                 * Get metadata.
+                 * @return Map<String, String>
+                 */
+                public Map<String, String> getMetadata() {
+                    return metadata;
+                }
+            
+                /**
+                 * Set metadata.
+                 * @param metadata
+                 */
+                public void setMetadata(Map<String, String> metadata) {
+                    this.metadata = metadata;
+                }
+            
+                /**
+                 * Get orderId.
+                 * Unique identifier for the order.
+                 * @return UUID
+                 */
+                public UUID getOrderId() {
+                    return orderId;
+                }
+            
+                /**
+                 * Set orderId.
+                 * @param orderId Unique identifier for the order.
+                 */
+                public void setOrderId(UUID orderId) {
+                    this.orderId = orderId;
+                }
+            
+                /**
+                 * Get createdAt.
+                 * Timestamp for when the order was created.
+                 * @return OffsetDateTime
+                 */
+                public OffsetDateTime getCreatedAt() {
+                    return createdAt;
+                }
+            
+                /**
+                 * Set createdAt.
+                 * @param createdAt Timestamp for when the order was created.
+                 */
+                public void setCreatedAt(OffsetDateTime createdAt) {
+                    this.createdAt = createdAt;
+                }
+            
+                /**
+                 * Get status.
+                 * Current status of the order. Valid values include:
+                 * * `NEW`
+                 * * `PROCESSING`
+                 * * `COMPLETED`
+                 * * `CANCELLED`
+                 * @return String
+                 */
+                public String getStatus() {
+                    return status;
+                }
+            
+                /**
+                 * Set status.
+                 * @param status Current status of the order. Valid values include:
+                 */
+                public void setStatus(String status) {
+                    this.status = status;
+                }
+            
+                /**
+                 * Get customer.
+                 * Customer object with nested contact points and primitive lists.
+                 * @return CustomerWithContacts
+                 */
+                public CustomerWithContacts getCustomer() {
+                    return customer;
+                }
+            
+                /**
+                 * Set customer.
+                 * @param customer Customer object with nested contact points and primitive lists.
+                 */
+                public void setCustomer(CustomerWithContacts customer) {
+                    this.customer = customer;
+                }
+            
+                /**
+                 * Get orderLines.
+                 * One or more order lines included in the order.
+                 * @return List<OrderLineType>
+                 */
+                public List<OrderLineType> getOrderLines() {
+                    return orderLines;
+                }
+            
+                /**
+                 * Set orderLines.
+                 * @param orderLines One or more order lines included in the order.
+                 */
+                public void setOrderLines(List<OrderLineType> orderLines) {
+                    this.orderLines = orderLines;
+                }
+            
+                /**
+                 * Get notes.
+                 * Optional free-text notes attached to the order.
+                 * @return String
+                 */
+                public String getNotes() {
+                    return notes;
+                }
+            
+                /**
+                 * Set notes.
+                 * @param notes Optional free-text notes attached to the order.
+                 */
+                public void setNotes(String notes) {
+                    this.notes = notes;
+                }
+            
+                @Override
+                public boolean equals(Object o) {
+                    if (this == o) return true;
+                    if (o == null || getClass() != o.getClass()) return false;
+                    ComplexOrderPayloadType that = (ComplexOrderPayloadType) o;
+                    return
+                        Objects.equals(metadata, that.metadata) &&
+            
+                        Objects.equals(orderId, that.orderId) &&
+            
+                        Objects.equals(createdAt, that.createdAt) &&
+            
+                        Objects.equals(status, that.status) &&
+            
+                        Objects.equals(customer, that.customer) &&
+            
+                        Objects.equals(orderLines, that.orderLines) &&
+            
+                        Objects.equals(notes, that.notes)
+            ;
+                }
+            
+                @Override
+                public int hashCode() {
+                    return Objects.hash(
+            
+                        metadata,
+                        orderId,
+                        createdAt,
+                        status,
+                        customer,
+                        orderLines,
+                        notes
+                    );
+                }
+            
+                @Override
+                public String toString() {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("class ComplexOrderPayloadType {\n");
+                    sb.append("    metadata: ").append(metadata).append("\n");
+                    sb.append("    orderId: ").append(orderId).append("\n");
+                    sb.append("    createdAt: ").append(createdAt).append("\n");
+                    sb.append("    status: ").append(status).append("\n");
+                    sb.append("    customer: ").append(customer).append("\n");
+                    sb.append("    orderLines: ").append(orderLines).append("\n");
+                    sb.append("    notes: ").append(notes).append("\n");
+                    sb.append("}");
+                    return sb.toString();
+                }
+            }
+            """.trimIndent()
         assertEquals(expected, classBody)
     }
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/complexorder/GenerateComplexOrderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/complexorder/GenerateComplexOrderTest.kt
@@ -42,26 +42,28 @@ class GenerateComplexOrderTest : AbstractKotlinGeneratorClass() {
         )
         val dataClass = extractElement(generated)
         val expected = """
-        data class ComplexOrderPayloadType(
+            data class ComplexOrderPayloadType(
 
-            val orderId: UUID,
-
-            val createdAt: OffsetDateTime,
-
-            @field:Size(min = 3, max = 30)
-            val status: String,
-
-            @field:Valid
-            val customer: CustomerWithContacts,
-
-            @field:Valid
-            val orderLines: List<OrderLineType>,
-
-            @field:Size(max = 2000)
-            val notes: String? = null
-        ) {
-        }
-    """.trimIndent()
+                val metadata: Map<String, String>? = null,
+            
+                val orderId: UUID,
+            
+                val createdAt: OffsetDateTime,
+            
+                @field:Size(min = 3, max = 30)
+                val status: String,
+            
+                @field:Valid
+                val customer: CustomerWithContacts,
+            
+                @field:Valid
+                val orderLines: List<OrderLineType>,
+            
+                @field:Size(max = 2000)
+                val notes: String? = null
+            ) {
+            }
+            """.trimIndent()
         assertEquals(expected, dataClass)
     }
 

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_complex_order_payload_type.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_complex_order_payload_type.yaml
@@ -17,6 +17,11 @@ components:
         - customer
         - orderLines
       properties:
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
         orderId:
           description: Unique identifier for the order.
           type: string


### PR DESCRIPTION
Motivation:
By default generator ignores avro maps creation with "additionalProperties" yaml item.

```
   SomeEntity:
      ....
      properties:
        metadata:
          type: object
          additionalProperties:
            type: string
```

converts into following avro schema:

```
{
      "name": "metadata",
      "type": ["null", "string"],
      "default": null
}
```

This PR should fix this