### PR TITLE
Feature/parser error contracts

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParser.kt
@@ -8,6 +8,7 @@ import dev.banking.asyncapi.generator.core.context.AsyncApiContext
  * Parses AsyncAPI message example objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `MessageExampleParserTest`
  * - `MessageParserTest`
  */
 class MessageExampleParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParser.kt
@@ -16,6 +16,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI message trait objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `MessageTraitParserTest`
  * - `MessageParserTest`
  */
 class MessageTraitParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParser.kt
@@ -11,6 +11,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI operation reply address objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `OperationReplyAddressParserTest`
  * - `OperationReplyParserTest`
  */
 class OperationReplyAddressParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParser.kt
@@ -15,6 +15,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI operation trait objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `OperationTraitParserTest`
  * - `OperationParserTest`
  */
 class OperationTraitParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParser.kt
@@ -11,6 +11,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI parameter objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `ParameterParserTest`
  * - `ChannelParserTest`
  */
 class ParameterParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParser.kt
@@ -9,6 +9,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses generic AsyncAPI reference objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `ReferenceParserTest`
  * - `ChannelParserTest`
  * - `OperationParserTest`
  * - `OperationReplyParserTest`

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
@@ -20,13 +20,14 @@ import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseExcepti
  * - For other known formats (e.g., JSON Schema Draft-07, Avro, OpenAPI, RAML, Protobuf),
  *   it *recognizes* the format but **throws a [UnsupportedSchemaFormat]**, indicating that
  *   code generation for these specific formats is not yet implemented in the generator.
- * - For any unknown `schemaFormat` string, it throws an [UnexpectedValue] error.
+ * - For any unknown `schemaFormat` string, it throws an [UnexpectedSchemaFormat] error.
  *
  * **Future Expansion:**
  * This parser is designed to be expanded in the future to provide full parsing and
  * code generation support for the currently unimplemented schema formats.
  *
  * Expected behavior is covered by:
+ * - `MultiFormatSchemaParserTest`
  * - `SchemaParserTest`
  */
 class MultiFormatSchemaParser(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParser.kt
@@ -11,6 +11,7 @@ import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey
  * Parses AsyncAPI server variable objects from parser nodes.
  *
  * Expected behavior is covered by:
+ * - `ServerVariableParserTest`
  * - `ServerParserTest`
  */
 class ServerVariableParser(

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/channels/ChannelParserTest.kt
@@ -118,7 +118,11 @@ class ChannelParserTest : ParserTestSupport() {
     @Test
     fun `parse channel with invalid messages structure throws UnexpectedValue`() {
         val channelsNode = readNode("parser/channels/asyncapi_parser_channel_invalid.yaml", "channels")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map/List",
+            "asyncapi_parser_channel_invalid.yaml",
+            "asyncapi_parser_channel_invalid.root.channels.InvalidMessages.messages",
+        ) {
             parser.parseMap(channelsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/correlations/CorrelationIdParserTest.kt
@@ -35,7 +35,11 @@ class CorrelationIdParserTest : ParserTestSupport() {
             "correlationIds",
             "MissingLocationId",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'location'",
+            "asyncapi_parser_correlationid_invalid.yaml",
+            "asyncapi_parser_correlationid_invalid.root.components.correlationIds.MissingLocationId.location",
+        ) {
             parser.parseElement(correlationIdNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/externaldocs/ExternalDocsParserTest.kt
@@ -43,7 +43,11 @@ class ExternalDocsParserTest : ParserTestSupport() {
             "externalDocs",
             "MissingUrl",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'url'",
+            "asyncapi_parser_externaldocs_invalid.yaml",
+            "asyncapi_parser_externaldocs_invalid.root.components.externalDocs.MissingUrl.url",
+        ) {
             parser.parseElement(externalDocsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.messages
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class MessageExampleParserTest : ParserTestSupport() {
+
+    private val parser = MessageExampleParser(asyncApiContext)
+
+    @Test
+    fun `parse message example with invalid structure throws UnexpectedValue`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_example_invalid.yaml",
+            "components",
+            "messageExampleCases",
+            "InvalidExampleStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_example_invalid.yaml",
+            "asyncapi_parser_message_example_invalid.root.components.messageExampleCases.InvalidExampleStructure[0]",
+        ) {
+            parser.parseList(examplesNode)
+        }
+    }
+
+    @Test
+    fun `parse message example with invalid headers throws UnexpectedValue`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_example_invalid.yaml",
+            "components",
+            "messageExampleCases",
+            "InvalidHeaders",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_example_invalid.yaml",
+            "asyncapi_parser_message_example_invalid.root.components.messageExampleCases.InvalidHeaders[0].headers",
+        ) {
+            parser.parseList(examplesNode)
+        }
+    }
+
+    @Test
+    fun `parse message example with boolean name throws UnexpectedValue`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_example_invalid.yaml",
+            "components",
+            "messageExampleCases",
+            "BooleanName",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_message_example_invalid.yaml",
+            "asyncapi_parser_message_example_invalid.root.components.messageExampleCases.BooleanName[0].name",
+        ) {
+            parser.parseList(examplesNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageExampleParserTest.kt
@@ -3,10 +3,32 @@ package dev.banking.asyncapi.generator.core.parser.messages
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class MessageExampleParserTest : ParserTestSupport() {
 
     private val parser = MessageExampleParser(asyncApiContext)
+
+    @Test
+    fun `parse message examples`() {
+        val examplesNode = readNode(
+            "parser/messages/asyncapi_parser_message_valid.yaml",
+            "components",
+            "messages",
+            "lightMeasured",
+            "examples",
+        )
+
+        val examples = parser.parseList(examplesNode)
+
+        assertEquals(2, examples.size)
+        val example = examples.first()
+        assertEquals("lightMeasurementExample", example.name)
+        assertEquals("Example of light measurement payload", example.summary)
+        assertNotNull(example.headers)
+        assertNotNull(example.payload)
+    }
 
     @Test
     fun `parse message example with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageParserTest.kt
@@ -98,7 +98,13 @@ class MessageParserTest : ParserTestSupport() {
             "components",
             "messages",
         )
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "12345",
+            "quote the value",
+            "asyncapi_parser_message_invalid_type.yaml",
+            "asyncapi_parser_message_invalid_type.root.components.messages.InvalidNameMessage.name",
+        ) {
             parser.parseMap(messagesNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
@@ -1,12 +1,35 @@
 package dev.banking.asyncapi.generator.core.parser.messages
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.messages.MessageTraitInterface
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class MessageTraitParserTest : ParserTestSupport() {
 
     private val parser = MessageTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse message trait list`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_edge_cases.yaml",
+            "components",
+            "messages",
+            "InlineTraitMessage",
+            "traits",
+        )
+
+        val traits = parser.parseList(traitsNode)
+
+        assertEquals(1, traits.size)
+        assertTrue(traits.first() is MessageTraitInterface.InlineMessageTrait)
+        val trait = (traits.first() as MessageTraitInterface.InlineMessageTrait).trait
+        assertTrue(trait.headers is SchemaInterface.SchemaInline)
+        assertEquals("string", (trait.headers as SchemaInterface.SchemaInline).schema.type)
+    }
 
     @Test
     fun `parse message trait with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/messages/MessageTraitParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.messages
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class MessageTraitParserTest : ParserTestSupport() {
+
+    private val parser = MessageTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse message trait with invalid structure throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_trait_invalid.yaml",
+            "components",
+            "messageTraitCases",
+            "InvalidTraitStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_trait_invalid.yaml",
+            "asyncapi_parser_message_trait_invalid.root.components.messageTraitCases.InvalidTraitStructure.badTrait",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+
+    @Test
+    fun `parse message trait with boolean content type throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_trait_invalid.yaml",
+            "components",
+            "messageTraitCases",
+            "BooleanContentType",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_message_trait_invalid.yaml",
+            "asyncapi_parser_message_trait_invalid.root.components.messageTraitCases.BooleanContentType.badTrait.contentType",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+
+    @Test
+    fun `parse message trait with invalid example structure throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/messages/asyncapi_parser_message_trait_invalid.yaml",
+            "components",
+            "messageTraitCases",
+            "InvalidExampleStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_message_trait_invalid.yaml",
+            "asyncapi_parser_message_trait_invalid.root.components.messageTraitCases.InvalidExampleStructure.badTrait.examples[0]",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationParserTest.kt
@@ -38,7 +38,11 @@ class OperationParserTest : ParserTestSupport() {
     @Test
     fun `parse operation missing action throws RequiredObject`() {
         val operationsNode = readNode("parser/operations/asyncapi_parser_operations_invalid.yaml", "operations")
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'action'",
+            "asyncapi_parser_operations_invalid.yaml",
+            "asyncapi_parser_operations_invalid.root.operations.MissingAction.action",
+        ) {
             parser.parseMap(operationsNode)
         }
     }
@@ -49,7 +53,11 @@ class OperationParserTest : ParserTestSupport() {
             "parser/operations/asyncapi_validator_operations_inline_message_error.yaml",
             "operations",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_validator_operations_inline_message_error.yaml",
+            "asyncapi_validator_operations_inline_message_error.root.operations.testOperation.messages[0].\$ref",
+        ) {
             parser.parseMap(operationsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.operations
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class OperationReplyAddressParserTest : ParserTestSupport() {
+
+    private val parser = OperationReplyAddressParser(asyncApiContext)
+
+    @Test
+    fun `parse operation reply address missing location throws Mandatory`() {
+        val addressNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml",
+            "components",
+            "operationReplyAddressCases",
+            "MissingLocation",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'location'",
+            "asyncapi_parser_operation_reply_address_invalid.yaml",
+            "asyncapi_parser_operation_reply_address_invalid.root.components.operationReplyAddressCases.MissingLocation.location",
+        ) {
+            parser.parseElement(addressNode)
+        }
+    }
+
+    @Test
+    fun `parse operation reply address with boolean location throws UnexpectedValue`() {
+        val addressNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml",
+            "components",
+            "operationReplyAddressCases",
+            "BooleanLocation",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_operation_reply_address_invalid.yaml",
+            "asyncapi_parser_operation_reply_address_invalid.root.components.operationReplyAddressCases.BooleanLocation.location",
+        ) {
+            parser.parseElement(addressNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyAddressParserTest.kt
@@ -1,12 +1,31 @@
 package dev.banking.asyncapi.generator.core.parser.operations
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class OperationReplyAddressParserTest : ParserTestSupport() {
 
     private val parser = OperationReplyAddressParser(asyncApiContext)
+
+    @Test
+    fun `parse operation reply address`() {
+        val addressNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "operations",
+            "receiveLightMeasurement",
+            "reply",
+            "address",
+        )
+
+        val address = parser.parseElement(addressNode)
+
+        assertTrue(address is OperationReplyAddressInterface.OperationReplyAddressInline)
+        assertEquals($$"$message.header#/replyTo", address.operationReplyAddress.location)
+    }
 
     @Test
     fun `parse operation reply address missing location throws Mandatory`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
@@ -1,5 +1,6 @@
 package dev.banking.asyncapi.generator.core.parser.operations
 
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
@@ -34,5 +35,56 @@ class OperationReplyParserTest : ParserTestSupport() {
 
         assertNotNull(reply.channel, "Reply channel should be present")
         assertEquals("#/channels/lightingMeasured", reply.channel.ref)
+    }
+
+    @Test
+    fun `parse operation reply with missing channel ref throws Mandatory`() {
+        val replyNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_invalid.yaml",
+            "components",
+            "operationReplyCases",
+            "MissingChannelReference",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_operation_reply_invalid.yaml",
+            "asyncapi_parser_operation_reply_invalid.root.components.operationReplyCases.MissingChannelReference.channel.\$ref",
+        ) {
+            parser.parseElement(replyNode)
+        }
+    }
+
+    @Test
+    fun `parse operation reply with missing message ref throws Mandatory with indexed path`() {
+        val replyNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_invalid.yaml",
+            "components",
+            "operationReplyCases",
+            "MissingMessageReference",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_operation_reply_invalid.yaml",
+            "asyncapi_parser_operation_reply_invalid.root.components.operationReplyCases.MissingMessageReference.messages[0].\$ref",
+        ) {
+            parser.parseElement(replyNode)
+        }
+    }
+
+    @Test
+    fun `parse operation reply with missing address location throws Mandatory`() {
+        val replyNode = readNode(
+            "parser/operations/asyncapi_parser_operation_reply_invalid.yaml",
+            "components",
+            "operationReplyCases",
+            "MissingAddressLocation",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'location'",
+            "asyncapi_parser_operation_reply_invalid.yaml",
+            "asyncapi_parser_operation_reply_invalid.root.components.operationReplyCases.MissingAddressLocation.address.location",
+        ) {
+            parser.parseElement(replyNode)
+        }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationReplyParserTest.kt
@@ -35,6 +35,9 @@ class OperationReplyParserTest : ParserTestSupport() {
 
         assertNotNull(reply.channel, "Reply channel should be present")
         assertEquals("#/channels/lightingMeasured", reply.channel.ref)
+
+        assertNotNull(reply.messages, "Reply messages should be present")
+        assertEquals(listOf("#/components/messages/lightMeasured"), reply.messages.map { it.ref })
     }
 
     @Test

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.operations
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class OperationTraitParserTest : ParserTestSupport() {
+
+    private val parser = OperationTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse operation trait with invalid structure throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/operations/asyncapi_parser_operation_trait_invalid.yaml",
+            "components",
+            "operationTraitCases",
+            "InvalidTraitStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_operation_trait_invalid.yaml",
+            "asyncapi_parser_operation_trait_invalid.root.components.operationTraitCases.InvalidTraitStructure.badTrait",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+
+    @Test
+    fun `parse operation trait with boolean title throws UnexpectedValue`() {
+        val traitsNode = readNode(
+            "parser/operations/asyncapi_parser_operation_trait_invalid.yaml",
+            "components",
+            "operationTraitCases",
+            "BooleanTitle",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_operation_trait_invalid.yaml",
+            "asyncapi_parser_operation_trait_invalid.root.components.operationTraitCases.BooleanTitle.badTrait.title",
+        ) {
+            parser.parseMap(traitsNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/operations/OperationTraitParserTest.kt
@@ -1,12 +1,28 @@
 package dev.banking.asyncapi.generator.core.parser.operations
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.operations.OperationTraitInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
 
 class OperationTraitParserTest : ParserTestSupport() {
 
     private val parser = OperationTraitParser(asyncApiContext)
+
+    @Test
+    fun `parse operation traits`() {
+        val traitsNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "components",
+            "operationTraits",
+        )
+
+        val traits = parser.parseMap(traitsNode)
+
+        assertTrue(traits["kafka"] is OperationTraitInterface.OperationTraitInline)
+        assertTrue(traits["logging"] is OperationTraitInterface.OperationTraitInline)
+    }
 
     @Test
     fun `parse operation trait with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
@@ -1,12 +1,35 @@
 package dev.banking.asyncapi.generator.core.parser.parameters
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.parameters.ParameterInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ParameterParserTest : ParserTestSupport() {
 
     private val parser = ParameterParser(asyncApiContext)
+
+    @Test
+    fun `parse parameters`() {
+        val parametersNode = readNode(
+            "parser/channels/asyncapi_parser_channel_valid.yaml",
+            "channels",
+            "lightStatus",
+            "parameters",
+        )
+
+        val parameters = parser.parseMap(parametersNode)
+
+        assertTrue(parameters["city"] is ParameterInterface.ParameterInline)
+        val city = (parameters["city"] as ParameterInterface.ParameterInline).parameter
+        assertEquals("The city where the streetlights are located.", city.description)
+        assertEquals($$"$message.payload#/city", city.location)
+        assertEquals(listOf("helsinki", "oslo", "stockholm"), city.enum)
+        assertEquals("helsinki", city.default)
+        assertEquals(listOf("helsinki", "oslo"), city.examples)
+    }
 
     @Test
     fun `parse parameter with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/parameters/ParameterParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.parameters
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class ParameterParserTest : ParserTestSupport() {
+
+    private val parser = ParameterParser(asyncApiContext)
+
+    @Test
+    fun `parse parameter with invalid structure throws UnexpectedValue`() {
+        val parametersNode = readNode(
+            "parser/parameters/asyncapi_parser_parameter_invalid.yaml",
+            "components",
+            "parameterCases",
+            "InvalidParameterStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_parameter_invalid.yaml",
+            "asyncapi_parser_parameter_invalid.root.components.parameterCases.InvalidParameterStructure.badParameter",
+        ) {
+            parser.parseMap(parametersNode)
+        }
+    }
+
+    @Test
+    fun `parse parameter with boolean location throws UnexpectedValue`() {
+        val parametersNode = readNode(
+            "parser/parameters/asyncapi_parser_parameter_invalid.yaml",
+            "components",
+            "parameterCases",
+            "BooleanLocation",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_parameter_invalid.yaml",
+            "asyncapi_parser_parameter_invalid.root.components.parameterCases.BooleanLocation.badParameter.location",
+        ) {
+            parser.parseMap(parametersNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.references
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class ReferenceParserTest : ParserTestSupport() {
+
+    private val parser = ReferenceParser(asyncApiContext)
+
+    @Test
+    fun `parse reference missing ref throws Mandatory`() {
+        val referenceNode = readNode(
+            "parser/references/asyncapi_parser_reference_invalid.yaml",
+            "components",
+            "references",
+            "MissingReference",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_reference_invalid.yaml",
+            "asyncapi_parser_reference_invalid.root.components.references.MissingReference.\$ref",
+        ) {
+            parser.parseElement(referenceNode)
+        }
+    }
+
+    @Test
+    fun `parse reference with non-string ref throws UnexpectedValue`() {
+        val referenceNode = readNode(
+            "parser/references/asyncapi_parser_reference_invalid.yaml",
+            "components",
+            "references",
+            "NumericReference",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "12345",
+            "quote the value",
+            "asyncapi_parser_reference_invalid.yaml",
+            "asyncapi_parser_reference_invalid.root.components.references.NumericReference.\$ref",
+        ) {
+            parser.parseElement(referenceNode)
+        }
+    }
+
+    @Test
+    fun `parse reference list missing ref throws Mandatory with indexed path`() {
+        val referencesNode = readNode(
+            "parser/references/asyncapi_parser_reference_invalid.yaml",
+            "components",
+            "references",
+            "ReferenceList",
+        )
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory '\$ref'",
+            "asyncapi_parser_reference_invalid.yaml",
+            "asyncapi_parser_reference_invalid.root.components.references.ReferenceList[0].\$ref",
+        ) {
+            parser.parseList(referencesNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/references/ReferenceParserTest.kt
@@ -1,12 +1,44 @@
 package dev.banking.asyncapi.generator.core.parser.references
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.references.ReferenceCategoryKey.REFERENCE
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class ReferenceParserTest : ParserTestSupport() {
 
     private val parser = ReferenceParser(asyncApiContext)
+
+    @Test
+    fun `parse reference element`() {
+        val referenceNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "operations",
+            "receiveLightMeasurement",
+            "channel",
+        )
+
+        val reference = parser.parseElement(referenceNode)
+
+        assertEquals("#/channels/lightingMeasured", reference.ref)
+        assertEquals(REFERENCE, reference.referenceCategoryKey)
+    }
+
+    @Test
+    fun `parse reference list`() {
+        val referencesNode = readNode(
+            "parser/operations/asyncapi_parser_operations_valid.yaml",
+            "operations",
+            "receiveLightMeasurement",
+            "messages",
+        )
+
+        val references = parser.parseList(referencesNode)
+
+        assertEquals(listOf("#/components/messages/lightMeasured"), references.map { it.ref })
+        assertEquals(listOf(REFERENCE), references.map { it.referenceCategoryKey })
+    }
 
     @Test
     fun `parse reference missing ref throws Mandatory`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
@@ -1,0 +1,63 @@
+package dev.banking.asyncapi.generator.core.parser.schemas
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class MultiFormatSchemaParserTest : ParserTestSupport() {
+
+    private val parser = SchemaParser(asyncApiContext)
+
+    @Test
+    fun `parse unsupported schema format throws UnsupportedSchemaFormat`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "UnsupportedJsonSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnsupportedSchemaFormat>(
+            "SchemaFormat: application/schema+json;version=draft-07 is not supported.",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnsupportedJsonSchemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+
+    @Test
+    fun `parse unknown schema format throws UnexpectedSchemaFormat`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "UnknownSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedSchemaFormat>(
+            "SchemaFormat: application/unknown is not valid.",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnknownSchemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+
+    @Test
+    fun `parse non-string schema format throws UnexpectedValue`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "NonStringSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean true",
+            "quote the value",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.NonStringSchemaFormat.schemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
@@ -1,12 +1,31 @@
 package dev.banking.asyncapi.generator.core.parser.schemas
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class MultiFormatSchemaParserTest : ParserTestSupport() {
 
     private val parser = SchemaParser(asyncApiContext)
+
+    @Test
+    fun `parse supported asyncapi schema format`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_valid.yaml",
+            "components",
+            "schemas",
+            "AsyncApiYamlSchemaFormat",
+        )
+
+        val schema = parser.parseElement(schemaNode)
+
+        assertTrue(schema is SchemaInterface.SchemaInline)
+        assertEquals("Supported schema format", schema.schema.title)
+        assertEquals("object", schema.schema.type)
+    }
 
     @Test
     fun `parse unsupported schema format throws UnsupportedSchemaFormat`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -344,7 +344,13 @@ class SchemaParserTest : ParserTestSupport() {
             "schemas",
             "InvalidCoercions",
         )
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Number",
+            "found String \"10\"",
+            "quoted numbers are strings in YAML",
+            "asyncapi_schema_parser_assertion.yaml",
+            "asyncapi_schema_parser_assertion.root.components.schemas.InvalidCoercions.maxLength",
+        ) {
             parser.parseElement(schemaNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerParserTest.kt
@@ -45,7 +45,11 @@ class ServerParserTest : ParserTestSupport() {
     @Test
     fun `parse server with invalid variables structure throws UnexpectedValue`() {
         val serversNode = readNode("parser/servers/asyncapi_parser_server_invalid.yaml", "servers")
-        assertParseFailure<AsyncApiParseException.UnexpectedValue> {
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map/List",
+            "asyncapi_parser_server_invalid.yaml",
+            "asyncapi_parser_server_invalid.root.servers.InvalidVariables.variables",
+        ) {
             parser.parseMap(serversNode)
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.parser.servers
+
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
+import org.junit.jupiter.api.Test
+
+class ServerVariableParserTest : ParserTestSupport() {
+
+    private val parser = ServerVariableParser(asyncApiContext)
+
+    @Test
+    fun `parse server variable with invalid structure throws UnexpectedValue`() {
+        val variablesNode = readNode(
+            "parser/servers/asyncapi_parser_server_variable_invalid.yaml",
+            "components",
+            "serverVariableCases",
+            "InvalidVariableStructure",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected Map",
+            "asyncapi_parser_server_variable_invalid.yaml",
+            "asyncapi_parser_server_variable_invalid.root.components.serverVariableCases.InvalidVariableStructure.badVariable",
+        ) {
+            parser.parseMap(variablesNode)
+        }
+    }
+
+    @Test
+    fun `parse server variable with boolean default throws UnexpectedValue`() {
+        val variablesNode = readNode(
+            "parser/servers/asyncapi_parser_server_variable_invalid.yaml",
+            "components",
+            "serverVariableCases",
+            "BooleanDefault",
+        )
+        assertParseFailure<AsyncApiParseException.UnexpectedValue>(
+            "Unexpected value: expected String",
+            "found Boolean false",
+            "quote the value",
+            "asyncapi_parser_server_variable_invalid.yaml",
+            "asyncapi_parser_server_variable_invalid.root.components.serverVariableCases.BooleanDefault.badVariable.default",
+        ) {
+            parser.parseMap(variablesNode)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/servers/ServerVariableParserTest.kt
@@ -1,12 +1,33 @@
 package dev.banking.asyncapi.generator.core.parser.servers
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.servers.ServerVariableInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ServerVariableParserTest : ParserTestSupport() {
 
     private val parser = ServerVariableParser(asyncApiContext)
+
+    @Test
+    fun `parse server variables`() {
+        val variablesNode = readNode(
+            "parser/servers/asyncapi_parser_servers_valid.yaml",
+            "servers",
+            "scram-connections",
+            "variables",
+        )
+
+        val variables = parser.parseMap(variablesNode)
+
+        assertTrue(variables["port"] is ServerVariableInterface.ServerVariableInline)
+        val port = (variables["port"] as ServerVariableInterface.ServerVariableInline).serverVariable
+        assertEquals(listOf("18092", "28092"), port.enum)
+        assertEquals("18092", port.default)
+        assertEquals("The port used for Kafka connections", port.description)
+    }
 
     @Test
     fun `parse server variable with invalid structure throws UnexpectedValue`() {

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/tags/TagParserTest.kt
@@ -42,7 +42,11 @@ class TagParserTest : ParserTestSupport() {
             "components",
             "tags",
         )
-        assertParseFailure<AsyncApiParseException.Mandatory> {
+        assertParseFailure<AsyncApiParseException.Mandatory>(
+            "Missing mandatory 'name'",
+            "asyncapi_parser_tag_invalid.yaml",
+            "asyncapi_parser_tag_invalid.root.components.tags.MissingName.name",
+        ) {
             parser.parseMap(tagsNode)
         }
     }

--- a/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_example_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_example_invalid.yaml
@@ -1,0 +1,12 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Message Example Parser Test
+  version: 1.0.0
+components:
+  messageExampleCases:
+    InvalidExampleStructure:
+      - "not-a-map"
+    InvalidHeaders:
+      - headers: "not-a-map"
+    BooleanName:
+      - name: true

--- a/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_trait_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/messages/asyncapi_parser_message_trait_invalid.yaml
@@ -1,0 +1,15 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Message Trait Parser Test
+  version: 1.0.0
+components:
+  messageTraitCases:
+    InvalidTraitStructure:
+      badTrait: "not-a-map"
+    BooleanContentType:
+      badTrait:
+        contentType: true
+    InvalidExampleStructure:
+      badTrait:
+        examples:
+          - "not-a-map"

--- a/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_address_invalid.yaml
@@ -1,0 +1,10 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Operation Reply Address Parser Test
+  version: 1.0.0
+components:
+  operationReplyAddressCases:
+    MissingLocation:
+      description: "Missing reply address location"
+    BooleanLocation:
+      location: true

--- a/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_reply_invalid.yaml
@@ -1,0 +1,17 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Operation Reply Parser Test
+  version: 1.0.0
+components:
+  operationReplyCases:
+    MissingChannelReference:
+      channel:
+        payload:
+          type: string
+    MissingMessageReference:
+      messages:
+        - payload:
+            type: string
+    MissingAddressLocation:
+      address:
+        description: "Missing reply address location"

--- a/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_trait_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/operations/asyncapi_parser_operation_trait_invalid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Operation Trait Parser Test
+  version: 1.0.0
+components:
+  operationTraitCases:
+    InvalidTraitStructure:
+      badTrait: "not-a-map"
+    BooleanTitle:
+      badTrait:
+        title: true

--- a/asyncapi-generator-core/src/test/resources/parser/parameters/asyncapi_parser_parameter_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/parameters/asyncapi_parser_parameter_invalid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Parameter Parser Test
+  version: 1.0.0
+components:
+  parameterCases:
+    InvalidParameterStructure:
+      badParameter: "not-a-map"
+    BooleanLocation:
+      badParameter:
+        location: true

--- a/asyncapi-generator-core/src/test/resources/parser/references/asyncapi_parser_reference_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/references/asyncapi_parser_reference_invalid.yaml
@@ -1,0 +1,13 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Reference Parser Test
+  version: 1.0.0
+components:
+  references:
+    MissingReference:
+      summary: "Reference object missing its reference value"
+    NumericReference:
+      $ref: 12345
+    ReferenceList:
+      - payload:
+          type: string

--- a/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
@@ -1,0 +1,18 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Schema Format Parser Test
+  version: 1.0.0
+components:
+  schemas:
+    UnsupportedJsonSchemaFormat:
+      schemaFormat: application/schema+json;version=draft-07
+      schema:
+        type: object
+    UnknownSchemaFormat:
+      schemaFormat: application/unknown
+      schema:
+        type: object
+    NonStringSchemaFormat:
+      schemaFormat: true
+      schema:
+        type: object

--- a/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_valid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_valid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Valid Schema Format Parser Test
+  version: 1.0.0
+components:
+  schemas:
+    AsyncApiYamlSchemaFormat:
+      schemaFormat: application/vnd.aai.asyncapi+yaml;version=3.0.0
+      schema:
+        title: Supported schema format
+        type: object

--- a/asyncapi-generator-core/src/test/resources/parser/servers/asyncapi_parser_server_variable_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/servers/asyncapi_parser_server_variable_invalid.yaml
@@ -1,0 +1,11 @@
+asyncapi: 3.0.0
+info:
+  title: Invalid Server Variable Parser Test
+  version: 1.0.0
+components:
+  serverVariableCases:
+    InvalidVariableStructure:
+      badVariable: "not-a-map"
+    BooleanDefault:
+      badVariable:
+        default: false


### PR DESCRIPTION
Adresses,
- #92 
- #93 

The previous parser tests mostly verified that invalid input caused an exception, but they did not consistently verify the quality of the error contract. That made it harder to know whether a parser failure included the right exception type, a useful message, the source file, and the document path where the problem happened.

This was risky because parser errors are part of the user experience. If a user gives the generator an invalid AsyncAPI document, the parser should fail in a predictable way and point to the part of the document that needs attention.

For the proposed solution, the parser tests now assert structured parse failures through a shared `assertParseFailure` helper. This keeps the tests readable while still checking the important parts of the error contract: the exception type, message content, source file, and source path.

Focused parser error tests were added for references, server variables, parameters, message examples, message traits, operation traits, operation replies, operation reply addresses, and multi-format schema parsing.

Happy-flow tests were also added for those same parser areas. This is intentional because the parser contract is not only that invalid input fails clearly, but also that valid input does not fail and produces the expected parsed model.

The parser KDocs were updated so implementation classes point to the test classes that cover their expected behavior. This keeps the implementation-to-test relationship visible and makes it easier to extend the parser stage in a consistent way.

The new tests use file-based parser fixtures and shared parser test support, so the setup stays aligned with the reader and parser test strategy already introduced in earlier work.