### PR TITLE
feature/parser contract

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/AsyncApiParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/AsyncApiParser.kt
@@ -9,6 +9,17 @@ import dev.banking.asyncapi.generator.core.parser.info.InfoParser
 import dev.banking.asyncapi.generator.core.parser.operations.OperationParser
 import dev.banking.asyncapi.generator.core.parser.servers.ServerParser
 
+/**
+ * Parses a reader-backed parser-node tree into an AsyncAPI document model.
+ *
+ * The parser stage consumes typed [ParserNode] values and maps supported
+ * AsyncAPI structures into [AsyncApiDocument]. It does not read files, detect
+ * input formats, parse YAML or JSON, validate the model, bundle references, or
+ * generate output.
+ *
+ * Expected behavior is covered by:
+ * - `AsyncApiParserTest`
+ */
 class AsyncApiParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParser.kt
@@ -7,6 +7,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.model.references.Reference
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.BINDING
 
+/**
+ * Parses AsyncAPI binding objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `BindingParserTest`
+ */
 class BindingParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParser.kt
@@ -13,6 +13,12 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.CHANNEL
 import dev.banking.asyncapi.generator.core.parser.references.ReferenceParser
 
+/**
+ * Parses AsyncAPI channel objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `ChannelParserTest`
+ */
 class ChannelParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParser.kt
@@ -21,6 +21,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.parser.bindings.BindingParser
 
+/**
+ * Parses AsyncAPI component objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `ComponentParserTest`
+ */
 class ComponentParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParser.kt
@@ -7,6 +7,12 @@ import dev.banking.asyncapi.generator.core.model.references.Reference
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.CORRELATION_ID
 
+/**
+ * Parses AsyncAPI correlation ID objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `CorrelationIdParserTest`
+ */
 class CorrelationIdParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParser.kt
@@ -7,6 +7,12 @@ import dev.banking.asyncapi.generator.core.model.references.Reference
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.EXTERNAL_DOC
 
+/**
+ * Parses AsyncAPI external documentation objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `ExternalDocsParserTest`
+ */
 class ExternalDocsParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParser.kt
@@ -8,6 +8,12 @@ import dev.banking.asyncapi.generator.core.parser.tags.TagParser
 import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 
+/**
+ * Parses the AsyncAPI info object from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `InfoParserTest`
+ */
 class InfoParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParser.kt
@@ -4,6 +4,12 @@ import dev.banking.asyncapi.generator.core.model.messages.MessageExample
 import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 
+/**
+ * Parses AsyncAPI message example objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `MessageParserTest`
+ */
 class MessageExampleParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParser.kt
@@ -8,6 +8,7 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
  * Parses AsyncAPI message example objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `MessageExampleParserTest`
  * - `MessageParserTest`
  */
 class MessageExampleParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParser.kt
@@ -12,6 +12,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.MESSAGE
 
+/**
+ * Parses AsyncAPI message objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `MessageParserTest`
+ */
 class MessageParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParser.kt
@@ -12,6 +12,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.MESSAGE_TRAIT
 
+/**
+ * Parses AsyncAPI message trait objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `MessageParserTest`
+ */
 class MessageTraitParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParser.kt
@@ -16,6 +16,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI message trait objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `MessageTraitParserTest`
  * - `MessageParserTest`
  */
 class MessageTraitParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParser.kt
@@ -12,6 +12,12 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.OPERATION
 import dev.banking.asyncapi.generator.core.parser.references.ReferenceParser
 
+/**
+ * Parses AsyncAPI operation objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `OperationParserTest`
+ */
 class OperationParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParser.kt
@@ -7,6 +7,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.OPERATION_REPLY_ADDRESS
 
+/**
+ * Parses AsyncAPI operation reply address objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `OperationReplyParserTest`
+ */
 class OperationReplyAddressParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParser.kt
@@ -11,6 +11,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI operation reply address objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `OperationReplyAddressParserTest`
  * - `OperationReplyParserTest`
  */
 class OperationReplyAddressParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParser.kt
@@ -8,6 +8,12 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.OPERATION_REPLY
 import dev.banking.asyncapi.generator.core.parser.references.ReferenceParser
 
+/**
+ * Parses AsyncAPI operation reply objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `OperationReplyParserTest`
+ */
 class OperationReplyParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParser.kt
@@ -11,6 +11,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.OPERATION_TRAIT
 
+/**
+ * Parses AsyncAPI operation trait objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `OperationParserTest`
+ */
 class OperationTraitParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParser.kt
@@ -15,6 +15,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI operation trait objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `OperationTraitParserTest`
  * - `OperationParserTest`
  */
 class OperationTraitParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParser.kt
@@ -11,6 +11,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI parameter objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `ParameterParserTest`
  * - `ChannelParserTest`
  */
 class ParameterParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParser.kt
@@ -7,6 +7,12 @@ import dev.banking.asyncapi.generator.core.model.references.Reference
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.PARAMETER
 
+/**
+ * Parses AsyncAPI parameter objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `ChannelParserTest`
+ */
 class ParameterParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParser.kt
@@ -9,6 +9,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses generic AsyncAPI reference objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `ReferenceParserTest`
  * - `ChannelParserTest`
  * - `OperationParserTest`
  * - `OperationReplyParserTest`

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParser.kt
@@ -5,6 +5,14 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.REFERENCE
 
+/**
+ * Parses generic AsyncAPI reference objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `ChannelParserTest`
+ * - `OperationParserTest`
+ * - `OperationReplyParserTest`
+ */
 class ReferenceParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
@@ -25,6 +25,9 @@ import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseExcepti
  * **Future Expansion:**
  * This parser is designed to be expanded in the future to provide full parsing and
  * code generation support for the currently unimplemented schema formats.
+ *
+ * Expected behavior is covered by:
+ * - `SchemaParserTest`
  */
 class MultiFormatSchemaParser(
     val asyncApiContext: AsyncApiContext,
@@ -74,4 +77,3 @@ class MultiFormatSchemaParser(
             format == AsyncApiConstants.PROTOBUF_V_3
     }
 }
-

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
@@ -20,13 +20,14 @@ import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseExcepti
  * - For other known formats (e.g., JSON Schema Draft-07, Avro, OpenAPI, RAML, Protobuf),
  *   it *recognizes* the format but **throws a [UnsupportedSchemaFormat]**, indicating that
  *   code generation for these specific formats is not yet implemented in the generator.
- * - For any unknown `schemaFormat` string, it throws an [UnexpectedValue] error.
+ * - For any unknown `schemaFormat` string, it throws an [UnexpectedSchemaFormat] error.
  *
  * **Future Expansion:**
  * This parser is designed to be expanded in the future to provide full parsing and
  * code generation support for the currently unimplemented schema formats.
  *
  * Expected behavior is covered by:
+ * - `MultiFormatSchemaParserTest`
  * - `SchemaParserTest`
  */
 class MultiFormatSchemaParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParser.kt
@@ -12,6 +12,12 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
 import kotlin.String
 import kotlin.collections.Map
 
+/**
+ * Parses AsyncAPI schema objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `SchemaParserTest`
+ */
 class SchemaParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParser.kt
@@ -9,6 +9,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.SECURITY_SCHEME
 
+/**
+ * Parses AsyncAPI security scheme objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `SecuritySchemeParserTest`
+ */
 class SecuritySchemeParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParser.kt
@@ -11,6 +11,12 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.SERVER
 import dev.banking.asyncapi.generator.core.parser.bindings.BindingParser
 
+/**
+ * Parses AsyncAPI server objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `ServerParserTest`
+ */
 class ServerParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParser.kt
@@ -7,6 +7,12 @@ import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.SERVER_VARIABLE
 
+/**
+ * Parses AsyncAPI server variable objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `ServerParserTest`
+ */
 class ServerVariableParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParser.kt
@@ -11,6 +11,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI server variable objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `ServerVariableParserTest`
  * - `ServerParserTest`
  */
 class ServerVariableParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParser.kt
@@ -8,6 +8,12 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.TAG
 import dev.banking.asyncapi.generator.core.parser.externaldocs.ExternalDocsParser
 
+/**
+ * Parses AsyncAPI tag objects from parser nodes.
+ *
+ * Expected behavior is covered by:
+ * - `TagParserTest`
+ */
 class TagParser(
     val asyncApiContext: AsyncApiContext,
 ) {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/AbstractParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/AbstractParserTest.kt
@@ -4,12 +4,18 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.fixtures.ParserFixtures
 import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 
+/**
+ * Shared base for parser-stage tests.
+ *
+ * It exposes reader-backed parser roots so parser tests can focus on
+ * `ParserNode` input and model output instead of file-format handling.
+ */
 abstract class AbstractParserTest {
 
     protected val asyncApiContext = AsyncApiContext()
     private val parserFixtures = ParserFixtures(asyncApiContext)
 
-    protected fun readYaml(path: String): ParserNode {
+    protected fun readRoot(path: String): ParserNode {
         return parserFixtures.root(path)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
@@ -5,6 +5,7 @@ import dev.banking.asyncapi.generator.core.fixtures.ParserFixtures
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.parser.node.ParserNode
+import org.assertj.core.api.Assertions.assertThat
 import kotlin.test.assertFailsWith
 
 /**
@@ -27,8 +28,13 @@ abstract class ParserTestSupport {
     }
 
     protected inline fun <reified T : AsyncApiParseException> assertParseFailure(
+        vararg expectedMessageParts: String,
         noinline block: () -> Unit,
     ): T {
-        return assertFailsWith<T>(block = block)
+        val error = assertFailsWith<T>(block = block)
+        expectedMessageParts.forEach { expected ->
+            assertThat(error.message).contains(expected)
+        }
+        return error
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
@@ -3,7 +3,9 @@ package dev.banking.asyncapi.generator.core.parser
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.fixtures.ParserFixtures
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.parser.node.ParserNode
+import kotlin.test.assertFailsWith
 
 /**
  * Shared support for parser-stage tests.
@@ -22,5 +24,11 @@ abstract class ParserTestSupport {
 
     protected fun parseDocument(path: String): AsyncApiDocument {
         return parserFixtures.document(path)
+    }
+
+    protected inline fun <reified T : AsyncApiParseException> assertParseFailure(
+        noinline block: () -> Unit,
+    ): T {
+        return assertFailsWith<T>(block = block)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
@@ -2,20 +2,25 @@ package dev.banking.asyncapi.generator.core.parser
 
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.fixtures.ParserFixtures
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 
 /**
- * Shared base for parser-stage tests.
+ * Shared support for parser-stage tests.
  *
  * It exposes reader-backed parser roots so parser tests can focus on
  * `ParserNode` input and model output instead of file-format handling.
  */
-abstract class AbstractParserTest {
+abstract class ParserTestSupport {
 
     protected val asyncApiContext = AsyncApiContext()
     private val parserFixtures = ParserFixtures(asyncApiContext)
 
     protected fun readRoot(path: String): ParserNode {
         return parserFixtures.root(path)
+    }
+
+    protected fun parseDocument(path: String): AsyncApiDocument {
+        return parserFixtures.document(path)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/ParserTestSupport.kt
@@ -23,6 +23,15 @@ abstract class ParserTestSupport {
         return parserFixtures.root(path)
     }
 
+    protected fun readNode(
+        path: String,
+        vararg nodePath: String,
+    ): ParserNode {
+        return nodePath.fold(readRoot(path)) { node, key ->
+            node.mandatory(key)
+        }
+    }
+
     protected fun parseDocument(path: String): AsyncApiDocument {
         return parserFixtures.document(path)
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
@@ -17,7 +17,7 @@ class AsyncApiParserTest : AbstractParserTest() {
 
     @Test
     fun parseSingleFileAsyncApi() {
-        val root = readYaml("asyncapi_kafka_single_file_example.yaml")
+        val root = readRoot("asyncapi_kafka_single_file_example.yaml")
         val result = parser.parse(root)
 
         assertEquals("3.0.0", result.asyncapi, "AsyncAPI version mismatch")
@@ -65,7 +65,7 @@ class AsyncApiParserTest : AbstractParserTest() {
 
     @Test
     fun `parsed schema is registered in model repository`() {
-        val root = readYaml("asyncapi_kafka_single_file_example.yaml")
+        val root = readRoot("asyncapi_kafka_single_file_example.yaml")
         val asyncApi =  parser.parse(root)
         val schemasMap = (asyncApi.components as ComponentInterface.ComponentInline).component.schemas!!
 
@@ -104,7 +104,7 @@ class AsyncApiParserTest : AbstractParserTest() {
 
     @Test
     fun `parsed schema properties have correct line numbers in source repository`() {
-        val root = readYaml("asyncapi_kafka_single_file_example.yaml")
+        val root = readRoot("asyncapi_kafka_single_file_example.yaml")
         parser.parse(root)
         val schemaPath =
             "${asyncApiContext.sourceRepository.getCurrentFile().nameWithoutExtension}.root.components.schemas.simpleString"

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
@@ -1,17 +1,16 @@
 package dev.banking.asyncapi.generator.core.parser.asyncapi
 
-import dev.banking.asyncapi.generator.core.fixtures.ParserFixtures
 import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
 import dev.banking.asyncapi.generator.core.parser.AsyncApiParser
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 
-class AsyncApiParserTest : AbstractParserTest() {
+class AsyncApiParserTest : ParserTestSupport() {
 
     private val parser = AsyncApiParser(asyncApiContext)
 
@@ -57,8 +56,8 @@ class AsyncApiParserTest : AbstractParserTest() {
 
     @Test
     fun `parses equivalent yaml and json documents into the same model`() {
-        val yaml = ParserFixtures().document("parser/asyncapi/format-independent.yaml")
-        val json = ParserFixtures().document("parser/asyncapi/format-independent.json")
+        val yaml = parseDocument("parser/asyncapi/format-independent.yaml")
+        val json = parseDocument("parser/asyncapi/format-independent.json")
 
         assertEquals(yaml, json)
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
@@ -16,8 +16,8 @@ class AsyncApiParserTest : ParserTestSupport() {
 
     @Test
     fun parseSingleFileAsyncApi() {
-        val root = readRoot("asyncapi_kafka_single_file_example.yaml")
-        val result = parser.parse(root)
+        val rootNode = readNode("asyncapi_kafka_single_file_example.yaml")
+        val result = parser.parse(rootNode)
 
         assertEquals("3.0.0", result.asyncapi, "AsyncAPI version mismatch")
         assertEquals("Streetlights Kafka API", result.info.title)
@@ -64,8 +64,8 @@ class AsyncApiParserTest : ParserTestSupport() {
 
     @Test
     fun `parsed schema is registered in model repository`() {
-        val root = readRoot("asyncapi_kafka_single_file_example.yaml")
-        val asyncApi =  parser.parse(root)
+        val rootNode = readNode("asyncapi_kafka_single_file_example.yaml")
+        val asyncApi = parser.parse(rootNode)
         val schemasMap = (asyncApi.components as ComponentInterface.ComponentInline).component.schemas!!
 
         val lightMeasuredPayloadSchema = (schemasMap["lightMeasuredPayload"] as SchemaInterface.SchemaInline).schema
@@ -103,8 +103,8 @@ class AsyncApiParserTest : ParserTestSupport() {
 
     @Test
     fun `parsed schema properties have correct line numbers in source repository`() {
-        val root = readRoot("asyncapi_kafka_single_file_example.yaml")
-        parser.parse(root)
+        val rootNode = readNode("asyncapi_kafka_single_file_example.yaml")
+        parser.parse(rootNode)
         val schemaPath =
             "${asyncApiContext.sourceRepository.getCurrentFile().nameWithoutExtension}.root.components.schemas.simpleString"
         val simpleStringSchema = asyncApiContext.modelRepository.getModelsByPath()[schemaPath] as Schema

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
@@ -5,7 +5,6 @@ import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseExcepti
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class BindingParserTest : ParserTestSupport() {
@@ -63,7 +62,7 @@ class BindingParserTest : ParserTestSupport() {
     @Test
     fun `parse binding with invalid structure throws UnexpectedValue`() {
         val root = readRoot("parser/bindings/asyncapi_parser_binding_invalid.yaml")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(root.mandatory("components").mandatory("channelBindings"))
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
@@ -13,8 +13,13 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid channel bindings`() {
-        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
-        val bindings = parser.parseMap(root.mandatory("components").mandatory("channelBindings"))
+        val bindings = parser.parseMap(
+            readNode(
+                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+                "components",
+                "channelBindings",
+            )
+        )
         assertTrue("userSignedUpChannel" in bindings)
         val binding = (bindings["userSignedUpChannel"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -25,8 +30,13 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid message bindings`() {
-        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
-        val bindings = parser.parseMap(root.mandatory("components").mandatory("messageBindings"))
+        val bindings = parser.parseMap(
+            readNode(
+                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+                "components",
+                "messageBindings",
+            )
+        )
         assertTrue("userSignedUpMessage" in bindings)
         val binding = (bindings["userSignedUpMessage"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -37,8 +47,13 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid server bindings`() {
-        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
-        val bindings = parser.parseMap(root.mandatory("components").mandatory("serverBindings"))
+        val bindings = parser.parseMap(
+            readNode(
+                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+                "components",
+                "serverBindings",
+            )
+        )
         assertTrue("myServerBinding" in bindings)
         val binding = (bindings["myServerBinding"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -49,8 +64,13 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid operation bindings`() {
-        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
-        val bindings = parser.parseMap(root.mandatory("components").mandatory("operationBindings"))
+        val bindings = parser.parseMap(
+            readNode(
+                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+                "components",
+                "operationBindings",
+            )
+        )
         assertTrue("myOperationBinding" in bindings)
         val binding = (bindings["myOperationBinding"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -61,13 +81,18 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse binding with invalid structure throws UnexpectedValue`() {
-        val root = readRoot("parser/bindings/asyncapi_parser_binding_invalid.yaml")
         assertParseFailure<AsyncApiParseException.UnexpectedValue>(
             "Unexpected value: expected Map",
             "asyncapi_parser_binding_invalid.yaml",
             "asyncapi_parser_binding_invalid.root.components.channelBindings.InvalidBindingStructure",
         ) {
-            parser.parseMap(root.mandatory("components").mandatory("channelBindings"))
+            parser.parseMap(
+                readNode(
+                    "parser/bindings/asyncapi_parser_binding_invalid.yaml",
+                    "components",
+                    "channelBindings",
+                )
+            )
         }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
@@ -14,7 +14,7 @@ class BindingParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid channel bindings`() {
-        val root = readYaml("parser/bindings/asyncapi_parser_bindings_valid.yaml")
+        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
         val bindings = parser.parseMap(root.mandatory("components").mandatory("channelBindings"))
         assertTrue("userSignedUpChannel" in bindings)
         val binding = (bindings["userSignedUpChannel"] as BindingInterface.BindingInline).binding
@@ -26,7 +26,7 @@ class BindingParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid message bindings`() {
-        val root = readYaml("parser/bindings/asyncapi_parser_bindings_valid.yaml")
+        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
         val bindings = parser.parseMap(root.mandatory("components").mandatory("messageBindings"))
         assertTrue("userSignedUpMessage" in bindings)
         val binding = (bindings["userSignedUpMessage"] as BindingInterface.BindingInline).binding
@@ -38,7 +38,7 @@ class BindingParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid server bindings`() {
-        val root = readYaml("parser/bindings/asyncapi_parser_bindings_valid.yaml")
+        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
         val bindings = parser.parseMap(root.mandatory("components").mandatory("serverBindings"))
         assertTrue("myServerBinding" in bindings)
         val binding = (bindings["myServerBinding"] as BindingInterface.BindingInline).binding
@@ -50,7 +50,7 @@ class BindingParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid operation bindings`() {
-        val root = readYaml("parser/bindings/asyncapi_parser_bindings_valid.yaml")
+        val root = readRoot("parser/bindings/asyncapi_parser_bindings_valid.yaml")
         val bindings = parser.parseMap(root.mandatory("components").mandatory("operationBindings"))
         assertTrue("myOperationBinding" in bindings)
         val binding = (bindings["myOperationBinding"] as BindingInterface.BindingInline).binding
@@ -62,7 +62,7 @@ class BindingParserTest : AbstractParserTest() {
 
     @Test
     fun `parse binding with invalid structure throws UnexpectedValue`() {
-        val root = readYaml("parser/bindings/asyncapi_parser_binding_invalid.yaml")
+        val root = readRoot("parser/bindings/asyncapi_parser_binding_invalid.yaml")
         assertFailsWith<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(root.mandatory("components").mandatory("channelBindings"))
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.bindings
 
 import dev.banking.asyncapi.generator.core.model.bindings.BindingInterface
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class BindingParserTest : AbstractParserTest() {
+class BindingParserTest : ParserTestSupport() {
 
     private val parser = BindingParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
@@ -62,7 +62,11 @@ class BindingParserTest : ParserTestSupport() {
     @Test
     fun `parse binding with invalid structure throws UnexpectedValue`() {
         val root = readRoot("parser/bindings/asyncapi_parser_binding_invalid.yaml")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_binding_invalid.yaml",
+            "asyncapi_parser_binding_invalid.root.components.channelBindings.InvalidBindingStructure",
+        ) {
             parser.parseMap(root.mandatory("components").mandatory("channelBindings"))
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/bindings/BindingParserTest.kt
@@ -13,13 +13,12 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid channel bindings`() {
-        val bindings = parser.parseMap(
-            readNode(
-                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
-                "components",
-                "channelBindings",
-            )
+        val channelBindingsNode = readNode(
+            "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+            "components",
+            "channelBindings",
         )
+        val bindings = parser.parseMap(channelBindingsNode)
         assertTrue("userSignedUpChannel" in bindings)
         val binding = (bindings["userSignedUpChannel"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -30,13 +29,12 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid message bindings`() {
-        val bindings = parser.parseMap(
-            readNode(
-                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
-                "components",
-                "messageBindings",
-            )
+        val messageBindingsNode = readNode(
+            "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+            "components",
+            "messageBindings",
         )
+        val bindings = parser.parseMap(messageBindingsNode)
         assertTrue("userSignedUpMessage" in bindings)
         val binding = (bindings["userSignedUpMessage"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -47,13 +45,12 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid server bindings`() {
-        val bindings = parser.parseMap(
-            readNode(
-                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
-                "components",
-                "serverBindings",
-            )
+        val serverBindingsNode = readNode(
+            "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+            "components",
+            "serverBindings",
         )
+        val bindings = parser.parseMap(serverBindingsNode)
         assertTrue("myServerBinding" in bindings)
         val binding = (bindings["myServerBinding"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -64,13 +61,12 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid operation bindings`() {
-        val bindings = parser.parseMap(
-            readNode(
-                "parser/bindings/asyncapi_parser_bindings_valid.yaml",
-                "components",
-                "operationBindings",
-            )
+        val operationBindingsNode = readNode(
+            "parser/bindings/asyncapi_parser_bindings_valid.yaml",
+            "components",
+            "operationBindings",
         )
+        val bindings = parser.parseMap(operationBindingsNode)
         assertTrue("myOperationBinding" in bindings)
         val binding = (bindings["myOperationBinding"] as BindingInterface.BindingInline).binding
         assertThat(binding)
@@ -81,18 +77,17 @@ class BindingParserTest : ParserTestSupport() {
 
     @Test
     fun `parse binding with invalid structure throws UnexpectedValue`() {
+        val channelBindingsNode = readNode(
+            "parser/bindings/asyncapi_parser_binding_invalid.yaml",
+            "components",
+            "channelBindings",
+        )
         assertParseFailure<AsyncApiParseException.UnexpectedValue>(
             "Unexpected value: expected Map",
             "asyncapi_parser_binding_invalid.yaml",
             "asyncapi_parser_binding_invalid.root.components.channelBindings.InvalidBindingStructure",
         ) {
-            parser.parseMap(
-                readNode(
-                    "parser/bindings/asyncapi_parser_binding_invalid.yaml",
-                    "components",
-                    "channelBindings",
-                )
-            )
+            parser.parseMap(channelBindingsNode)
         }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.channels
 
 import dev.banking.asyncapi.generator.core.model.channels.ChannelInterface
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
-class ChannelParserTest : AbstractParserTest() {
+class ChannelParserTest : ParserTestSupport() {
 
     private val parser = ChannelParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
@@ -118,7 +118,11 @@ class ChannelParserTest : ParserTestSupport() {
     @Test
     fun `parse channel with invalid messages structure throws UnexpectedValue`() {
         val channelsNode = readNode("parser/channels/asyncapi_parser_channel_invalid.yaml", "channels")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map/List",
+            "asyncapi_parser_channel_invalid.yaml",
+            "asyncapi_parser_channel_invalid.root.channels.InvalidMessages.messages",
+        ) {
             parser.parseMap(channelsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
@@ -6,7 +6,6 @@ import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 class ChannelParserTest : ParserTestSupport() {
 
@@ -119,7 +118,7 @@ class ChannelParserTest : ParserTestSupport() {
     @Test
     fun `parse channel with invalid messages structure throws UnexpectedValue`() {
         val root = readRoot("parser/channels/asyncapi_parser_channel_invalid.yaml")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(root.mandatory("channels"))
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
@@ -14,7 +14,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse lightingMeasured channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("lightingMeasured" in result)
         val lightingMeasured = (result["lightingMeasured"] as ChannelInterface.ChannelInline).channel
@@ -27,7 +27,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse lightTurnOn channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("lightTurnOn" in result)
         val lightTurnOn = (result["lightTurnOn"] as ChannelInterface.ChannelInline).channel
@@ -40,7 +40,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse lightTurnOff channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("lightTurnOff" in result)
         val lightTurnOff = (result["lightTurnOff"] as ChannelInterface.ChannelInline).channel
@@ -53,7 +53,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse lightsDim channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("lightsDim" in result)
         val lightsDim = (result["lightsDim"] as ChannelInterface.ChannelInline).channel
@@ -66,7 +66,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse lightStatus channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("lightStatus" in result)
         val lightStatus = (result["lightStatus"] as ChannelInterface.ChannelInline).channel
@@ -79,7 +79,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse maintenanceRequest channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("maintenanceRequest" in result)
         val maintenanceRequest = (result["maintenanceRequest"] as ChannelInterface.ChannelInline).channel
@@ -92,7 +92,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse cityLights channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("cityLights" in result)
         val cityLights = (result["cityLights"] as ChannelInterface.ChannelInline).channel
@@ -105,7 +105,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse powerStatus channel`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_valid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
         val result = parser.parseMap(root.mandatory("channels"))
         assertTrue("powerStatus" in result)
         val powerStatus = (result["powerStatus"] as ChannelInterface.ChannelInline).channel
@@ -118,7 +118,7 @@ class ChannelParserTest : AbstractParserTest() {
 
     @Test
     fun `parse channel with invalid messages structure throws UnexpectedValue`() {
-        val root = readYaml("parser/channels/asyncapi_parser_channel_invalid.yaml")
+        val root = readRoot("parser/channels/asyncapi_parser_channel_invalid.yaml")
         assertFailsWith<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(root.mandatory("channels"))
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
@@ -13,8 +13,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse lightingMeasured channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("lightingMeasured" in result)
         val lightingMeasured = (result["lightingMeasured"] as ChannelInterface.ChannelInline).channel
         val expectedLightingMeasured = lightingMeasured()
@@ -26,8 +26,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse lightTurnOn channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("lightTurnOn" in result)
         val lightTurnOn = (result["lightTurnOn"] as ChannelInterface.ChannelInline).channel
         val expectedLightTurnOn = lightTurnOn()
@@ -39,8 +39,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse lightTurnOff channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("lightTurnOff" in result)
         val lightTurnOff = (result["lightTurnOff"] as ChannelInterface.ChannelInline).channel
         val expectedLightTurnOff = lightTurnOff()
@@ -52,8 +52,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse lightsDim channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("lightsDim" in result)
         val lightsDim = (result["lightsDim"] as ChannelInterface.ChannelInline).channel
         val expectedLightsDim = lightsDim()
@@ -65,8 +65,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse lightStatus channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("lightStatus" in result)
         val lightStatus = (result["lightStatus"] as ChannelInterface.ChannelInline).channel
         val expectedLightStatus = lightStatus()
@@ -78,8 +78,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse maintenanceRequest channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("maintenanceRequest" in result)
         val maintenanceRequest = (result["maintenanceRequest"] as ChannelInterface.ChannelInline).channel
         val expectedMaintenanceRequest = maintenanceRequest()
@@ -91,8 +91,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse cityLights channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("cityLights" in result)
         val cityLights = (result["cityLights"] as ChannelInterface.ChannelInline).channel
         val expectedCityLights = cityLights()
@@ -104,8 +104,8 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse powerStatus channel`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_valid.yaml")
-        val result = parser.parseMap(root.mandatory("channels"))
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_valid.yaml", "channels")
+        val result = parser.parseMap(channelsNode)
         assertTrue("powerStatus" in result)
         val powerStatus = (result["powerStatus"] as ChannelInterface.ChannelInline).channel
         val expectedPowerStatus = powerStatus()
@@ -117,9 +117,9 @@ class ChannelParserTest : ParserTestSupport() {
 
     @Test
     fun `parse channel with invalid messages structure throws UnexpectedValue`() {
-        val root = readRoot("parser/channels/asyncapi_parser_channel_invalid.yaml")
+        val channelsNode = readNode("parser/channels/asyncapi_parser_channel_invalid.yaml", "channels")
         assertParseFailure<AsyncApiParseException.UnexpectedValue> {
-            parser.parseMap(root.mandatory("channels"))
+            parser.parseMap(channelsNode)
         }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
@@ -12,7 +12,7 @@ class ComponentParserTest : AbstractParserTest() {
 
     @Test
     fun `parse components object delegates to all sub-parsers`() {
-        val root = readYaml("parser/components/asyncapi_parser_components_valid.yaml")
+        val root = readRoot("parser/components/asyncapi_parser_components_valid.yaml")
         val result = parser.parseElement(root.mandatory("components"))
 
         assertTrue(result is ComponentInterface.ComponentInline)

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
@@ -1,12 +1,12 @@
 package dev.banking.asyncapi.generator.core.parser.components
 
 import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class ComponentParserTest : AbstractParserTest() {
+class ComponentParserTest : ParserTestSupport() {
 
     private val parser = ComponentParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
@@ -12,8 +12,9 @@ class ComponentParserTest : ParserTestSupport() {
 
     @Test
     fun `parse components object delegates to all sub-parsers`() {
-        val root = readRoot("parser/components/asyncapi_parser_components_valid.yaml")
-        val result = parser.parseElement(root.mandatory("components"))
+        val result = parser.parseElement(
+            readNode("parser/components/asyncapi_parser_components_valid.yaml", "components")
+        )
 
         assertTrue(result is ComponentInterface.ComponentInline)
         val component = result.component

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/components/ComponentParserTest.kt
@@ -12,9 +12,8 @@ class ComponentParserTest : ParserTestSupport() {
 
     @Test
     fun `parse components object delegates to all sub-parsers`() {
-        val result = parser.parseElement(
-            readNode("parser/components/asyncapi_parser_components_valid.yaml", "components")
-        )
+        val componentsNode = readNode("parser/components/asyncapi_parser_components_valid.yaml", "components")
+        val result = parser.parseElement(componentsNode)
 
         assertTrue(result is ComponentInterface.ComponentInline)
         val component = result.component

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
@@ -14,7 +14,7 @@ class CorrelationIdParserTest : AbstractParserTest() {
 
     @Test
     fun `parse inline correlation ID`() {
-        val root = readYaml("parser/correlations/asyncapi_parser_correlationid_valid.yaml")
+        val root = readRoot("parser/correlations/asyncapi_parser_correlationid_valid.yaml")
         val correlationIdNode = root
             .mandatory("components")
             .mandatory("correlationIds")
@@ -29,7 +29,7 @@ class CorrelationIdParserTest : AbstractParserTest() {
 
     @Test
     fun `parse correlation ID missing location throws RequiredObject`() {
-        val root = readYaml("parser/correlations/asyncapi_parser_correlationid_invalid.yaml")
+        val root = readRoot("parser/correlations/asyncapi_parser_correlationid_invalid.yaml")
         val correlationIdNode = root.mandatory("components").mandatory("correlationIds").mandatory("MissingLocationId")
         assertFailsWith<AsyncApiParseException.Mandatory> {
             parser.parseElement(correlationIdNode)

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
@@ -5,7 +5,6 @@ import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseExcepti
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class CorrelationIdParserTest : ParserTestSupport() {
@@ -31,7 +30,7 @@ class CorrelationIdParserTest : ParserTestSupport() {
     fun `parse correlation ID missing location throws RequiredObject`() {
         val root = readRoot("parser/correlations/asyncapi_parser_correlationid_invalid.yaml")
         val correlationIdNode = root.mandatory("components").mandatory("correlationIds").mandatory("MissingLocationId")
-        assertFailsWith<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseElement(correlationIdNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
@@ -35,7 +35,11 @@ class CorrelationIdParserTest : ParserTestSupport() {
             "correlationIds",
             "MissingLocationId",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'location'",
+            "asyncapi_parser_correlationid_invalid.yaml",
+            "asyncapi_parser_correlationid_invalid.root.components.correlationIds.MissingLocationId.location",
+        ) {
             parser.parseElement(correlationIdNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.correlations
 
 import dev.banking.asyncapi.generator.core.model.correlations.CorrelationIdInterface
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class CorrelationIdParserTest : AbstractParserTest() {
+class CorrelationIdParserTest : ParserTestSupport() {
 
     private val parser = CorrelationIdParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
@@ -13,11 +13,12 @@ class CorrelationIdParserTest : ParserTestSupport() {
 
     @Test
     fun `parse inline correlation ID`() {
-        val root = readRoot("parser/correlations/asyncapi_parser_correlationid_valid.yaml")
-        val correlationIdNode = root
-            .mandatory("components")
-            .mandatory("correlationIds")
-            .mandatory("MyCorrelationId")
+        val correlationIdNode = readNode(
+            "parser/correlations/asyncapi_parser_correlationid_valid.yaml",
+            "components",
+            "correlationIds",
+            "MyCorrelationId",
+        )
         val correlationIdInterface = parser.parseElement(correlationIdNode)
         assertTrue(correlationIdInterface is CorrelationIdInterface.CorrelationIdInline)
         assertThat(correlationIdInterface.correlationId)
@@ -28,8 +29,12 @@ class CorrelationIdParserTest : ParserTestSupport() {
 
     @Test
     fun `parse correlation ID missing location throws RequiredObject`() {
-        val root = readRoot("parser/correlations/asyncapi_parser_correlationid_invalid.yaml")
-        val correlationIdNode = root.mandatory("components").mandatory("correlationIds").mandatory("MissingLocationId")
+        val correlationIdNode = readNode(
+            "parser/correlations/asyncapi_parser_correlationid_invalid.yaml",
+            "components",
+            "correlationIds",
+            "MissingLocationId",
+        )
         assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseElement(correlationIdNode)
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
@@ -43,7 +43,11 @@ class ExternalDocsParserTest : ParserTestSupport() {
             "externalDocs",
             "MissingUrl",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'url'",
+            "asyncapi_parser_externaldocs_invalid.yaml",
+            "asyncapi_parser_externaldocs_invalid.root.components.externalDocs.MissingUrl.url",
+        ) {
             parser.parseElement(externalDocsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
@@ -5,7 +5,6 @@ import dev.banking.asyncapi.generator.core.model.externaldocs.ExternalDocInterfa
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ExternalDocsParserTest : ParserTestSupport() {
@@ -36,7 +35,7 @@ class ExternalDocsParserTest : ParserTestSupport() {
     fun `parse external docs missing url throws RequiredObject`() {
         val root = readRoot("parser/externaldocs/asyncapi_parser_externaldocs_invalid.yaml")
         val externalDocsNode = root.mandatory("components").mandatory("externalDocs").mandatory("MissingUrl")
-        assertFailsWith<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseElement(externalDocsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.externaldocs
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.externaldocs.ExternalDocInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class ExternalDocsParserTest : AbstractParserTest() {
+class ExternalDocsParserTest : ParserTestSupport() {
 
     private val parser = ExternalDocsParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
@@ -14,7 +14,7 @@ class ExternalDocsParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid external docs`() {
-        val root = readYaml("parser/externaldocs/asyncapi_parser_externaldocs_valid.yaml")
+        val root = readRoot("parser/externaldocs/asyncapi_parser_externaldocs_valid.yaml")
         val result = parser.parseMap(root.mandatory("components").mandatory("externalDocs"))
 
         assertTrue("MyExternalDocs" in result)
@@ -34,7 +34,7 @@ class ExternalDocsParserTest : AbstractParserTest() {
 
     @Test
     fun `parse external docs missing url throws RequiredObject`() {
-        val root = readYaml("parser/externaldocs/asyncapi_parser_externaldocs_invalid.yaml")
+        val root = readRoot("parser/externaldocs/asyncapi_parser_externaldocs_invalid.yaml")
         val externalDocsNode = root.mandatory("components").mandatory("externalDocs").mandatory("MissingUrl")
         assertFailsWith<AsyncApiParseException.Mandatory> {
             parser.parseElement(externalDocsNode)

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
@@ -13,13 +13,12 @@ class ExternalDocsParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid external docs`() {
-        val result = parser.parseMap(
-            readNode(
-                "parser/externaldocs/asyncapi_parser_externaldocs_valid.yaml",
-                "components",
-                "externalDocs",
-            )
+        val externalDocsNode = readNode(
+            "parser/externaldocs/asyncapi_parser_externaldocs_valid.yaml",
+            "components",
+            "externalDocs",
         )
+        val result = parser.parseMap(externalDocsNode)
 
         assertTrue("MyExternalDocs" in result)
         val myExternalDocs = (result["MyExternalDocs"] as ExternalDocInterface.ExternalDocInline).externalDoc

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
@@ -13,8 +13,13 @@ class ExternalDocsParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid external docs`() {
-        val root = readRoot("parser/externaldocs/asyncapi_parser_externaldocs_valid.yaml")
-        val result = parser.parseMap(root.mandatory("components").mandatory("externalDocs"))
+        val result = parser.parseMap(
+            readNode(
+                "parser/externaldocs/asyncapi_parser_externaldocs_valid.yaml",
+                "components",
+                "externalDocs",
+            )
+        )
 
         assertTrue("MyExternalDocs" in result)
         val myExternalDocs = (result["MyExternalDocs"] as ExternalDocInterface.ExternalDocInline).externalDoc
@@ -33,8 +38,12 @@ class ExternalDocsParserTest : ParserTestSupport() {
 
     @Test
     fun `parse external docs missing url throws RequiredObject`() {
-        val root = readRoot("parser/externaldocs/asyncapi_parser_externaldocs_invalid.yaml")
-        val externalDocsNode = root.mandatory("components").mandatory("externalDocs").mandatory("MissingUrl")
+        val externalDocsNode = readNode(
+            "parser/externaldocs/asyncapi_parser_externaldocs_invalid.yaml",
+            "components",
+            "externalDocs",
+            "MissingUrl",
+        )
         assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseElement(externalDocsNode)
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
@@ -24,7 +24,11 @@ class InfoParserTest : ParserTestSupport() {
     fun `parse Info missing mandatory fields throws RequiredObject`() {
         val root = readRoot("parser/info/asyncapi_parser_info_invalid.yaml")
         val infoNode = root.mandatory("info")
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'title'",
+            "asyncapi_parser_info_invalid.yaml",
+            "asyncapi_parser_info_invalid.root.info.title",
+        ) {
             parser.parseMap(infoNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
@@ -1,12 +1,12 @@
 package dev.banking.asyncapi.generator.core.parser.info
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
-class InfoParserTest : AbstractParserTest() {
+class InfoParserTest : ParserTestSupport() {
 
     private val parser = InfoParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
@@ -4,7 +4,6 @@ import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseExcepti
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 class InfoParserTest : ParserTestSupport() {
 
@@ -25,7 +24,7 @@ class InfoParserTest : ParserTestSupport() {
     fun `parse Info missing mandatory fields throws RequiredObject`() {
         val root = readRoot("parser/info/asyncapi_parser_info_invalid.yaml")
         val infoNode = root.mandatory("info")
-        assertFailsWith<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseMap(infoNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
@@ -12,7 +12,7 @@ class InfoParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid info object`() {
-        val root = readYaml("parser/info/asyncapi_parser_info_valid.yaml")
+        val root = readRoot("parser/info/asyncapi_parser_info_valid.yaml")
         val result = parser.parseMap(root.mandatory("info"))
         val expected = simpleInfo()
         assertThat(result)
@@ -23,7 +23,7 @@ class InfoParserTest : AbstractParserTest() {
 
     @Test
     fun `parse Info missing mandatory fields throws RequiredObject`() {
-        val root = readYaml("parser/info/asyncapi_parser_info_invalid.yaml")
+        val root = readRoot("parser/info/asyncapi_parser_info_invalid.yaml")
         val infoNode = root.mandatory("info")
         assertFailsWith<AsyncApiParseException.Mandatory> {
             parser.parseMap(infoNode)

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
@@ -11,8 +11,9 @@ class InfoParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid info object`() {
-        val root = readRoot("parser/info/asyncapi_parser_info_valid.yaml")
-        val result = parser.parseMap(root.mandatory("info"))
+        val result = parser.parseMap(
+            readNode("parser/info/asyncapi_parser_info_valid.yaml", "info")
+        )
         val expected = simpleInfo()
         assertThat(result)
             .usingRecursiveComparison()
@@ -22,8 +23,7 @@ class InfoParserTest : ParserTestSupport() {
 
     @Test
     fun `parse Info missing mandatory fields throws RequiredObject`() {
-        val root = readRoot("parser/info/asyncapi_parser_info_invalid.yaml")
-        val infoNode = root.mandatory("info")
+        val infoNode = readNode("parser/info/asyncapi_parser_info_invalid.yaml", "info")
         assertParseFailure<AsyncApiParseException.Mandatory>(
             "Missing mandatory 'title'",
             "asyncapi_parser_info_invalid.yaml",

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/info/InfoParserTest.kt
@@ -11,9 +11,8 @@ class InfoParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid info object`() {
-        val result = parser.parseMap(
-            readNode("parser/info/asyncapi_parser_info_valid.yaml", "info")
-        )
+        val infoNode = readNode("parser/info/asyncapi_parser_info_valid.yaml", "info")
+        val result = parser.parseMap(infoNode)
         val expected = simpleInfo()
         assertThat(result)
             .usingRecursiveComparison()

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.messages
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class MessageExampleParserTest : ParserTestSupport() {
+
+    private val parser = MessageExampleParser(asyncApiContext)
+
+    @Test
+    fun `parse message example with invalid structure throws UnexpectedValue`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_example_invalid.yaml",
+            "components",
+            "messageExampleCases",
+            "InvalidExampleStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_example_invalid.yaml",
+            "asyncapi_parser_message_example_invalid.root.components.messageExampleCases.InvalidExampleStructure[0]",
+        ) {
+            parser.parseList(examplesNode)
+        }
+    }
+
+    @Test
+    fun `parse message example with invalid headers throws UnexpectedValue`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_example_invalid.yaml",
+            "components",
+            "messageExampleCases",
+            "InvalidHeaders",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_example_invalid.yaml",
+            "asyncapi_parser_message_example_invalid.root.components.messageExampleCases.InvalidHeaders[0].headers",
+        ) {
+            parser.parseList(examplesNode)
+        }
+    }
+
+    @Test
+    fun `parse message example with boolean name throws UnexpectedValue`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_example_invalid.yaml",
+            "components",
+            "messageExampleCases",
+            "BooleanName",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_message_example_invalid.yaml",
+            "asyncapi_parser_message_example_invalid.root.components.messageExampleCases.BooleanName[0].name",
+        ) {
+            parser.parseList(examplesNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
@@ -3,10 +3,32 @@ package dev.banking.asyncapi.generator.core.parser.messages
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class MessageExampleParserTest : ParserTestSupport() {
 
     private val parser = MessageExampleParser(asyncApiContext)
+
+    @Test
+    fun `parse message examples`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_valid.yaml",
+            "components",
+            "messages",
+            "lightMeasured",
+            "examples",
+        )
+
+        val examples = parser.parseList(examplesNode)
+
+        assertEquals(2, examples.size)
+        val example = examples.first()
+        assertEquals("lightMeasurementExample", example.name)
+        assertEquals("Example of light measurement payload", example.summary)
+        assertNotNull(example.headers)
+        assertNotNull(example.payload)
+    }
 
     @Test
     fun `parse message example with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
@@ -13,8 +13,12 @@ class MessageParserTest : ParserTestSupport() {
 
     @Test
     fun parseMessages_validate_data_class() {
-        val root = readRoot("parser/messages/asyncapi_parser_message_valid.yaml")
-        val result = parser.parseMap(root.mandatory("components").mandatory("messages"))
+        val messagesNode = readNode(
+            "parser/messages/asyncapi_parser_message_valid.yaml",
+            "components",
+            "messages",
+        )
+        val result = parser.parseMap(messagesNode)
 
         assertTrue("lightMeasured" in result)
         assertTrue("turnOnOff" in result)
@@ -44,8 +48,12 @@ class MessageParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid message objects`() {
-        val root = readRoot("parser/messages/asyncapi_parser_message_edge_cases.yaml")
-        val messages = parser.parseMap(root.mandatory("components").mandatory("messages"))
+        val messagesNode = readNode(
+            "parser/messages/asyncapi_parser_message_edge_cases.yaml",
+            "components",
+            "messages",
+        )
+        val messages = parser.parseMap(messagesNode)
 
         val refPayload = (messages["RefPayload"] as MessageInterface.MessageInline).message
         assertThat(refPayload)
@@ -63,8 +71,12 @@ class MessageParserTest : ParserTestSupport() {
 
     @Test
     fun `parse message with inline trait`() {
-        val root = readRoot("parser/messages/asyncapi_parser_message_edge_cases.yaml")
-        val messages = parser.parseMap(root.mandatory("components").mandatory("messages"))
+        val messagesNode = readNode(
+            "parser/messages/asyncapi_parser_message_edge_cases.yaml",
+            "components",
+            "messages",
+        )
+        val messages = parser.parseMap(messagesNode)
 
         val emptyPayload = (messages["EmptyPayloadMessage"] as MessageInterface.MessageInline).message
         assertThat(emptyPayload)
@@ -81,8 +93,11 @@ class MessageParserTest : ParserTestSupport() {
 
     @Test
     fun `parse message with invalid field type throws InvalidValue`() {
-        val root = readRoot("parser/messages/asyncapi_parser_message_invalid_type.yaml")
-        val messagesNode = root.mandatory("components").mandatory("messages")
+        val messagesNode = readNode(
+            "parser/messages/asyncapi_parser_message_invalid_type.yaml",
+            "components",
+            "messages",
+        )
         assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(messagesNode)
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
@@ -14,7 +14,7 @@ class MessageParserTest : AbstractParserTest() {
 
     @Test
     fun parseMessages_validate_data_class() {
-        val root = readYaml("parser/messages/asyncapi_parser_message_valid.yaml")
+        val root = readRoot("parser/messages/asyncapi_parser_message_valid.yaml")
         val result = parser.parseMap(root.mandatory("components").mandatory("messages"))
 
         assertTrue("lightMeasured" in result)
@@ -45,7 +45,7 @@ class MessageParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid message objects`() {
-        val root = readYaml("parser/messages/asyncapi_parser_message_edge_cases.yaml")
+        val root = readRoot("parser/messages/asyncapi_parser_message_edge_cases.yaml")
         val messages = parser.parseMap(root.mandatory("components").mandatory("messages"))
 
         val refPayload = (messages["RefPayload"] as MessageInterface.MessageInline).message
@@ -64,7 +64,7 @@ class MessageParserTest : AbstractParserTest() {
 
     @Test
     fun `parse message with inline trait`() {
-        val root = readYaml("parser/messages/asyncapi_parser_message_edge_cases.yaml")
+        val root = readRoot("parser/messages/asyncapi_parser_message_edge_cases.yaml")
         val messages = parser.parseMap(root.mandatory("components").mandatory("messages"))
 
         val emptyPayload = (messages["EmptyPayloadMessage"] as MessageInterface.MessageInline).message
@@ -82,7 +82,7 @@ class MessageParserTest : AbstractParserTest() {
 
     @Test
     fun `parse message with invalid field type throws InvalidValue`() {
-        val root = readYaml("parser/messages/asyncapi_parser_message_invalid_type.yaml")
+        val root = readRoot("parser/messages/asyncapi_parser_message_invalid_type.yaml")
         val messagesNode = root.mandatory("components").mandatory("messages")
         assertFailsWith<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(messagesNode)

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.messages
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class MessageParserTest : AbstractParserTest() {
+class MessageParserTest : ParserTestSupport() {
 
     private val parser = MessageParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
@@ -5,7 +5,6 @@ import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class MessageParserTest : ParserTestSupport() {
@@ -84,7 +83,7 @@ class MessageParserTest : ParserTestSupport() {
     fun `parse message with invalid field type throws InvalidValue`() {
         val root = readRoot("parser/messages/asyncapi_parser_message_invalid_type.yaml")
         val messagesNode = root.mandatory("components").mandatory("messages")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(messagesNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
@@ -98,7 +98,13 @@ class MessageParserTest : ParserTestSupport() {
             "components",
             "messages",
         )
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "12345",
+            "quote the value",
+            "asyncapi_parser_message_invalid_type.yaml",
+            "asyncapi_parser_message_invalid_type.root.components.messages.InvalidNameMessage.name",
+        ) {
             parser.parseMap(messagesNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
@@ -1,12 +1,35 @@
 package dev.banking.asyncapi.generator.core.parser.messages
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.messages.MessageTraitInterface
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class MessageTraitParserTest : ParserTestSupport() {
 
     private val parser = MessageTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse message trait list`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_edge_cases.yaml",
+            "components",
+            "messages",
+            "InlineTraitMessage",
+            "traits",
+        )
+
+        val traits = parser.parseList(traitsNode)
+
+        assertEquals(1, traits.size)
+        assertTrue(traits.first() is MessageTraitInterface.InlineMessageTrait)
+        val trait = (traits.first() as MessageTraitInterface.InlineMessageTrait).trait
+        assertTrue(trait.headers is SchemaInterface.SchemaInline)
+        assertEquals("string", (trait.headers as SchemaInterface.SchemaInline).schema.type)
+    }
 
     @Test
     fun `parse message trait with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.messages
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class MessageTraitParserTest : ParserTestSupport() {
+
+    private val parser = MessageTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse message trait with invalid structure throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_trait_invalid.yaml",
+            "components",
+            "messageTraitCases",
+            "InvalidTraitStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_trait_invalid.yaml",
+            "asyncapi_parser_message_trait_invalid.root.components.messageTraitCases.InvalidTraitStructure.badTrait",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+
+    @Test
+    fun `parse message trait with boolean content type throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_trait_invalid.yaml",
+            "components",
+            "messageTraitCases",
+            "BooleanContentType",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_message_trait_invalid.yaml",
+            "asyncapi_parser_message_trait_invalid.root.components.messageTraitCases.BooleanContentType.badTrait.contentType",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+
+    @Test
+    fun `parse message trait with invalid example structure throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_trait_invalid.yaml",
+            "components",
+            "messageTraitCases",
+            "InvalidExampleStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_trait_invalid.yaml",
+            "asyncapi_parser_message_trait_invalid.root.components.messageTraitCases.InvalidExampleStructure.badTrait.examples[0]",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
@@ -14,7 +14,7 @@ class OperationParserTest : AbstractParserTest() {
 
     @Test
     fun parseOperations_validate_data_class() {
-        val root = readYaml("parser/operations/asyncapi_parser_operations_valid.yaml")
+        val root = readRoot("parser/operations/asyncapi_parser_operations_valid.yaml")
         val result = parser.parseMap(root.mandatory("operations"))
 
         assertTrue("receiveLightMeasurement" in result)
@@ -38,7 +38,7 @@ class OperationParserTest : AbstractParserTest() {
 
     @Test
     fun `parse operation missing action throws RequiredObject`() {
-        val root = readYaml("parser/operations/asyncapi_parser_operations_invalid.yaml")
+        val root = readRoot("parser/operations/asyncapi_parser_operations_invalid.yaml")
         assertFailsWith<AsyncApiParseException.Mandatory> {
             parser.parseMap(root.mandatory("operations"))
         }
@@ -46,7 +46,7 @@ class OperationParserTest : AbstractParserTest() {
 
     @Test
     fun `validation fails for operation with inline message definition`() {
-        val root = readYaml("parser/operations/asyncapi_validator_operations_inline_message_error.yaml")
+        val root = readRoot("parser/operations/asyncapi_validator_operations_inline_message_error.yaml")
         assertFailsWith<AsyncApiParseException.Mandatory> {
             parser.parseMap(root.mandatory("operations"))
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
@@ -38,7 +38,11 @@ class OperationParserTest : ParserTestSupport() {
     @Test
     fun `parse operation missing action throws RequiredObject`() {
         val operationsNode = readNode("parser/operations/asyncapi_parser_operations_invalid.yaml", "operations")
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'action'",
+            "asyncapi_parser_operations_invalid.yaml",
+            "asyncapi_parser_operations_invalid.root.operations.MissingAction.action",
+        ) {
             parser.parseMap(operationsNode)
         }
     }
@@ -49,7 +53,11 @@ class OperationParserTest : ParserTestSupport() {
             "parser/operations/asyncapi_validator_operations_inline_message_error.yaml",
             "operations",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_validator_operations_inline_message_error.yaml",
+            "asyncapi_validator_operations_inline_message_error.root.operations.testOperation.messages[0].\$ref",
+        ) {
             parser.parseMap(operationsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
@@ -6,7 +6,6 @@ import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
-import kotlin.test.assertFailsWith
 
 class OperationParserTest : ParserTestSupport() {
 
@@ -39,7 +38,7 @@ class OperationParserTest : ParserTestSupport() {
     @Test
     fun `parse operation missing action throws RequiredObject`() {
         val root = readRoot("parser/operations/asyncapi_parser_operations_invalid.yaml")
-        assertFailsWith<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseMap(root.mandatory("operations"))
         }
     }
@@ -47,7 +46,7 @@ class OperationParserTest : ParserTestSupport() {
     @Test
     fun `validation fails for operation with inline message definition`() {
         val root = readRoot("parser/operations/asyncapi_validator_operations_inline_message_error.yaml")
-        assertFailsWith<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseMap(root.mandatory("operations"))
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
@@ -13,8 +13,8 @@ class OperationParserTest : ParserTestSupport() {
 
     @Test
     fun parseOperations_validate_data_class() {
-        val root = readRoot("parser/operations/asyncapi_parser_operations_valid.yaml")
-        val result = parser.parseMap(root.mandatory("operations"))
+        val operationsNode = readNode("parser/operations/asyncapi_parser_operations_valid.yaml", "operations")
+        val result = parser.parseMap(operationsNode)
 
         assertTrue("receiveLightMeasurement" in result)
         assertTrue("turnOn" in result)
@@ -37,17 +37,20 @@ class OperationParserTest : ParserTestSupport() {
 
     @Test
     fun `parse operation missing action throws RequiredObject`() {
-        val root = readRoot("parser/operations/asyncapi_parser_operations_invalid.yaml")
+        val operationsNode = readNode("parser/operations/asyncapi_parser_operations_invalid.yaml", "operations")
         assertParseFailure<AsyncApiParseException.Mandatory> {
-            parser.parseMap(root.mandatory("operations"))
+            parser.parseMap(operationsNode)
         }
     }
 
     @Test
     fun `validation fails for operation with inline message definition`() {
-        val root = readRoot("parser/operations/asyncapi_validator_operations_inline_message_error.yaml")
+        val operationsNode = readNode(
+            "parser/operations/asyncapi_validator_operations_inline_message_error.yaml",
+            "operations",
+        )
         assertParseFailure<AsyncApiParseException.Mandatory> {
-            parser.parseMap(root.mandatory("operations"))
+            parser.parseMap(operationsNode)
         }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.operations
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.operations.OperationInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
 
-class OperationParserTest : AbstractParserTest() {
+class OperationParserTest : ParserTestSupport() {
 
     private val parser = OperationParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.operations
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class OperationReplyAddressParserTest : ParserTestSupport() {
+
+    private val parser = OperationReplyAddressParser(asyncApiContext)
+
+    @Test
+    fun `parse operation reply address missing location throws Mandatory`() {
+        val addressNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml",
+            "components",
+            "operationReplyAddressCases",
+            "MissingLocation",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'location'",
+            "asyncapi_parser_operation_reply_address_invalid.yaml",
+            "asyncapi_parser_operation_reply_address_invalid.root.components.operationReplyAddressCases.MissingLocation.location",
+        ) {
+            parser.parseElement(addressNode)
+        }
+    }
+
+    @Test
+    fun `parse operation reply address with boolean location throws UnexpectedValue`() {
+        val addressNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml",
+            "components",
+            "operationReplyAddressCases",
+            "BooleanLocation",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_operation_reply_address_invalid.yaml",
+            "asyncapi_parser_operation_reply_address_invalid.root.components.operationReplyAddressCases.BooleanLocation.location",
+        ) {
+            parser.parseElement(addressNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
@@ -1,12 +1,31 @@
 package dev.banking.asyncapi.generator.core.parser.operations
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class OperationReplyAddressParserTest : ParserTestSupport() {
 
     private val parser = OperationReplyAddressParser(asyncApiContext)
+
+    @Test
+    fun `parse operation reply address`() {
+        val addressNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "operations",
+            "receiveLightMeasurement",
+            "reply",
+            "address",
+        )
+
+        val address = parser.parseElement(addressNode)
+
+        assertTrue(address is OperationReplyAddressInterface.OperationReplyAddressInline)
+        assertEquals($$"$message.header#/replyTo", address.operationReplyAddress.location)
+    }
 
     @Test
     fun `parse operation reply address missing location throws Mandatory`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
@@ -14,11 +14,12 @@ class OperationReplyParserTest : ParserTestSupport() {
 
     @Test
     fun `parse operation reply with address`() {
-        val root = readRoot("parser/operations/asyncapi_parser_operations_valid.yaml")
-        val replyNode = root
-            .mandatory("operations")
-            .mandatory("receiveLightMeasurement")
-            .mandatory("reply")
+        val replyNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "operations",
+            "receiveLightMeasurement",
+            "reply",
+        )
 
         val replyInterface = parser.parseElement(replyNode)
         assertNotNull(replyInterface, "Reply should be present")

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
@@ -1,5 +1,6 @@
 package dev.banking.asyncapi.generator.core.parser.operations
 
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
@@ -34,5 +35,56 @@ class OperationReplyParserTest : ParserTestSupport() {
 
         assertNotNull(reply.channel, "Reply channel should be present")
         assertEquals("#/channels/lightingMeasured", reply.channel.ref)
+    }
+
+    @Test
+    fun `parse operation reply with missing channel ref throws Mandatory`() {
+        val replyNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_invalid.yaml",
+            "components",
+            "operationReplyCases",
+            "MissingChannelReference",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_operation_reply_invalid.yaml",
+            "asyncapi_parser_operation_reply_invalid.root.components.operationReplyCases.MissingChannelReference.channel.\$ref",
+        ) {
+            parser.parseElement(replyNode)
+        }
+    }
+
+    @Test
+    fun `parse operation reply with missing message ref throws Mandatory with indexed path`() {
+        val replyNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_invalid.yaml",
+            "components",
+            "operationReplyCases",
+            "MissingMessageReference",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_operation_reply_invalid.yaml",
+            "asyncapi_parser_operation_reply_invalid.root.components.operationReplyCases.MissingMessageReference.messages[0].\$ref",
+        ) {
+            parser.parseElement(replyNode)
+        }
+    }
+
+    @Test
+    fun `parse operation reply with missing address location throws Mandatory`() {
+        val replyNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_invalid.yaml",
+            "components",
+            "operationReplyCases",
+            "MissingAddressLocation",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'location'",
+            "asyncapi_parser_operation_reply_invalid.yaml",
+            "asyncapi_parser_operation_reply_invalid.root.components.operationReplyCases.MissingAddressLocation.address.location",
+        ) {
+            parser.parseElement(replyNode)
+        }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
@@ -35,6 +35,9 @@ class OperationReplyParserTest : ParserTestSupport() {
 
         assertNotNull(reply.channel, "Reply channel should be present")
         assertEquals("#/channels/lightingMeasured", reply.channel.ref)
+
+        assertNotNull(reply.messages, "Reply messages should be present")
+        assertEquals(listOf("#/components/messages/lightMeasured"), reply.messages.map { it.ref })
     }
 
     @Test

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
@@ -14,7 +14,7 @@ class OperationReplyParserTest : AbstractParserTest() {
 
     @Test
     fun `parse operation reply with address`() {
-        val root = readYaml("parser/operations/asyncapi_parser_operations_valid.yaml")
+        val root = readRoot("parser/operations/asyncapi_parser_operations_valid.yaml")
         val replyNode = root
             .mandatory("operations")
             .mandatory("receiveLightMeasurement")

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.operations
 
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class OperationReplyParserTest : AbstractParserTest() {
+class OperationReplyParserTest : ParserTestSupport() {
 
     private val parser = OperationReplyParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.operations
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class OperationTraitParserTest : ParserTestSupport() {
+
+    private val parser = OperationTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse operation trait with invalid structure throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/operations/asyncapi_parser_operation_trait_invalid.yaml",
+            "components",
+            "operationTraitCases",
+            "InvalidTraitStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_operation_trait_invalid.yaml",
+            "asyncapi_parser_operation_trait_invalid.root.components.operationTraitCases.InvalidTraitStructure.badTrait",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+
+    @Test
+    fun `parse operation trait with boolean title throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/operations/asyncapi_parser_operation_trait_invalid.yaml",
+            "components",
+            "operationTraitCases",
+            "BooleanTitle",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_operation_trait_invalid.yaml",
+            "asyncapi_parser_operation_trait_invalid.root.components.operationTraitCases.BooleanTitle.badTrait.title",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
@@ -1,12 +1,28 @@
 package dev.banking.asyncapi.generator.core.parser.operations
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.operations.OperationTraitInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
 
 class OperationTraitParserTest : ParserTestSupport() {
 
     private val parser = OperationTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse operation traits`() {
+        val traitsNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "components",
+            "operationTraits",
+        )
+
+        val traits = parser.parseMap(traitsNode)
+
+        assertTrue(traits["kafka"] is OperationTraitInterface.OperationTraitInline)
+        assertTrue(traits["logging"] is OperationTraitInterface.OperationTraitInline)
+    }
 
     @Test
     fun `parse operation trait with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
@@ -1,12 +1,35 @@
 package dev.banking.asyncapi.generator.core.parser.parameters
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.parameters.ParameterInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ParameterParserTest : ParserTestSupport() {
 
     private val parser = ParameterParser(asyncApiContext)
+
+    @Test
+    fun `parse parameters`() {
+        val parametersNode = readNode(
+            "parser/channels/asyncapi_parser_channel_valid.yaml",
+            "channels",
+            "lightStatus",
+            "parameters",
+        )
+
+        val parameters = parser.parseMap(parametersNode)
+
+        assertTrue(parameters["city"] is ParameterInterface.ParameterInline)
+        val city = (parameters["city"] as ParameterInterface.ParameterInline).parameter
+        assertEquals("The city where the streetlights are located.", city.description)
+        assertEquals($$"$message.payload#/city", city.location)
+        assertEquals(listOf("helsinki", "oslo", "stockholm"), city.enum)
+        assertEquals("helsinki", city.default)
+        assertEquals(listOf("helsinki", "oslo"), city.examples)
+    }
 
     @Test
     fun `parse parameter with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.parameters
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class ParameterParserTest : ParserTestSupport() {
+
+    private val parser = ParameterParser(asyncApiContext)
+
+    @Test
+    fun `parse parameter with invalid structure throws UnexpectedValue`() {
+        val parametersNode = readNode(
+            "parser/parameters/asyncapi_parser_parameter_invalid.yaml",
+            "components",
+            "parameterCases",
+            "InvalidParameterStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_parameter_invalid.yaml",
+            "asyncapi_parser_parameter_invalid.root.components.parameterCases.InvalidParameterStructure.badParameter",
+        ) {
+            parser.parseMap(parametersNode)
+        }
+    }
+
+    @Test
+    fun `parse parameter with boolean location throws UnexpectedValue`() {
+        val parametersNode = readNode(
+            "parser/parameters/asyncapi_parser_parameter_invalid.yaml",
+            "components",
+            "parameterCases",
+            "BooleanLocation",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_parameter_invalid.yaml",
+            "asyncapi_parser_parameter_invalid.root.components.parameterCases.BooleanLocation.badParameter.location",
+        ) {
+            parser.parseMap(parametersNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.references
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class ReferenceParserTest : ParserTestSupport() {
+
+    private val parser = ReferenceParser(asyncApiContext)
+
+    @Test
+    fun `parse reference missing ref throws Mandatory`() {
+        val referenceNode = readNode(
+            "parser/references/asyncapi_parser_reference_invalid.yaml",
+            "components",
+            "references",
+            "MissingReference",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_reference_invalid.yaml",
+            "asyncapi_parser_reference_invalid.root.components.references.MissingReference.\$ref",
+        ) {
+            parser.parseElement(referenceNode)
+        }
+    }
+
+    @Test
+    fun `parse reference with non-string ref throws UnexpectedValue`() {
+        val referenceNode = readNode(
+            "parser/references/asyncapi_parser_reference_invalid.yaml",
+            "components",
+            "references",
+            "NumericReference",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "12345",
+            "quote the value",
+            "asyncapi_parser_reference_invalid.yaml",
+            "asyncapi_parser_reference_invalid.root.components.references.NumericReference.\$ref",
+        ) {
+            parser.parseElement(referenceNode)
+        }
+    }
+
+    @Test
+    fun `parse reference list missing ref throws Mandatory with indexed path`() {
+        val referencesNode = readNode(
+            "parser/references/asyncapi_parser_reference_invalid.yaml",
+            "components",
+            "references",
+            "ReferenceList",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_reference_invalid.yaml",
+            "asyncapi_parser_reference_invalid.root.components.references.ReferenceList[0].\$ref",
+        ) {
+            parser.parseList(referencesNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
@@ -1,12 +1,44 @@
 package dev.banking.asyncapi.generator.core.parser.references
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.REFERENCE
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class ReferenceParserTest : ParserTestSupport() {
 
     private val parser = ReferenceParser(asyncApiContext)
+
+    @Test
+    fun `parse reference element`() {
+        val referenceNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "operations",
+            "receiveLightMeasurement",
+            "channel",
+        )
+
+        val reference = parser.parseElement(referenceNode)
+
+        assertEquals("#/channels/lightingMeasured", reference.ref)
+        assertEquals(REFERENCE, reference.referenceCategoryKey)
+    }
+
+    @Test
+    fun `parse reference list`() {
+        val referencesNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "operations",
+            "receiveLightMeasurement",
+            "messages",
+        )
+
+        val references = parser.parseList(referencesNode)
+
+        assertEquals(listOf("#/components/messages/lightMeasured"), references.map { it.ref })
+        assertEquals(listOf(REFERENCE), references.map { it.referenceCategoryKey })
+    }
 
     @Test
     fun `parse reference missing ref throws Mandatory`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.schemas
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class MultiFormatSchemaParserTest : ParserTestSupport() {
+
+    private val parser = SchemaParser(asyncApiContext)
+
+    @Test
+    fun `parse unsupported schema format throws UnsupportedSchemaFormat`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "UnsupportedJsonSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnsupportedSchemaFormat>(
+            "SchemaFormat: application/schema+json;version=draft-07 is not supported.",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnsupportedJsonSchemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+
+    @Test
+    fun `parse unknown schema format throws UnexpectedSchemaFormat`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "UnknownSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedSchemaFormat>(
+            "SchemaFormat: application/unknown is not valid.",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnknownSchemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+
+    @Test
+    fun `parse non-string schema format throws UnexpectedValue`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "NonStringSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.NonStringSchemaFormat.schemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
@@ -1,12 +1,31 @@
 package dev.banking.asyncapi.generator.core.parser.schemas
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class MultiFormatSchemaParserTest : ParserTestSupport() {
 
     private val parser = SchemaParser(asyncApiContext)
+
+    @Test
+    fun `parse supported asyncapi schema format`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_valid.yaml",
+            "components",
+            "schemas",
+            "AsyncApiYamlSchemaFormat",
+        )
+
+        val schema = parser.parseElement(schemaNode)
+
+        assertTrue(schema is SchemaInterface.SchemaInline)
+        assertEquals("Supported schema format", schema.schema.title)
+        assertEquals("object", schema.schema.type)
+    }
 
     @Test
     fun `parse unsupported schema format throws UnsupportedSchemaFormat`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -5,7 +5,7 @@ import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseExcepti
 import dev.banking.asyncapi.generator.core.model.references.Reference
 import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.SCHEMA
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
-class SchemaParserTest : AbstractParserTest() {
+class SchemaParserTest : ParserTestSupport() {
 
     private val parser = SchemaParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -18,8 +18,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_data_classes() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_valid.yaml")
-        val result = parser.parseMap(root.mandatory("components").mandatory("schemas"))
+        val schemasNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_valid.yaml",
+            "components",
+            "schemas",
+        )
+        val result = parser.parseMap(schemasNode)
 
         assertTrue("lightMeasuredPayload" in result)
         assertTrue("turnOnOffPayload" in result)
@@ -145,9 +149,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_SimpleObject_asyncapi_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("SimpleObject")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "SimpleObject",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = simpleObject()
         assertThat(nestedObjectSchema)
             .usingRecursiveComparison()
@@ -157,9 +165,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_NestedObject_asyncapi_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("NestedObject")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "NestedObject",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = nestedObject()
         assertThat(nestedObjectSchema)
             .usingRecursiveComparison()
@@ -169,9 +181,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_ArrayOfObjects_asyncapi_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("ArrayOfObjects")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "ArrayOfObjects",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = arrayOfObjects()
         assertThat(nestedObjectSchema)
             .usingRecursiveComparison()
@@ -181,9 +197,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_EnumAndConst_asyncapi_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("EnumAndConst")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "EnumAndConst",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = enumAndConst()
         assertThat(nestedObjectSchema)
             .usingRecursiveComparison()
@@ -193,8 +213,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_AllosAll_and_DenyAll_asyncapi_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val allowAllNode = root.mandatory("components").mandatory("schemas").mandatory("AllowAll")
+        val allowAllNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "AllowAll",
+        )
         val allowAll = parser.parseElement(allowAllNode) as SchemaInterface.BooleanSchema
         val expectedAllowAll = SchemaInterface.BooleanSchema(value = true)
         assertThat(allowAll)
@@ -202,7 +226,12 @@ class SchemaParserTest : ParserTestSupport() {
             .ignoringFieldsMatchingRegexes(".*sourceId", ".*inline")
             .isEqualTo(expectedAllowAll)
 
-        val denyAllNode = root.mandatory("components").mandatory("schemas").mandatory("DenyAll")
+        val denyAllNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "DenyAll",
+        )
         val denyAll = parser.parseElement(denyAllNode) as SchemaInterface.BooleanSchema
         val expectedDenyAll = SchemaInterface.BooleanSchema(value = false)
         assertThat(denyAll)
@@ -213,9 +242,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_Combined_asyncapi_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("Combined")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "Combined",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = combined()
         assertThat(nestedObjectSchema)
             .usingRecursiveComparison()
@@ -225,9 +258,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_Conditional_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("Conditional")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "Conditional",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = conditional()
         assertThat(expectedSchema)
             .usingRecursiveComparison()
@@ -237,9 +274,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_ObjectWithDeps_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("ObjectWithDeps")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "ObjectWithDeps",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = objectWithDeps()
         assertThat(expectedSchema)
             .usingRecursiveComparison()
@@ -249,9 +290,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_ArrayWithContains_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("ArrayWithContains")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "ArrayWithContains",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = arrayWithContains()
         assertThat(expectedSchema)
             .usingRecursiveComparison()
@@ -261,9 +306,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_FlexibleObject_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("FlexibleObject")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "FlexibleObject",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaInline).schema
         val expectedSchema = flexibleObject()
         assertThat(expectedSchema)
             .usingRecursiveComparison()
@@ -273,9 +322,13 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_UserRef_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("UserRef")
-        val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaReference).reference
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "UserRef",
+        )
+        val nestedObjectSchema = (parser.parseElement(schemaNode) as SchemaInterface.SchemaReference).reference
         val expectedSchema = Reference(ref = "#/components/schemas/SimpleObject", referenceCategoryKey = SCHEMA)
         assertThat(expectedSchema)
             .usingRecursiveComparison()
@@ -285,17 +338,25 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun parseSchemas_parser_InvalidCoercions_schema_parser_assertion_yaml() {
-        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
-        val node = root.mandatory("components").mandatory("schemas").mandatory("InvalidCoercions")
+        val schemaNode = readNode(
+            "schemas/asyncapi_schema_parser_assertion.yaml",
+            "components",
+            "schemas",
+            "InvalidCoercions",
+        )
         assertParseFailure<AsyncApiParseException.UnexpectedValue> {
-            parser.parseElement(node)
+            parser.parseElement(schemaNode)
         }
     }
 
     @Test
     fun `parse schema with property and schema dependencies`() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_dependencies.yaml")
-        val productNode = root.mandatory("components").mandatory("schemas").mandatory("Product")
+        val productNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_dependencies.yaml",
+            "components",
+            "schemas",
+            "Product",
+        )
         val productSchema = (parser.parseElement(productNode) as SchemaInterface.SchemaInline).schema
 
         assertNotNull(productSchema.dependencies, "Product schema should have dependencies")
@@ -320,8 +381,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun `parse recursive external references populates context correctly`() {
-        val root = readRoot("parser/schemas/references/main.yaml")
-        parser.parseMap(root.mandatory("components").mandatory("schemas"))
+        val schemasNode = readNode(
+            "parser/schemas/references/main.yaml",
+            "components",
+            "schemas",
+        )
+        parser.parseMap(schemasNode)
         val modelPaths = asyncApiContext.modelRepository.getModelsByPath()
         val expectedLevel2Path = "level2.root.components.schemas.Level2Object"
         assertTrue(
@@ -335,8 +400,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun `parse recursive composition (allOf inside oneOf)`() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
-        val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
+        val schemasNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml",
+            "components",
+            "schemas",
+        )
+        val schemaMap = parser.parseMap(schemasNode)
 
         val recursiveSchema = (schemaMap["RecursiveComposition"] as SchemaInterface.SchemaInline).schema
         assertNotNull(recursiveSchema.oneOf, "oneOf should not be null")
@@ -360,8 +429,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun `parse mixed references and inline schemas in anyOf`() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
-        val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
+        val schemasNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml",
+            "components",
+            "schemas",
+        )
+        val schemaMap = parser.parseMap(schemasNode)
 
         val mixedSchema = (schemaMap["MixedComposition"] as SchemaInterface.SchemaInline).schema
         assertNotNull(mixedSchema.anyOf, "anyOf should not be null")
@@ -377,8 +450,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun `parse empty allOf`() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
-        val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
+        val schemasNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml",
+            "components",
+            "schemas",
+        )
+        val schemaMap = parser.parseMap(schemasNode)
 
         val emptyAllOfSchema = (schemaMap["EmptyAllOf"] as SchemaInterface.SchemaInline).schema
         assertNotNull(
@@ -390,8 +467,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun `parse untyped oneOf`() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
-        val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
+        val schemasNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml",
+            "components",
+            "schemas",
+        )
+        val schemaMap = parser.parseMap(schemasNode)
 
         val untypedSchema = (schemaMap["UntypedOneOf"] as SchemaInterface.SchemaInline).schema
         assertEquals(null, untypedSchema.type, "Type should be null for untyped oneOf parent")
@@ -400,8 +481,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun `parse Schema with invalid enum type throws InvalidValue`() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
-        val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("InvalidEnumSchema")
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_negative_test.yaml",
+            "components",
+            "schemas",
+            "InvalidEnumSchema",
+        )
         assertParseFailure<AsyncApiParseException.UnexpectedValue>(
             "Unexpected value: expected List",
             "asyncapi_parser_schema_negative_test.yaml",
@@ -413,8 +498,12 @@ class SchemaParserTest : ParserTestSupport() {
 
     @Test
     fun `parse Schema with invalid dependencies type (list instead of map) throws InvalidValue`() {
-        val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
-        val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("MissingDependenciesObject")
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_negative_test.yaml",
+            "components",
+            "schemas",
+            "MissingDependenciesObject",
+        )
         assertParseFailure<AsyncApiParseException.UnexpectedValue>(
             "Unexpected value: expected Map",
             "asyncapi_parser_schema_negative_test.yaml",

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -10,7 +10,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 class SchemaParserTest : ParserTestSupport() {
@@ -288,7 +287,7 @@ class SchemaParserTest : ParserTestSupport() {
     fun parseSchemas_parser_InvalidCoercions_schema_parser_assertion_yaml() {
         val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("InvalidCoercions")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseElement(node)
         }
     }
@@ -403,7 +402,7 @@ class SchemaParserTest : ParserTestSupport() {
     fun `parse Schema with invalid enum type throws InvalidValue`() {
         val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
         val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("InvalidEnumSchema")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseElement(schemaNode)
         }
     }
@@ -412,7 +411,7 @@ class SchemaParserTest : ParserTestSupport() {
     fun `parse Schema with invalid dependencies type (list instead of map) throws InvalidValue`() {
         val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
         val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("MissingDependenciesObject")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseElement(schemaNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -19,7 +19,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_data_classes() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_valid.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_valid.yaml")
         val result = parser.parseMap(root.mandatory("components").mandatory("schemas"))
 
         assertTrue("lightMeasuredPayload" in result)
@@ -146,7 +146,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_SimpleObject_asyncapi_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("SimpleObject")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = simpleObject()
@@ -158,7 +158,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_NestedObject_asyncapi_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("NestedObject")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = nestedObject()
@@ -170,7 +170,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_ArrayOfObjects_asyncapi_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("ArrayOfObjects")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = arrayOfObjects()
@@ -182,7 +182,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_EnumAndConst_asyncapi_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("EnumAndConst")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = enumAndConst()
@@ -194,7 +194,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_AllosAll_and_DenyAll_asyncapi_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val allowAllNode = root.mandatory("components").mandatory("schemas").mandatory("AllowAll")
         val allowAll = parser.parseElement(allowAllNode) as SchemaInterface.BooleanSchema
         val expectedAllowAll = SchemaInterface.BooleanSchema(value = true)
@@ -214,7 +214,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_Combined_asyncapi_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("Combined")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = combined()
@@ -226,7 +226,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_Conditional_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("Conditional")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = conditional()
@@ -238,7 +238,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_ObjectWithDeps_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("ObjectWithDeps")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = objectWithDeps()
@@ -250,7 +250,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_ArrayWithContains_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("ArrayWithContains")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = arrayWithContains()
@@ -262,7 +262,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_FlexibleObject_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("FlexibleObject")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaInline).schema
         val expectedSchema = flexibleObject()
@@ -274,7 +274,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_UserRef_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("UserRef")
         val nestedObjectSchema = (parser.parseElement(node) as SchemaInterface.SchemaReference).reference
         val expectedSchema = Reference(ref = "#/components/schemas/SimpleObject", referenceCategoryKey = SCHEMA)
@@ -286,7 +286,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun parseSchemas_parser_InvalidCoercions_schema_parser_assertion_yaml() {
-        val root = readYaml("schemas/asyncapi_schema_parser_assertion.yaml")
+        val root = readRoot("schemas/asyncapi_schema_parser_assertion.yaml")
         val node = root.mandatory("components").mandatory("schemas").mandatory("InvalidCoercions")
         assertFailsWith<AsyncApiParseException.UnexpectedValue> {
             parser.parseElement(node)
@@ -295,7 +295,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse schema with property and schema dependencies`() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_dependencies.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_dependencies.yaml")
         val productNode = root.mandatory("components").mandatory("schemas").mandatory("Product")
         val productSchema = (parser.parseElement(productNode) as SchemaInterface.SchemaInline).schema
 
@@ -321,7 +321,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse recursive external references populates context correctly`() {
-        val root = readYaml("parser/schemas/references/main.yaml")
+        val root = readRoot("parser/schemas/references/main.yaml")
         parser.parseMap(root.mandatory("components").mandatory("schemas"))
         val modelPaths = asyncApiContext.modelRepository.getModelsByPath()
         val expectedLevel2Path = "level2.root.components.schemas.Level2Object"
@@ -336,7 +336,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse recursive composition (allOf inside oneOf)`() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
         val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
 
         val recursiveSchema = (schemaMap["RecursiveComposition"] as SchemaInterface.SchemaInline).schema
@@ -361,7 +361,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse mixed references and inline schemas in anyOf`() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
         val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
 
         val mixedSchema = (schemaMap["MixedComposition"] as SchemaInterface.SchemaInline).schema
@@ -378,7 +378,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse empty allOf`() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
         val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
 
         val emptyAllOfSchema = (schemaMap["EmptyAllOf"] as SchemaInterface.SchemaInline).schema
@@ -391,7 +391,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse untyped oneOf`() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_composition_edge_cases.yaml")
         val schemaMap = parser.parseMap(root.mandatory("components").mandatory("schemas"))
 
         val untypedSchema = (schemaMap["UntypedOneOf"] as SchemaInterface.SchemaInline).schema
@@ -401,7 +401,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse Schema with invalid enum type throws InvalidValue`() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
         val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("InvalidEnumSchema")
         assertFailsWith<AsyncApiParseException.UnexpectedValue> {
             parser.parseElement(schemaNode)
@@ -410,7 +410,7 @@ class SchemaParserTest : AbstractParserTest() {
 
     @Test
     fun `parse Schema with invalid dependencies type (list instead of map) throws InvalidValue`() {
-        val root = readYaml("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
+        val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
         val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("MissingDependenciesObject")
         assertFailsWith<AsyncApiParseException.UnexpectedValue> {
             parser.parseElement(schemaNode)

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -402,7 +402,11 @@ class SchemaParserTest : ParserTestSupport() {
     fun `parse Schema with invalid enum type throws InvalidValue`() {
         val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
         val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("InvalidEnumSchema")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected List",
+            "asyncapi_parser_schema_negative_test.yaml",
+            "asyncapi_parser_schema_negative_test.root.components.schemas.InvalidEnumSchema.enum",
+        ) {
             parser.parseElement(schemaNode)
         }
     }
@@ -411,7 +415,11 @@ class SchemaParserTest : ParserTestSupport() {
     fun `parse Schema with invalid dependencies type (list instead of map) throws InvalidValue`() {
         val root = readRoot("parser/schemas/asyncapi_parser_schema_negative_test.yaml")
         val schemaNode = root.mandatory("components").mandatory("schemas").mandatory("MissingDependenciesObject")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_schema_negative_test.yaml",
+            "asyncapi_parser_schema_negative_test.root.components.schemas.MissingDependenciesObject.dependencies",
+        ) {
             parser.parseElement(schemaNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -344,7 +344,13 @@ class SchemaParserTest : ParserTestSupport() {
             "schemas",
             "InvalidCoercions",
         )
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Number",
+            "found String \"10\"",
+            "quoted numbers are strings in YAML",
+            "asyncapi_schema_parser_assertion.yaml",
+            "asyncapi_schema_parser_assertion.root.components.schemas.InvalidCoercions.maxLength",
+        ) {
             parser.parseElement(schemaNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
@@ -14,7 +14,7 @@ class SecuritySchemeParserTest : AbstractParserTest() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_saslScram_certs_basicAuth() {
-        val root = readYaml("parser/security/asyncapi_parser_security_valid.yaml")
+        val root = readRoot("parser/security/asyncapi_parser_security_valid.yaml")
         val result = parser.parseMap(root.mandatory("components").mandatory("securitySchemes"))
 
         assertTrue("saslScram" in result)
@@ -45,7 +45,7 @@ class SecuritySchemeParserTest : AbstractParserTest() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_bearerAuth_apiKeyHeader_apiKeyQuery() {
-        val root = readYaml("parser/security/asyncapi_parser_security_valid.yaml")
+        val root = readRoot("parser/security/asyncapi_parser_security_valid.yaml")
         val result = parser.parseMap(root.mandatory("components").mandatory("securitySchemes"))
 
         assertTrue("bearerAuth" in result)
@@ -76,7 +76,7 @@ class SecuritySchemeParserTest : AbstractParserTest() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_openIdConnectExample_oauthExample() {
-        val root = readYaml("parser/security/asyncapi_parser_security_valid.yaml")
+        val root = readRoot("parser/security/asyncapi_parser_security_valid.yaml")
         val result = parser.parseMap(root.mandatory("components").mandatory("securitySchemes"))
 
         assertTrue("openIdConnectExample" in result)
@@ -100,7 +100,7 @@ class SecuritySchemeParserTest : AbstractParserTest() {
 
     @Test
     fun `parse security scheme missing type throws RequiredObject`() {
-        val root = readYaml("parser/security/asyncapi_parser_security_invalid.yaml")
+        val root = readRoot("parser/security/asyncapi_parser_security_invalid.yaml")
         val schemeNode = root
             .mandatory("components")
             .mandatory("securitySchemes")
@@ -112,7 +112,7 @@ class SecuritySchemeParserTest : AbstractParserTest() {
 
     @Test
     fun `parse security scheme with invalid flows structure throws UnexpectedValue`() {
-        val root = readYaml("parser/security/asyncapi_parser_security_invalid.yaml")
+        val root = readRoot("parser/security/asyncapi_parser_security_invalid.yaml")
         val schemeNode = root
             .mandatory("components")
             .mandatory("securitySchemes")

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.security
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.security.SecuritySchemeInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
-class SecuritySchemeParserTest : AbstractParserTest() {
+class SecuritySchemeParserTest : ParserTestSupport() {
 
     private val parser = SecuritySchemeParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
@@ -13,8 +13,13 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_saslScram_certs_basicAuth() {
-        val root = readRoot("parser/security/asyncapi_parser_security_valid.yaml")
-        val result = parser.parseMap(root.mandatory("components").mandatory("securitySchemes"))
+        val result = parser.parseMap(
+            readNode(
+                "parser/security/asyncapi_parser_security_valid.yaml",
+                "components",
+                "securitySchemes",
+            )
+        )
 
         assertTrue("saslScram" in result)
         assertTrue("certs" in result)
@@ -44,8 +49,13 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_bearerAuth_apiKeyHeader_apiKeyQuery() {
-        val root = readRoot("parser/security/asyncapi_parser_security_valid.yaml")
-        val result = parser.parseMap(root.mandatory("components").mandatory("securitySchemes"))
+        val result = parser.parseMap(
+            readNode(
+                "parser/security/asyncapi_parser_security_valid.yaml",
+                "components",
+                "securitySchemes",
+            )
+        )
 
         assertTrue("bearerAuth" in result)
         assertTrue("apiKeyHeader" in result)
@@ -75,8 +85,13 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_openIdConnectExample_oauthExample() {
-        val root = readRoot("parser/security/asyncapi_parser_security_valid.yaml")
-        val result = parser.parseMap(root.mandatory("components").mandatory("securitySchemes"))
+        val result = parser.parseMap(
+            readNode(
+                "parser/security/asyncapi_parser_security_valid.yaml",
+                "components",
+                "securitySchemes",
+            )
+        )
 
         assertTrue("openIdConnectExample" in result)
         assertTrue("oauthExample" in result)
@@ -99,11 +114,12 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun `parse security scheme missing type throws RequiredObject`() {
-        val root = readRoot("parser/security/asyncapi_parser_security_invalid.yaml")
-        val schemeNode = root
-            .mandatory("components")
-            .mandatory("securitySchemes")
-            .mandatory("MissingType")
+        val schemeNode = readNode(
+            "parser/security/asyncapi_parser_security_invalid.yaml",
+            "components",
+            "securitySchemes",
+            "MissingType",
+        )
         assertParseFailure<AsyncApiParseException.Mandatory>(
             "Missing mandatory 'type'",
             "asyncapi_parser_security_invalid.yaml",
@@ -115,11 +131,12 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun `parse security scheme with invalid flows structure throws UnexpectedValue`() {
-        val root = readRoot("parser/security/asyncapi_parser_security_invalid.yaml")
-        val schemeNode = root
-            .mandatory("components")
-            .mandatory("securitySchemes")
-            .mandatory("InvalidFlowsStructure")
+        val schemeNode = readNode(
+            "parser/security/asyncapi_parser_security_invalid.yaml",
+            "components",
+            "securitySchemes",
+            "InvalidFlowsStructure",
+        )
         assertParseFailure<AsyncApiParseException.UnexpectedValue>(
             "Unexpected value: expected Map",
             "asyncapi_parser_security_invalid.yaml",

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
@@ -104,7 +104,11 @@ class SecuritySchemeParserTest : ParserTestSupport() {
             .mandatory("components")
             .mandatory("securitySchemes")
             .mandatory("MissingType")
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'type'",
+            "asyncapi_parser_security_invalid.yaml",
+            "asyncapi_parser_security_invalid.root.components.securitySchemes.MissingType.type",
+        ) {
             parser.parseElement(schemeNode)
         }
     }
@@ -116,7 +120,11 @@ class SecuritySchemeParserTest : ParserTestSupport() {
             .mandatory("components")
             .mandatory("securitySchemes")
             .mandatory("InvalidFlowsStructure")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_security_invalid.yaml",
+            "asyncapi_parser_security_invalid.root.components.securitySchemes.InvalidFlowsStructure.flows",
+        ) {
             parser.parseElement(schemeNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
@@ -6,7 +6,6 @@ import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 class SecuritySchemeParserTest : ParserTestSupport() {
 
@@ -105,7 +104,7 @@ class SecuritySchemeParserTest : ParserTestSupport() {
             .mandatory("components")
             .mandatory("securitySchemes")
             .mandatory("MissingType")
-        assertFailsWith<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseElement(schemeNode)
         }
     }
@@ -117,7 +116,7 @@ class SecuritySchemeParserTest : ParserTestSupport() {
             .mandatory("components")
             .mandatory("securitySchemes")
             .mandatory("InvalidFlowsStructure")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseElement(schemeNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/security/SecuritySchemeParserTest.kt
@@ -13,13 +13,12 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_saslScram_certs_basicAuth() {
-        val result = parser.parseMap(
-            readNode(
-                "parser/security/asyncapi_parser_security_valid.yaml",
-                "components",
-                "securitySchemes",
-            )
+        val securitySchemesNode = readNode(
+            "parser/security/asyncapi_parser_security_valid.yaml",
+            "components",
+            "securitySchemes",
         )
+        val result = parser.parseMap(securitySchemesNode)
 
         assertTrue("saslScram" in result)
         assertTrue("certs" in result)
@@ -49,13 +48,12 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_bearerAuth_apiKeyHeader_apiKeyQuery() {
-        val result = parser.parseMap(
-            readNode(
-                "parser/security/asyncapi_parser_security_valid.yaml",
-                "components",
-                "securitySchemes",
-            )
+        val securitySchemesNode = readNode(
+            "parser/security/asyncapi_parser_security_valid.yaml",
+            "components",
+            "securitySchemes",
         )
+        val result = parser.parseMap(securitySchemesNode)
 
         assertTrue("bearerAuth" in result)
         assertTrue("apiKeyHeader" in result)
@@ -85,13 +83,12 @@ class SecuritySchemeParserTest : ParserTestSupport() {
 
     @Test
     fun parseSecuritySchemes_validate_data_classes_openIdConnectExample_oauthExample() {
-        val result = parser.parseMap(
-            readNode(
-                "parser/security/asyncapi_parser_security_valid.yaml",
-                "components",
-                "securitySchemes",
-            )
+        val securitySchemesNode = readNode(
+            "parser/security/asyncapi_parser_security_valid.yaml",
+            "components",
+            "securitySchemes",
         )
+        val result = parser.parseMap(securitySchemesNode)
 
         assertTrue("openIdConnectExample" in result)
         assertTrue("oauthExample" in result)

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.servers
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.servers.ServerInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
-class ServerParserTest : AbstractParserTest() {
+class ServerParserTest : ParserTestSupport() {
 
     private val parser = ServerParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
@@ -45,7 +45,11 @@ class ServerParserTest : ParserTestSupport() {
     @Test
     fun `parse server with invalid variables structure throws UnexpectedValue`() {
         val serversNode = readNode("parser/servers/asyncapi_parser_server_invalid.yaml", "servers")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map/List",
+            "asyncapi_parser_server_invalid.yaml",
+            "asyncapi_parser_server_invalid.root.servers.InvalidVariables.variables",
+        ) {
             parser.parseMap(serversNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
@@ -6,7 +6,6 @@ import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 class ServerParserTest : ParserTestSupport() {
 
@@ -46,7 +45,7 @@ class ServerParserTest : ParserTestSupport() {
     @Test
     fun `parse server with invalid variables structure throws UnexpectedValue`() {
         val root = readRoot("parser/servers/asyncapi_parser_server_invalid.yaml")
-        assertFailsWith<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(root.mandatory("servers"))
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
@@ -13,8 +13,8 @@ class ServerParserTest : ParserTestSupport() {
 
     @Test
     fun parseServers_validate_data_classes() {
-        val root = readRoot("parser/servers/asyncapi_parser_servers_valid.yaml")
-        val result = parser.parseMap(root.mandatory("servers"))
+        val serversNode = readNode("parser/servers/asyncapi_parser_servers_valid.yaml", "servers")
+        val result = parser.parseMap(serversNode)
 
         assertTrue("scram-connections" in result)
         assertTrue("mtls-connections" in result)
@@ -44,9 +44,9 @@ class ServerParserTest : ParserTestSupport() {
 
     @Test
     fun `parse server with invalid variables structure throws UnexpectedValue`() {
-        val root = readRoot("parser/servers/asyncapi_parser_server_invalid.yaml")
+        val serversNode = readNode("parser/servers/asyncapi_parser_server_invalid.yaml", "servers")
         assertParseFailure<AsyncApiParseException.UnexpectedValue> {
-            parser.parseMap(root.mandatory("servers"))
+            parser.parseMap(serversNode)
         }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
@@ -14,7 +14,7 @@ class ServerParserTest : AbstractParserTest() {
 
     @Test
     fun parseServers_validate_data_classes() {
-        val root = readYaml("parser/servers/asyncapi_parser_servers_valid.yaml")
+        val root = readRoot("parser/servers/asyncapi_parser_servers_valid.yaml")
         val result = parser.parseMap(root.mandatory("servers"))
 
         assertTrue("scram-connections" in result)
@@ -45,7 +45,7 @@ class ServerParserTest : AbstractParserTest() {
 
     @Test
     fun `parse server with invalid variables structure throws UnexpectedValue`() {
-        val root = readYaml("parser/servers/asyncapi_parser_server_invalid.yaml")
+        val root = readRoot("parser/servers/asyncapi_parser_server_invalid.yaml")
         assertFailsWith<AsyncApiParseException.UnexpectedValue> {
             parser.parseMap(root.mandatory("servers"))
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.servers
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class ServerVariableParserTest : ParserTestSupport() {
+
+    private val parser = ServerVariableParser(asyncApiContext)
+
+    @Test
+    fun `parse server variable with invalid structure throws UnexpectedValue`() {
+        val variablesNode = readNode(
+            "parser/servers/asyncapi_parser_server_variable_invalid.yaml",
+            "components",
+            "serverVariableCases",
+            "InvalidVariableStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_server_variable_invalid.yaml",
+            "asyncapi_parser_server_variable_invalid.root.components.serverVariableCases.InvalidVariableStructure.badVariable",
+        ) {
+            parser.parseMap(variablesNode)
+        }
+    }
+
+    @Test
+    fun `parse server variable with boolean default throws UnexpectedValue`() {
+        val variablesNode = readNode(
+            "parser/servers/asyncapi_parser_server_variable_invalid.yaml",
+            "components",
+            "serverVariableCases",
+            "BooleanDefault",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean false",
+            "quote the value",
+            "asyncapi_parser_server_variable_invalid.yaml",
+            "asyncapi_parser_server_variable_invalid.root.components.serverVariableCases.BooleanDefault.badVariable.default",
+        ) {
+            parser.parseMap(variablesNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
@@ -1,12 +1,33 @@
 package dev.banking.asyncapi.generator.core.parser.servers
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.servers.ServerVariableInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ServerVariableParserTest : ParserTestSupport() {
 
     private val parser = ServerVariableParser(asyncApiContext)
+
+    @Test
+    fun `parse server variables`() {
+        val variablesNode = readNode(
+            "parser/servers/asyncapi_parser_servers_valid.yaml",
+            "servers",
+            "scram-connections",
+            "variables",
+        )
+
+        val variables = parser.parseMap(variablesNode)
+
+        assertTrue(variables["port"] is ServerVariableInterface.ServerVariableInline)
+        val port = (variables["port"] as ServerVariableInterface.ServerVariableInline).serverVariable
+        assertEquals(listOf("18092", "28092"), port.enum)
+        assertEquals("18092", port.default)
+        assertEquals("The port used for Kafka connections", port.description)
+    }
 
     @Test
     fun `parse server variable with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
@@ -5,7 +5,6 @@ import dev.banking.asyncapi.generator.core.model.tags.TagInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class TagParserTest : ParserTestSupport() {
@@ -35,7 +34,7 @@ class TagParserTest : ParserTestSupport() {
     @Test
     fun `parse tag missing name throws RequiredField`() { // or RequiredObject depending on parser logic
         val root = readRoot("parser/tags/asyncapi_parser_tag_invalid.yaml")
-        assertFailsWith<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory> {
             parser.parseMap(root.mandatory("components").mandatory("tags"))
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
@@ -2,13 +2,13 @@ package dev.banking.asyncapi.generator.core.parser.tags
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.tags.TagInterface
-import dev.banking.asyncapi.generator.core.parser.AbstractParserTest
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class TagParserTest : AbstractParserTest() {
+class TagParserTest : ParserTestSupport() {
 
     private val parser = TagParser(asyncApiContext)
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
@@ -42,7 +42,11 @@ class TagParserTest : ParserTestSupport() {
             "components",
             "tags",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'name'",
+            "asyncapi_parser_tag_invalid.yaml",
+            "asyncapi_parser_tag_invalid.root.components.tags.MissingName.name",
+        ) {
             parser.parseMap(tagsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
@@ -14,7 +14,7 @@ class TagParserTest : AbstractParserTest() {
 
     @Test
     fun `parse valid tags`() {
-        val root = readYaml("parser/tags/asyncapi_parser_tag_valid.yaml")
+        val root = readRoot("parser/tags/asyncapi_parser_tag_valid.yaml")
         val result = parser.parseMap(root.mandatory("components").mandatory("tags"))
 
         assertTrue("inlineTag" in result)
@@ -34,7 +34,7 @@ class TagParserTest : AbstractParserTest() {
 
     @Test
     fun `parse tag missing name throws RequiredField`() { // or RequiredObject depending on parser logic
-        val root = readYaml("parser/tags/asyncapi_parser_tag_invalid.yaml")
+        val root = readRoot("parser/tags/asyncapi_parser_tag_invalid.yaml")
         assertFailsWith<AsyncApiParseException.Mandatory> {
             parser.parseMap(root.mandatory("components").mandatory("tags"))
         }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
@@ -13,8 +13,13 @@ class TagParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid tags`() {
-        val root = readRoot("parser/tags/asyncapi_parser_tag_valid.yaml")
-        val result = parser.parseMap(root.mandatory("components").mandatory("tags"))
+        val result = parser.parseMap(
+            readNode(
+                "parser/tags/asyncapi_parser_tag_valid.yaml",
+                "components",
+                "tags",
+            )
+        )
 
         assertTrue("inlineTag" in result)
         val inlineTag = (result["inlineTag"] as TagInterface.TagInline).tag
@@ -33,9 +38,14 @@ class TagParserTest : ParserTestSupport() {
 
     @Test
     fun `parse tag missing name throws RequiredField`() { // or RequiredObject depending on parser logic
-        val root = readRoot("parser/tags/asyncapi_parser_tag_invalid.yaml")
         assertParseFailure<AsyncApiParseException.Mandatory> {
-            parser.parseMap(root.mandatory("components").mandatory("tags"))
+            parser.parseMap(
+                readNode(
+                    "parser/tags/asyncapi_parser_tag_invalid.yaml",
+                    "components",
+                    "tags",
+                )
+            )
         }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
@@ -13,13 +13,12 @@ class TagParserTest : ParserTestSupport() {
 
     @Test
     fun `parse valid tags`() {
-        val result = parser.parseMap(
-            readNode(
-                "parser/tags/asyncapi_parser_tag_valid.yaml",
-                "components",
-                "tags",
-            )
+        val tagsNode = readNode(
+            "parser/tags/asyncapi_parser_tag_valid.yaml",
+            "components",
+            "tags",
         )
+        val result = parser.parseMap(tagsNode)
 
         assertTrue("inlineTag" in result)
         val inlineTag = (result["inlineTag"] as TagInterface.TagInline).tag
@@ -38,14 +37,13 @@ class TagParserTest : ParserTestSupport() {
 
     @Test
     fun `parse tag missing name throws RequiredField`() { // or RequiredObject depending on parser logic
+        val tagsNode = readNode(
+            "parser/tags/asyncapi_parser_tag_invalid.yaml",
+            "components",
+            "tags",
+        )
         assertParseFailure<AsyncApiParseException.Mandatory> {
-            parser.parseMap(
-                readNode(
-                    "parser/tags/asyncapi_parser_tag_invalid.yaml",
-                    "components",
-                    "tags",
-                )
-            )
+            parser.parseMap(tagsNode)
         }
     }
 }

--- a/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_example_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_example_invalid.yaml
@@ -1,0 +1,12 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Message Example Parser Test
+  version: 1.0.0
+components:
+  messageExampleCases:
+    InvalidExampleStructure:
+      - "not-a-map"
+    InvalidHeaders:
+      - headers: "not-a-map"
+    BooleanName:
+      - name: true

--- a/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_trait_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_trait_invalid.yaml
@@ -1,0 +1,15 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Message Trait Parser Test
+  version: 1.0.0
+components:
+  messageTraitCases:
+    InvalidTraitStructure:
+      badTrait: "not-a-map"
+    BooleanContentType:
+      badTrait:
+        contentType: true
+    InvalidExampleStructure:
+      badTrait:
+        examples:
+          - "not-a-map"

--- a/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml
@@ -1,0 +1,10 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Operation Reply Address Parser Test
+  version: 1.0.0
+components:
+  operationReplyAddressCases:
+    MissingLocation:
+      description: "Missing reply address location"
+    BooleanLocation:
+      location: true

--- a/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_invalid.yaml
@@ -1,0 +1,17 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Operation Reply Parser Test
+  version: 1.0.0
+components:
+  operationReplyCases:
+    MissingChannelReference:
+      channel:
+        payload:
+          type: string
+    MissingMessageReference:
+      messages:
+        - payload:
+            type: string
+    MissingAddressLocation:
+      address:
+        description: "Missing reply address location"

--- a/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_trait_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_trait_invalid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Operation Trait Parser Test
+  version: 1.0.0
+components:
+  operationTraitCases:
+    InvalidTraitStructure:
+      badTrait: "not-a-map"
+    BooleanTitle:
+      badTrait:
+        title: true

--- a/asyncapi-generator-core/src/test/resources/parser/parameters/asyncapi_parser_parameter_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/parameters/asyncapi_parser_parameter_invalid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Parameter Parser Test
+  version: 1.0.0
+components:
+  parameterCases:
+    InvalidParameterStructure:
+      badParameter: "not-a-map"
+    BooleanLocation:
+      badParameter:
+        location: true

--- a/asyncapi-generator-core/src/test/resources/parser/references/asyncapi_parser_reference_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/references/asyncapi_parser_reference_invalid.yaml
@@ -1,0 +1,13 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Reference Parser Test
+  version: 1.0.0
+components:
+  references:
+    MissingReference:
+      summary: "Reference object missing its reference value"
+    NumericReference:
+      $ref: 12345
+    ReferenceList:
+      - payload:
+          type: string

--- a/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
@@ -1,0 +1,18 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Schema Format Parser Test
+  version: 1.0.0
+components:
+  schemas:
+    UnsupportedJsonSchemaFormat:
+      schemaFormat: application/schema+json;version=draft-07
+      schema:
+        type: object
+    UnknownSchemaFormat:
+      schemaFormat: application/unknown
+      schema:
+        type: object
+    NonStringSchemaFormat:
+      schemaFormat: true
+      schema:
+        type: object

--- a/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_valid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_valid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Valid Schema Format Parser Test
+  version: 1.0.0
+components:
+  schemas:
+    AsyncApiYamlSchemaFormat:
+      schemaFormat: application/vnd.aai.asyncapi+yaml;version=3.0.0
+      schema:
+        title: Supported schema format
+        type: object

--- a/asyncapi-generator-core/src/test/resources/parser/servers/asyncapi_parser_server_variable_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/servers/asyncapi_parser_server_variable_invalid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Server Variable Parser Test
+  version: 1.0.0
+components:
+  serverVariableCases:
+    InvalidVariableStructure:
+      badVariable: "not-a-map"
+    BooleanDefault:
+      badVariable:
+        default: false


### PR DESCRIPTION
Adresses,
- #91 
- #94 

The parser stage already worked, but the contract around it was not very explicit in the tests. Many tests mixed fixture loading, node traversal, parser invocation, and assertions in the same setup code. That made the parser input less obvious and made it harder to expand tests consistently across parser classes.

For the proposed solution, parser tests now use a shared `ParserTestSupport` base. Fixture-backed parser input is selected through `readNode`, and tests assign that selected input to a named variable before passing it to the parser. This keeps the test structure clear: first select the parser node, then parse it, then assert the result.

Parser failure assertions were also centralized through `assertParseFailure`. This keeps negative tests focused on parser behavior while still checking the exception type, message content, source file, and source path where needed.

KDoc was added to parser classes to document the expected parser-stage behavior and point readers toward the relevant test coverage classes. This creates a clearer link between implementation and tests without overstating the tests as a formal guarantee.

The parser tests were updated across the module to follow the same setup pattern. This includes AsyncAPI, schemas, messages, channels, servers, operations, bindings, security schemes, tags, external docs, correlation IDs, components, and info parsing.

A YAML/JSON format-independent parser test is also in place to verify that equivalent documents can be parsed into the same model through the shared fixture setup.