### PR TITLE
feature/parser source locations

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiContext.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiContext.kt
@@ -2,6 +2,7 @@ package dev.banking.asyncapi.generator.core.context
 
 import dev.banking.asyncapi.generator.core.model.references.Reference
 import dev.banking.asyncapi.generator.core.parser.node.ParserNode
+import dev.banking.asyncapi.generator.core.reader.SourceLocation
 import dev.banking.asyncapi.generator.core.repository.ModelRepository
 import dev.banking.asyncapi.generator.core.repository.SourceRepository
 import java.io.File
@@ -38,10 +39,26 @@ class AsyncApiContext {
         sourceRepository.registerLine(path, line)
     }
 
+    fun registerSourceLocation(
+        path: String,
+        location: SourceLocation,
+    ) {
+        sourceRepository.registerLocation(path, location)
+    }
+
     fun <R> getLine(
         model: Any,
         property: KProperty0<R>,
     ): Int? = modelRepository.getLine(model, property) ?: modelRepository.getLine(model)
+
+    fun <R> getSourceLocation(
+        model: Any,
+        property: KProperty0<R>,
+    ): SourceLocation? =
+        modelRepository.getSourceLocation(model, property)
+            ?: modelRepository.getSourceLocation(model)
+
+    fun getSourceLocation(model: Any): SourceLocation? = modelRepository.getSourceLocation(model)
 
     fun pathSnippet(
         path: String,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/node/ParserNodeFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/node/ParserNodeFactory.kt
@@ -26,11 +26,11 @@ object ParserNodeFactory {
         val rootPath = "${buildFileId(document.source.file)}.$ROOT"
         document.sourceMap.all().values.forEach { location ->
             val parserPath = parserPath(rootPath, location.path)
-            context.registerLine(parserPath, location.line)
+            context.registerSourceLocation(parserPath, location)
 
             val normalizedPath = normalizeArrayPath(parserPath)
             if (normalizedPath != parserPath) {
-                context.registerLine(normalizedPath, location.line)
+                context.registerSourceLocation(normalizedPath, location)
             }
         }
 

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/ModelRepository.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/ModelRepository.kt
@@ -1,16 +1,25 @@
 package dev.banking.asyncapi.generator.core.repository
 
 import dev.banking.asyncapi.generator.core.constants.AsyncApiConstants.ROOT
-import dev.banking.asyncapi.generator.core.parser.node.ParserNode
 import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.parser.node.ParserNode
+import dev.banking.asyncapi.generator.core.reader.SourceLocation
 import kotlin.reflect.KProperty0
 
+/**
+ * Tracks parsed model instances back to parser paths and source locations.
+ *
+ * Expected behavior is covered by:
+ * - `AsyncApiParserTest`
+ */
 class ModelRepository(
     private val sourceRepository: SourceRepository,
 ) {
 
     data class Model(
         val model: Any,
+        val sourceLocation: SourceLocation?,
+        val fieldLocations: Map<String, SourceLocation>,
         val fieldLines: Map<String, Int>,
         val fieldName: String?,
         val parentPath: String?,
@@ -21,28 +30,46 @@ class ModelRepository(
     private val modelsByPath = LinkedHashMap<String, Any>()
 
     fun register(model: Any, node: ParserNode) {
-        val fieldLines = collectFieldLines(node)
+        val fieldLocations = collectFieldLocations(node)
+        val fieldLines = if (fieldLocations.isNotEmpty()) {
+            fieldLocations.mapValues { (_, location) -> location.line }
+        } else {
+            collectFieldLines(node)
+        }
         val fieldName = node.path.substringAfterLast('.', node.path)
         val parentPath = node.path.substringBeforeLast('.', missingDelimiterValue = "")
         val path = node.path
+        val sourceLocation = sourceRepository.getLocation(path)
+            ?: sourceRepository.findNearestLocation(path)
 
         if (model is Reference) {
             model.sourceId = path.substringBefore(".root", path)
         }
 
-        modelsByInstance[model] = Model(model, fieldLines, fieldName, parentPath, path)
+        modelsByInstance[model] = Model(model, sourceLocation, fieldLocations, fieldLines, fieldName, parentPath, path)
         modelsByPath[path] = model
     }
 
     fun <R> getLine(model: Any, property: KProperty0<R>): Int? {
         val fieldName = property.name
-        return modelsByInstance[model]?.fieldLines?.get(fieldName)
+        val entry = modelsByInstance[model] ?: return null
+        return entry.fieldLocations[fieldName]?.line ?: entry.fieldLines[fieldName]
     }
 
     fun getLine(model: Any): Int? {
         val entry = modelsByInstance[model] ?: return null
-        // We use the full node path to look up the line in SourceRepository
-        return entry.nodePath?.let { sourceRepository.getLine(it) }
+        return getSourceLocation(model)?.line
+            ?: entry.nodePath?.let { sourceRepository.getLine(it) }
+    }
+
+    fun <R> getSourceLocation(model: Any, property: KProperty0<R>): SourceLocation? {
+        val fieldName = property.name
+        return modelsByInstance[model]?.fieldLocations?.get(fieldName)
+    }
+
+    fun getSourceLocation(model: Any): SourceLocation? {
+        val entry = modelsByInstance[model] ?: return null
+        return entry.sourceLocation ?: entry.nodePath?.let { sourceRepository.findNearestLocation(it) }
     }
 
     fun getModelsByInstance() = modelsByInstance.toMap()
@@ -51,6 +78,36 @@ class ModelRepository(
     fun findByReference(reference: Reference): Any? {
         val normalized = normalize(reference) ?: return null
         return modelsByPath[normalized]
+    }
+
+    private fun collectFieldLocations(node: ParserNode): Map<String, SourceLocation> {
+        val result = mutableMapOf<String, SourceLocation>()
+        val basePath = node.path
+        val normalizedPath = basePath.replace("[", ".").replace("]", "")
+        when (val raw = node.node) {
+            is Map<*, *> -> {
+                for (key in raw.keys.filterIsInstance<String>()) {
+                    val possiblePaths = sequenceOf("$basePath.$key", "$normalizedPath.$key")
+                    val location = possiblePaths.mapNotNull(sourceRepository::getLocation).firstOrNull()
+                    if (location != null) result[key] = location
+                }
+            }
+
+            is List<*> -> {
+                raw.forEachIndexed { index, _ ->
+                    val possiblePaths = sequenceOf("$basePath[$index]", "$normalizedPath.$index")
+                    val location = possiblePaths.mapNotNull(sourceRepository::getLocation).firstOrNull()
+                    if (location != null) result["[$index]"] = location
+                }
+            }
+
+            else -> {
+                (sourceRepository.getLocation(basePath)
+                    ?: sourceRepository.getLocation(normalizedPath))
+                    ?.let { location -> result["<value>"] = location }
+            }
+        }
+        return result
     }
 
     private fun collectFieldLines(node: ParserNode): Map<String, Int> {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/SourceRepository.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/SourceRepository.kt
@@ -1,9 +1,17 @@
 package dev.banking.asyncapi.generator.core.repository
 
+import dev.banking.asyncapi.generator.core.reader.SourceLocation
 import java.io.File
 import kotlin.math.max
 import kotlin.math.min
 
+/**
+ * Stores input sources and source locations using parser-stage paths.
+ *
+ * Expected behavior is covered by:
+ * - `ParserNodeFactoryTest`
+ * - `AsyncApiRegistryTest`
+ */
 class SourceRepository {
     data class Source(
         val file: File,
@@ -16,6 +24,9 @@ class SourceRepository {
 
     // Map of node path → line number
     internal val lineMap = mutableMapOf<String, Int>()
+
+    // Map of node path → source location
+    private val locations = mutableMapOf<String, SourceLocation>()
 
     private lateinit var current: Source
 
@@ -36,7 +47,17 @@ class SourceRepository {
         lineMap[path] = line
     }
 
+    fun registerLocation(
+        path: String,
+        location: SourceLocation,
+    ) {
+        locations[path] = location.copy(path = path)
+        registerLine(path, location.line)
+    }
+
     fun getLine(path: String): Int? = lineMap[path]
+
+    fun getLocation(path: String): SourceLocation? = locations[path]
 
     fun getCurrentFile(): File = current.file
 
@@ -45,6 +66,8 @@ class SourceRepository {
     fun getAllSources(): Collection<Source> = sources.values
 
     fun getAllLines(): Map<String, Int> = lineMap.toMap()
+
+    fun getAllLocations(): Map<String, SourceLocation> = locations.toMap()
 
     fun fileIdForName(name: String): String? {
         val clean = name.trim().trimStart('\'', '"', '|', '>')
@@ -57,22 +80,21 @@ class SourceRepository {
     }
 
     fun findNearestLine(path: String): Int? {
-        val normalized = path.replace(Regex("""\[\d+]"""), "") // e.g. tags[0] → tags
-        var key = normalized
-        while (true) {
-            lineMap[key]?.let { return it }
-            key = key.substringBeforeLast(".", missingDelimiterValue = "")
-            if (key.isEmpty()) return null
-        }
+        findNearestLocation(path)?.let { return it.line }
+        return nearestPaths(path).mapNotNull(lineMap::get).firstOrNull()
     }
+
+    fun findNearestLocation(path: String): SourceLocation? =
+        nearestPaths(path).mapNotNull(locations::get).firstOrNull()
 
     fun pathSnippet(
         path: String,
         contextLines: Int = 3,
     ): String {
-        val source = current
+        val location = findNearestLocation(path)
+        val source = location?.let(::sourceFor) ?: current
         val lines = source.lines
-        val line = findNearestLine(path) ?: return "(no line found for $path)"
+        val line = location?.line ?: findNearestLine(path) ?: return "(no line found for $path)"
         return buildSnippet(lines, source.file.name, line, contextLines, path)
     }
 
@@ -101,5 +123,25 @@ class SourceRepository {
                 appendLine("$mark ${(i + 1).toString().padStart(4)} | ${lines[i]}")
             }
         }.trimEnd()
+    }
+
+    private fun sourceFor(location: SourceLocation): Source =
+        sources[location.file.absolutePath]
+            ?: sources.values.firstOrNull { it.id == location.sourceId }
+            ?: current
+
+    private fun nearestPaths(path: String): Sequence<String> = sequence {
+        val candidates = linkedSetOf(
+            path,
+            path.replace(Regex("""\[(\d+)]"""), ".$1"),
+            path.replace(Regex("""\[\d+]"""), ""),
+        )
+        candidates.forEach { candidate ->
+            var key = candidate
+            while (key.isNotEmpty()) {
+                yield(key)
+                key = key.substringBeforeLast(".", missingDelimiterValue = "")
+            }
+        }
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/asyncapi/AsyncApiParserTest.kt
@@ -8,7 +8,7 @@ import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
+import kotlin.test.assertNotNull
 
 class AsyncApiParserTest : ParserTestSupport() {
 
@@ -115,5 +115,28 @@ class AsyncApiParserTest : ParserTestSupport() {
         assertEquals(429, asyncApiContext.getLine(simpleStringSchema, simpleStringSchema::title))
         assertEquals(430, asyncApiContext.getLine(simpleStringSchema, simpleStringSchema::description))
         assertEquals(431, asyncApiContext.getLine(simpleStringSchema, simpleStringSchema::type))
+    }
+
+    @Test
+    fun `parsed schema properties preserve source location links`() {
+        val rootNode = readNode("asyncapi_kafka_single_file_example.yaml")
+        parser.parse(rootNode)
+        val schemaPath =
+            "${asyncApiContext.sourceRepository.getCurrentFile().nameWithoutExtension}.root.components.schemas.simpleString"
+        val simpleStringSchema = asyncApiContext.modelRepository.getModelsByPath()[schemaPath] as Schema
+
+        val schemaLocation = assertNotNull(asyncApiContext.getSourceLocation(simpleStringSchema))
+        assertEquals("asyncapi_kafka_single_file_example.yaml", schemaLocation.file.name)
+        assertEquals("asyncapi_kafka_single_file_example.root.components.schemas.simpleString", schemaLocation.path)
+        assertEquals(428, schemaLocation.line)
+        assertTrue(schemaLocation.column > 0)
+
+        val titleLocation = assertNotNull(
+            asyncApiContext.getSourceLocation(simpleStringSchema, simpleStringSchema::title)
+        )
+        assertEquals("asyncapi_kafka_single_file_example.yaml", titleLocation.file.name)
+        assertEquals("asyncapi_kafka_single_file_example.root.components.schemas.simpleString.title", titleLocation.path)
+        assertEquals(429, titleLocation.line)
+        assertTrue(titleLocation.column > 0)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/node/ParserNodeFactoryTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/node/ParserNodeFactoryTest.kt
@@ -5,6 +5,7 @@ import dev.banking.asyncapi.generator.core.fixtures.ReaderFixtures
 import dev.banking.asyncapi.generator.core.reader.YamlDocumentReader
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class ParserNodeFactoryTest {
 
@@ -32,5 +33,23 @@ class ParserNodeFactoryTest {
         assertEquals(5, context.sourceRepository.getLine("source_map.root.info.tags[0]"))
         assertEquals(5, context.sourceRepository.getLine("source_map.root.info.tags.0"))
         assertEquals(ReaderFixtures.yamlFile("source-map.yaml"), context.findFileById("source_map"))
+    }
+
+    @Test
+    fun `registers full source locations using parser path convention`() {
+        val context = AsyncApiContext()
+        val document = reader.read(ReaderFixtures.yamlSource("source-map.yaml"))
+        ParserNodeFactory.root(document, context)
+
+        val titleLocation = assertNotNull(context.sourceRepository.getLocation("source_map.root.info.title"))
+        assertEquals("source-map", titleLocation.sourceId)
+        assertEquals(ReaderFixtures.yamlFile("source-map.yaml"), titleLocation.file)
+        assertEquals("source_map.root.info.title", titleLocation.path)
+        assertEquals(3, titleLocation.line)
+        assertEquals(3, titleLocation.column)
+
+        val normalizedArrayLocation = assertNotNull(context.sourceRepository.getLocation("source_map.root.info.tags.0"))
+        assertEquals("source_map.root.info.tags.0", normalizedArrayLocation.path)
+        assertEquals(5, normalizedArrayLocation.line)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParserTest.kt
@@ -402,6 +402,34 @@ class SchemaParserTest : ParserTestSupport() {
 
         val level2Schema = modelPaths[expectedLevel2Path] as Schema
         assertEquals("I am level 2 deep", level2Schema.description)
+
+        val mainSchema = modelPaths["main.root.components.schemas.MainObject"] as Schema
+        val mainLocation = assertNotNull(asyncApiContext.getSourceLocation(mainSchema))
+        assertEquals("main.yaml", mainLocation.file.name)
+        assertEquals("main.root.components.schemas.MainObject", mainLocation.path)
+        assertEquals(7, mainLocation.line)
+
+        val level2Location = assertNotNull(asyncApiContext.getSourceLocation(level2Schema))
+        assertEquals("level2.yaml", level2Location.file.name)
+        assertEquals("level2.root.components.schemas.Level2Object", level2Location.path)
+        assertEquals(7, level2Location.line)
+
+        val level2DescriptionLocation = assertNotNull(
+            asyncApiContext.getSourceLocation(level2Schema, level2Schema::description)
+        )
+        assertEquals("level2.yaml", level2DescriptionLocation.file.name)
+        assertEquals("level2.root.components.schemas.Level2Object.description", level2DescriptionLocation.path)
+        assertEquals(9, level2DescriptionLocation.line)
+        assertEquals(9, asyncApiContext.getLine(level2Schema, level2Schema::description))
+
+        assertTrue(
+            asyncApiContext.pathSnippet(mainLocation.path).contains("main.yaml"),
+            "Main schema snippet should use the main file after external files have been loaded"
+        )
+        assertTrue(
+            asyncApiContext.pathSnippet(level2DescriptionLocation.path).contains("level2.yaml"),
+            "External schema snippet should use the external file"
+        )
     }
 
     @Test


### PR DESCRIPTION
Adresses,
- #95 

The previous parser flow preserved line numbers for parsed model objects, but it did not expose the full source location for a parsed model or one of its fields. That made it harder for later stages, especially validation, to report diagnostics with the correct file, path, line, and column.

This was especially risky for multi-file documents because source reporting could depend too much on the current file state instead of the actual file where a model was parsed from.

For the proposed solution, parser-node source locations are now registered as full `SourceLocation` objects. Parsed model instances and model fields can now be resolved back to their source location through `AsyncApiContext`.

The existing `getLine` behavior is preserved, so current validators and diagnostics continue to work while the next validator-contract work can start using richer source-location metadata.

Tests were added to verify source locations for parser paths, parsed schema models, parsed schema fields, and recursive external references across multiple files.

