### PR TITLE
feature/validator contract

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiContext.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/context/AsyncApiContext.kt
@@ -65,10 +65,10 @@ class AsyncApiContext {
         contextLines: Int = 3,
     ): String = sourceRepository.pathSnippet(path, contextLines)
 
-    fun validatorSnippet(
-        line: Int,
+    fun sourceSnippet(
+        sourceLocation: SourceLocation,
         contextLines: Int = 3,
-    ): String = sourceRepository.lineSnippet(line, contextLines)
+    ): String = sourceRepository.locationSnippet(sourceLocation, contextLines)
 
     fun findReference(reference: Reference): Any? = modelRepository.findByReference(reference)
 

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiValidateException.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiValidateException.kt
@@ -1,25 +1,19 @@
 package dev.banking.asyncapi.generator.core.model.exceptions
 
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
-import dev.banking.asyncapi.generator.core.model.validator.ValidationError
+import dev.banking.asyncapi.generator.core.model.validator.ValidationFinding
+import dev.banking.asyncapi.generator.core.validator.util.ValidationFindingFormatter.format
 
 sealed class AsyncApiValidateException(message: String) : Exception(message) {
 
     class ValidateError(
-        val errors: List<ValidationError>,
+        val errors: List<ValidationFinding>,
         val context: AsyncApiContext
     ) : AsyncApiValidateException(
-        buildString {
-            appendLine("Validation failed with ${errors.size} error(s):")
-            appendLine()
-            errors.forEach { err ->
-                appendLine(">> ${err.message}")
-                appendLine()
-                appendLine(context.validatorSnippet(err.line ?: -1))
-                appendLine()
-                if (err.doc != null) appendLine("See documentation: ${err.doc}")
-                appendLine("---------------------------------------------------------------------------------------------------------------------")
-            }
-        }
+        format(
+            title = "Validation failed with ${errors.size} error(s):",
+            findings = errors,
+            asyncApiContext = context,
+        )
     )
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationError.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationError.kt
@@ -1,8 +1,0 @@
-package dev.banking.asyncapi.generator.core.model.validator
-
-data class ValidationError(
-    val message: String,
-    val line: Int?,
-    val doc: String? = null,
-)
-

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationFinding.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationFinding.kt
@@ -1,0 +1,18 @@
+package dev.banking.asyncapi.generator.core.model.validator
+
+import dev.banking.asyncapi.generator.core.reader.SourceLocation
+
+/**
+ * Structured validation diagnostic produced by the validator stage.
+ *
+ * Expected behavior is covered by:
+ * - `ValidationResultsTest`
+ */
+data class ValidationFinding(
+    val severity: ValidationSeverity,
+    val message: String,
+    val sourceLocation: SourceLocation? = null,
+    val path: String? = sourceLocation?.path,
+    val line: Int? = sourceLocation?.line,
+    val doc: String? = null,
+)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationSeverity.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationSeverity.kt
@@ -1,0 +1,12 @@
+package dev.banking.asyncapi.generator.core.model.validator
+
+/**
+ * Severity for a validation finding.
+ *
+ * Expected behavior is covered by:
+ * - `ValidationResultsTest`
+ */
+enum class ValidationSeverity {
+    ERROR,
+    WARNING,
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationWarning.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/validator/ValidationWarning.kt
@@ -1,7 +1,0 @@
-package dev.banking.asyncapi.generator.core.model.validator
-
-data class ValidationWarning(
-    val message: String,
-    val line: Int?,
-    val doc: String? = null,
-)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/SourceRepository.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/repository/SourceRepository.kt
@@ -98,13 +98,13 @@ class SourceRepository {
         return buildSnippet(lines, source.file.name, line, contextLines, path)
     }
 
-    fun lineSnippet(
-        line: Int,
+    fun locationSnippet(
+        location: SourceLocation,
         contextLines: Int = 3,
     ): String {
-        val source = current
+        val source = sourceFor(location)
         val lines = source.lines
-        return buildSnippet(lines, source.file.name, line, contextLines, "line $line")
+        return buildSnippet(lines, source.file.name, location.line, contextLines, location.path)
     }
 
     private fun buildSnippet(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/resolver/ReferenceResolver.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/resolver/ReferenceResolver.kt
@@ -15,7 +15,7 @@ class ReferenceResolver(
         }
         results.error(
             "$contextString reference '${reference.ref}' could not be resolved",
-            asyncApiContext.getLine(reference, reference::ref),
-            )
+            sourceLocation = asyncApiContext.getSourceLocation(reference, reference::ref),
+        )
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/AsyncApiValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/AsyncApiValidator.kt
@@ -13,9 +13,15 @@ import dev.banking.asyncapi.generator.core.validator.servers.ServerValidator
 import dev.banking.asyncapi.generator.core.validator.util.ValidationResults
 import dev.banking.asyncapi.generator.core.validator.util.ValidatorUtility.sanitizeString
 
+/**
+ * Validates a parsed [AsyncApiDocument] and returns validation results.
+ *
+ * Expected behavior is covered by:
+ * - `AsyncApiValidatorTest`
+ */
 class AsyncApiValidator(
     val asyncApiContext: AsyncApiContext,
-) {
+) : ValidationStage {
 
     private val infoValidator = InfoValidator(asyncApiContext)
     private val channelValidator = ChannelValidator(asyncApiContext)
@@ -23,7 +29,7 @@ class AsyncApiValidator(
     private val operationValidator = OperationValidator(asyncApiContext)
     private val componentValidator = ComponentValidator(asyncApiContext)
 
-    fun validate(asyncApiDocument: AsyncApiDocument): ValidationResults {
+    override fun validate(asyncApiDocument: AsyncApiDocument): ValidationResults {
         val results = ValidationResults(asyncApiContext)
 
         validateAsyncApiVersion(asyncApiDocument, results)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/AsyncApiValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/AsyncApiValidator.kt
@@ -65,17 +65,17 @@ class AsyncApiValidator(
         if (asyncApiVersion.isBlank()) {
             results.error(
                 "The 'asyncapi' field is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::asyncapi)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::asyncapi),
             )
         } else if (!SEMANTIC_VERSION.matches(asyncApiVersion)) {
             results.error(
                 "Invalid AsyncAPI version format '$asyncApiVersion'. Expected 'major.minor.patch' (e.g., 3.0.0).",
-                asyncApiContext.getLine(node, node::asyncapi)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::asyncapi),
             )
         } else if (!asyncApiVersion.startsWith("3.")) {
             results.error(
                 "AsyncAPI version '$asyncApiVersion' is not be supported by this plugin.",
-                asyncApiContext.getLine(node, node::asyncapi)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::asyncapi),
             )
         }
     }
@@ -86,12 +86,12 @@ class AsyncApiValidator(
         if (!URI.matches(id)) {
             results.error(
                 "The 'id' field must conform to the URI format (RFC3986). Got '$id'.",
-                asyncApiContext.getLine(node, node::id)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::id),
             )
         } else if (!id.startsWith("urn:")) {
             results.warn(
                 "It is RECOMMENDED to use a URN for the 'id' field to ensure global uniqueness.",
-                asyncApiContext.getLine(node, node::id)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::id),
             )
         }
     }
@@ -101,7 +101,7 @@ class AsyncApiValidator(
         if (!MIME_TYPE.matches(contentType)) {
             results.error(
                 "Invalid 'defaultContentType' format '$contentType'. Expected a MIME type (e.g., 'application/json').",
-                asyncApiContext.getLine(node, node::defaultContentType)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::defaultContentType),
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/ValidationStage.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/ValidationStage.kt
@@ -1,0 +1,18 @@
+package dev.banking.asyncapi.generator.core.validator
+
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+import dev.banking.asyncapi.generator.core.validator.util.ValidationResults
+
+/**
+ * Contract for validator-stage implementations.
+ *
+ * A validation stage receives an already parsed AsyncAPI model and returns
+ * validation results. It must not read input files, parse documents, bundle
+ * references, or generate output.
+ *
+ * Expected behavior is covered by:
+ * - `AsyncApiValidatorTest`
+ */
+interface ValidationStage {
+    fun validate(asyncApiDocument: AsyncApiDocument): ValidationResults
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/bindings/BindingValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/bindings/BindingValidator.kt
@@ -20,7 +20,7 @@ class BindingValidator(
         if (binding.content.isEmpty()) {
             results.warn(
                 "$bindingName is empty — no protocol-specific binding properties are defined.",
-                asyncApiContext.getLine(binding, binding::content)
+                sourceLocation = asyncApiContext.getSourceLocation(binding, binding::content),
             )
             return
         }
@@ -43,7 +43,7 @@ class BindingValidator(
         if (bindingData == null) {
             results.warn(
                 "Binding for protocol '$protocol' is null — consider removing or defining a value.",
-                asyncApiContext.getLine(binding, binding::content)
+                sourceLocation = asyncApiContext.getSourceLocation(binding, binding::content),
             )
             return
         }
@@ -51,7 +51,7 @@ class BindingValidator(
         if (bindingData !is Map<*, *>) {
             results.error(
                 "Binding for protocol '$protocol' must be an object (Map), but found ${bindingData::class.simpleName}.",
-                asyncApiContext.getLine(binding, binding::content)
+                sourceLocation = asyncApiContext.getSourceLocation(binding, binding::content),
             )
             return
         }
@@ -91,14 +91,14 @@ class BindingValidator(
             when (val mapValue = value?.let(::sanitizeAny)) {
                 null -> results.warn(
                     "Property '$key' in '$protocol' binding is null — consider removing.",
-                    asyncApiContext.getLine(binding, binding::content)
+                    sourceLocation = asyncApiContext.getSourceLocation(binding, binding::content),
                 )
 
                 is Map<*, *> -> {}
                 is List<*> -> {
                     results.warn(
                         "Property '$key' in '$protocol' binding has type List, which might be unsupported by this generator.",
-                        asyncApiContext.getLine(binding, binding::content)
+                        sourceLocation = asyncApiContext.getSourceLocation(binding, binding::content),
                     )
                 }
 
@@ -106,7 +106,7 @@ class BindingValidator(
                     if (mapValue.isBlank()) {
                         results.warn(
                             "Property '$key' in '$protocol' binding is empty — consider removing or defining a value.",
-                            asyncApiContext.getLine(binding, binding::content)
+                            sourceLocation = asyncApiContext.getSourceLocation(binding, binding::content),
                         )
                     }
                 }
@@ -115,7 +115,7 @@ class BindingValidator(
                 else -> {
                     results.warn(
                         "Property '$key' in '$protocol' binding has unsupported type: ${value::class.simpleName}",
-                        asyncApiContext.getLine(binding, binding::content)
+                        sourceLocation = asyncApiContext.getSourceLocation(binding, binding::content),
                     )
                 }
             }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/channels/ChannelValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/channels/ChannelValidator.kt
@@ -54,16 +54,16 @@ class ChannelValidator(
         if (address.isBlank()) {
             results.warn(
                 "$contextString does not define an 'address'. It may be treated as dynamically assigned.",
-                asyncApiContext.getLine(node, node::address),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::address),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
             )
             return
         }
         if (address.contains("?") || address.contains("#")) {
             results.error(
                 "$contextString address must not contain query parameters or fragments. Use bindings for that.",
-                asyncApiContext.getLine(node, node::address),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::address),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
             )
             return
         }
@@ -77,16 +77,16 @@ class ChannelValidator(
         if (missingDefinitions.isNotEmpty()) {
             results.error(
                 "$contextString address uses parameters $missingDefinitions which are not defined in channel parameters map.",
-                asyncApiContext.getLine(node, node::address),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#parametersObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::address),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#parametersObject",
             )
         }
         val unusedDefinitions = definedParameters - addressParameters
         if (unusedDefinitions.isNotEmpty()) {
             results.warn(
                 "$contextString defines parameters $unusedDefinitions which are not used in the channel address '$address'.",
-                asyncApiContext.getLine(node, node::parameters),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::parameters),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
             )
         }
     }
@@ -96,8 +96,8 @@ class ChannelValidator(
         if (messages.isNullOrEmpty()) {
             results.error(
                 "$contextString' must define at least one message in 'messages'.",
-                asyncApiContext.getLine(node, node::messages),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::messages),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
             )
             return
         }
@@ -119,8 +119,8 @@ class ChannelValidator(
         if (servers.isEmpty()) {
             results.warn(
                 "$contextString defines an empty 'servers' array. It will be available on all servers.",
-                asyncApiContext.getLine(node, node::servers),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::servers),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
             )
         }
         servers.forEachIndexed { index, reference ->
@@ -174,7 +174,7 @@ class ChannelValidator(
         if (bindings.isEmpty()) {
             results.warn(
                 "$contextString defines an empty 'bindings' object. Can be omitted if no bindings are defined.",
-                asyncApiContext.getLine(node, node::bindings),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::bindings),
             )
             return
         }
@@ -203,8 +203,8 @@ class ChannelValidator(
                 if (refMap.containsKey(ref)) {
                     results.warn(
                         "$contextString contains ambiguous messages which may be indistinguishable at runtime.",
-                        asyncApiContext.getLine(node, node::messages),
-                        "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject"
+                        sourceLocation = asyncApiContext.getSourceLocation(node, node::messages),
+                        doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#channelObject",
                     )
                 } else {
                     refMap[ref] = msgName

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/correlations/CorrelationIdValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/correlations/CorrelationIdValidator.kt
@@ -32,7 +32,7 @@ class CorrelationIdValidator(
         if (location.isBlank()) {
             results.error(
                 "$contextString 'location' is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::location)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::location),
             )
             return
         }
@@ -40,8 +40,8 @@ class CorrelationIdValidator(
         if (!RUNTIME_EXPRESSION_GENERAL.matches(location)) {
             results.warn(
                 "$contextString 'location' ('$location') does not follow valid runtime expression.",
-                asyncApiContext.getLine(node, node::location),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#correlationIdObject"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::location),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#correlationIdObject",
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/externaldocs/ExternalDocsValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/externaldocs/ExternalDocsValidator.kt
@@ -25,15 +25,15 @@ class ExternalDocsValidator(
         if (url.isBlank()) {
             results.error(
                 "$contextString 'url' is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::url),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#externalDocumentationObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::url),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#externalDocumentationObject",
             )
         } else {
             if (!URL.matches(url)) {
                 results.error(
                     "ExternalDoc '${contextString}' 'url' must be a valid absolute URL.",
-                    asyncApiContext.getLine(node, node::url),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#externalDocumentationObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::url),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#externalDocumentationObject",
                 )
             }
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/info/ContactValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/info/ContactValidator.kt
@@ -18,7 +18,7 @@ class ContactValidator(
         if (name.isNullOrBlank() && url.isNullOrBlank() && email.isNullOrBlank()) {
             results.warn(
                 "$contextString is defined but all its fields are empty.",
-                asyncApiContext.getLine(node, node::name)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::name),
             )
             return
         }
@@ -26,8 +26,8 @@ class ContactValidator(
             if (!URL.matches(it)) {
                 results.error(
                     "$contextString 'url' field must be a valid absolute URL.",
-                    asyncApiContext.getLine(node, node::url),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#contactObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::url),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#contactObject",
                 )
             }
         }
@@ -35,8 +35,8 @@ class ContactValidator(
             if (!EMAIL.matches(it)) {
                 results.error(
                     "$contextString 'email' field must be a valid email address.",
-                    asyncApiContext.getLine(node, node::email),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#contactObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::email),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#contactObject",
                 )
             }
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/info/InfoValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/info/InfoValidator.kt
@@ -38,8 +38,8 @@ class InfoValidator(
         if (title.isBlank()) {
             results.error(
                 "$contextString 'title' field is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::title),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#infoObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::title),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#infoObject",
             )
         }
     }
@@ -49,15 +49,15 @@ class InfoValidator(
         if (version.isBlank()) {
             results.error(
                 "$contextString 'version' field is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::version),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#infoObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::version),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#infoObject",
             )
             return
         }
         if (!SEMANTIC_VERSION.matches(version)) {
             results.warn(
                 "$contextString 'version' field contains unusual characters. Expected Semantic Versioning or alphanumeric format.",
-                asyncApiContext.getLine(node, node::version)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::version),
             )
         }
     }
@@ -67,8 +67,8 @@ class InfoValidator(
         if (!URL.matches(termsOfService)) {
             results.error(
                 "$contextString 'termsOfService' field must be a valid absolute URL. Got '$termsOfService'.",
-                asyncApiContext.getLine(node, node::termsOfService),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#infoObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::termsOfService),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#infoObject",
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/info/LicenseValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/info/LicenseValidator.kt
@@ -15,8 +15,8 @@ class LicenseValidator(
         if (name.isBlank()) {
             results.error(
                 "$contextString 'name' field is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::name),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#licenseObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::name),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#licenseObject",
             )
         }
         val url = node.url?.let(::sanitizeString)
@@ -25,8 +25,8 @@ class LicenseValidator(
             if (!URL.matches(url)) {
                 results.error(
                     "$contextString 'url' field must be a valid absolute URL.",
-                    asyncApiContext.getLine(node, node::url),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#licenseObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::url),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#licenseObject",
                 )
             }
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidator.kt
@@ -56,7 +56,7 @@ class MessageTraitValidator(
             results.warn(
                 "$contextString provides neither 'headers', 'bindings', 'correlationId', nor 'contentType'" +
                     " — it might not have any effect.",
-                asyncApiContext.getLine(node, node::headers),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::headers),
             )
         }
     }
@@ -87,8 +87,8 @@ class MessageTraitValidator(
         if (!MIME_TYPE.matches(contentType)) {
             results.error(
                 "$contextString invalid 'contentType' value '$contentType'. Expected a valid MIME type, e.g., 'application/json'.",
-                asyncApiContext.getLine(node, node::contentType),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#messageTraitObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::contentType),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#messageTraitObject",
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageValidator.kt
@@ -68,7 +68,7 @@ class MessageValidator(
                 is SchemaInterface.MultiFormatSchemaInline -> {
                     results.warn(
                         "$contextString MultiFormatSchema in headers are not validated (header '$headerName').",
-                        asyncApiContext.getLine(node, node::headers),
+                        sourceLocation = asyncApiContext.getSourceLocation(node, node::headers),
                     )
                 }
 

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationReplyAddressValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationReplyAddressValidator.kt
@@ -33,15 +33,15 @@ class OperationReplyAddressValidator(
         if (location.isBlank()) {
             results.error(
                 "$contextString 'location' is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::location),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyAddressObject"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::location),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyAddressObject",
             )
             return
         }
         if (!RUNTIME_EXPRESSION_GENERAL.matches(location)) {
             results.warn(
                 "$contextString 'location' ('$location') does not appear to follow a valid runtime expression format.",
-                asyncApiContext.getLine(node, node::location)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::location),
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationReplyValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationReplyValidator.kt
@@ -53,7 +53,7 @@ class OperationReplyValidator(
         if (messages.isEmpty()) {
             results.warn(
                 "$operationReplyName 'messages' is an empty list — omit it if unused.",
-                asyncApiContext.getLine(node, node::messages)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::messages),
             )
             return
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationValidator.kt
@@ -57,14 +57,14 @@ class OperationValidator(
         if (action.isBlank()) {
             results.error(
                 "$contextString must define an 'action' field ('send' or 'receive').",
-                asyncApiContext.getLine(node, node::action),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::action),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
             )
         } else if (action != "send" && action != "receive") {
             results.error(
                 "$contextString has invalid action '$action'. Allowed values are 'send' or 'receive'.",
-                asyncApiContext.getLine(node, node::action),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::action),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
             )
         }
     }
@@ -74,18 +74,19 @@ class OperationValidator(
         if (channelRef == null) {
             results.error(
                 "$contextString must define a 'channel' reference.",
-                asyncApiContext.getLine(node, node::channel),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::channel),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
             )
             return
         }
+        val channelRefSourceLocation = asyncApiContext.getSourceLocation(channelRef, channelRef::ref)
         referenceResolver.resolve(channelRef, "Channel", results)
         if (channelRef.model != null && channelRef.model !is Channel) {
             val invalidObject = channelRef.model?.javaClass?.simpleName
             results.error(
                 "$contextString channel reference must point to a Channel Object. Found: $invalidObject.",
-                asyncApiContext.getLine(channelRef, channelRef::ref),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
+                sourceLocation = channelRefSourceLocation,
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
             )
         }
     }
@@ -98,8 +99,8 @@ class OperationValidator(
             if (referenceString.isBlank()) {
                 results.error(
                     "$contextString 'messages' property value MUST be a list of Reference Objects.",
-                    asyncApiContext.getLine(node, node::messages),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::messages),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
                 )
             } else {
                 referenceResolver.resolve(messageReference, contextString, results)
@@ -137,8 +138,8 @@ class OperationValidator(
         if (node.bindings == null && node.security == null && node.tags == null) {
             results.warn(
                 "$contextString defines no 'bindings', 'security', or 'tags' — may have no effect.",
-                asyncApiContext.getLine(node, node::bindings),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::bindings),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject",
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/parameters/ParameterValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/parameters/ParameterValidator.kt
@@ -35,7 +35,7 @@ class ParameterValidator(
         if (enum.distinct().size != enum.size) {
             results.warn(
                 "$contextString 'enum' contains duplicate values.",
-                asyncApiContext.getLine(node, node::enum),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::enum),
             )
         }
     }
@@ -46,7 +46,7 @@ class ParameterValidator(
         if (!enum.contains(default)) {
             results.error(
                 "$contextString 'default' value ('$default') is not included in the allowed enum values.",
-                asyncApiContext.getLine(node, node::default),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::default),
             )
         }
     }
@@ -57,7 +57,7 @@ class ParameterValidator(
         if (enum != null && examples.any { it !in enum }) {
             results.warn(
                 "$contextString 'examples' are not part of the defined enum values.",
-                asyncApiContext.getLine(node, node::examples),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::examples),
             )
         }
     }
@@ -68,8 +68,8 @@ class ParameterValidator(
             results.error(
                 $$"$$contextString invalid 'location' expression '$$location'. Must be a valid " +
                     $$"runtime expression (e.g., $message.header#/param).",
-                asyncApiContext.getLine(node, node::location),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#parameterObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::location),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#parameterObject",
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/schemas/SchemaValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/schemas/SchemaValidator.kt
@@ -76,8 +76,8 @@ class SchemaValidator(
                 if (type.lowercase() !in allowedTypes) {
                     results.error(
                         "$contextString type '$type' is not valid. Must be one of: ${allowedTypes.joinToString()}",
-                        asyncApiContext.getLine(node, node::type),
-                        "https://www.learnjsonschema.com/draft7/validation/type/",
+                        sourceLocation = asyncApiContext.getSourceLocation(node, node::type),
+                        doc = "https://www.learnjsonschema.com/draft7/validation/type/",
                     )
                 }
             }
@@ -87,8 +87,8 @@ class SchemaValidator(
                 if (typeList.size != type.size) {
                     results.error(
                         "$contextString all elements in 'type' array must be strings. Found non-string elements.",
-                        asyncApiContext.getLine(node, node::type),
-                        "https://www.learnjsonschema.com/draft7/validation/type/",
+                        sourceLocation = asyncApiContext.getSourceLocation(node, node::type),
+                        doc = "https://www.learnjsonschema.com/draft7/validation/type/",
                     )
                 }
                 val invalidTypes = typeList.filter { it !in allowedTypes }
@@ -96,8 +96,8 @@ class SchemaValidator(
                     results.error(
                         "$contextString types ${invalidTypes.joinToString()} are not valid. Must be one " +
                             "of: ${allowedTypes.joinToString()}",
-                        asyncApiContext.getLine(node, node::type),
-                        "https://www.learnjsonschema.com/draft7/validation/type/",
+                        sourceLocation = asyncApiContext.getSourceLocation(node, node::type),
+                        doc = "https://www.learnjsonschema.com/draft7/validation/type/",
                     )
                 }
             }
@@ -106,8 +106,8 @@ class SchemaValidator(
                 val invalidType = type::class.simpleName
                 results.error(
                     "$contextString 'type' field must be a string or an array of strings. Found: $invalidType",
-                    asyncApiContext.getLine(node, node::type),
-                    "https://www.learnjsonschema.com/draft7/validation/type/",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::type),
+                    doc = "https://www.learnjsonschema.com/draft7/validation/type/",
                 )
             }
         }
@@ -118,15 +118,15 @@ class SchemaValidator(
         if (enum.isEmpty()) {
             results.error(
                 "$contextString 'enum' must be a non-empty array of unique values.",
-                asyncApiContext.getLine(node, node::enum),
-                "https://www.learnjsonschema.com/draft7/validation/enum/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::enum),
+                doc = "https://www.learnjsonschema.com/draft7/validation/enum/",
             )
         }
         if (enum.distinct().size != enum.size) {
             results.warn(
                 "$contextString 'enum' contains duplicate values.",
-                asyncApiContext.getLine(node, node::enum),
-                "https://www.learnjsonschema.com/draft7/validation/enum/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::enum),
+                doc = "https://www.learnjsonschema.com/draft7/validation/enum/",
             )
         }
     }
@@ -137,8 +137,8 @@ class SchemaValidator(
         if (!isDefaultCompatible(const, type)) {
             results.error(
                 "$schemaName 'const' value '$const' does not match declared type '$type'.",
-                asyncApiContext.getLine(node, node::const),
-                "https://www.learnjsonschema.com/draft7/validation/const/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::const),
+                doc = "https://www.learnjsonschema.com/draft7/validation/const/",
             )
         }
     }
@@ -152,43 +152,43 @@ class SchemaValidator(
         if (minimum != null && maximum != null && minimum > maximum) {
             results.error(
                 "$contextString 'minimum' ($minimum) cannot be greater than 'maximum' ($maximum).",
-                asyncApiContext.getLine(node, node::minimum),
-                "https://www.learnjsonschema.com/draft7/validation/minimum/, " +
-                    "https://www.learnjsonschema.com/draft7/validation/maximum/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::minimum),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minimum/, " +
+                    "https://www.learnjsonschema.com/draft7/validation/maximum/",
             )
         }
         if (exclusiveMinimum != null && exclusiveMaximum != null && exclusiveMinimum > exclusiveMaximum) {
             results.error(
                 "$contextString 'exclusiveMinimum' ($exclusiveMinimum) cannot be greater than " +
                     "'exclusiveMaximum' ($exclusiveMaximum).",
-                asyncApiContext.getLine(node, node::exclusiveMinimum),
-                "https://www.learnjsonschema.com/draft7/validation/exclusiveminimum/, " +
-                    "https://www.learnjsonschema.com/draft7/validation/exclusivemaximum/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::exclusiveMinimum),
+                doc = "https://www.learnjsonschema.com/draft7/validation/exclusiveminimum/, " +
+                    "https://www.learnjsonschema.com/draft7/validation/exclusivemaximum/",
             )
         }
         // Warn when both inclusive and exclusive bounds are present.
         if (minimum != null && node.exclusiveMinimum != null) {
             results.warn(
                 "$contextString defines both 'minimum' and 'exclusiveMinimum'. only 'minimum' will be used.",
-                asyncApiContext.getLine(node, node::exclusiveMinimum),
-                "https://www.learnjsonschema.com/draft7/validation/minimum/, " +
-                    "https://www.learnjsonschema.com/draft7/validation/exclusiveminimum/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::exclusiveMinimum),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minimum/, " +
+                    "https://www.learnjsonschema.com/draft7/validation/exclusiveminimum/",
             )
         }
         if (maximum != null && node.exclusiveMaximum != null) {
             results.warn(
                 "$contextString defines both 'maximum' and 'exclusiveMaximum'. only 'maximum' will be used.",
-                asyncApiContext.getLine(node, node::exclusiveMaximum),
-                "https://www.learnjsonschema.com/draft7/validation/maximum/, " +
-                    "https://www.learnjsonschema.com/draft7/validation/exclusivemaximum/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::exclusiveMaximum),
+                doc = "https://www.learnjsonschema.com/draft7/validation/maximum/, " +
+                    "https://www.learnjsonschema.com/draft7/validation/exclusivemaximum/",
             )
         }
         node.multipleOf?.let {
             if (it.toDouble() <= 0.0) {
                 results.error(
                     "$contextString 'multipleOf' must be greater than zero.",
-                    asyncApiContext.getLine(node, node::multipleOf),
-                    "https://www.learnjsonschema.com/draft7/validation/multipleof/"
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::multipleOf),
+                    doc = "https://www.learnjsonschema.com/draft7/validation/multipleof/",
                 )
             }
         }
@@ -201,22 +201,22 @@ class SchemaValidator(
         if (min < 0) {
             results.error(
                 "$contextString 'minLength' ($min) cannot be a negative value.",
-                asyncApiContext.getLine(node, node::minLength),
-                "https://www.learnjsonschema.com/draft7/validation/minlength/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::minLength),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minlength/",
             )
         }
         if (max < 0) {
             results.error(
                 "$contextString 'maxLength' ($max) cannot be a negative value.",
-                asyncApiContext.getLine(node, node::maxLength),
-                "https://www.learnjsonschema.com/draft7/validation/maxlength/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::maxLength),
+                doc = "https://www.learnjsonschema.com/draft7/validation/maxlength/",
             )
         }
         if (min > max) {
             results.error(
                 "$contextString 'minLength' ($min) cannot be greater than 'maxLength' ($max).",
-                asyncApiContext.getLine(node, node::minLength),
-                "https://www.learnjsonschema.com/draft7/validation/minlength/, " +
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::minLength),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minlength/, " +
                     "https://www.learnjsonschema.com/draft7/validation/maxlength/",
             )
         }
@@ -229,7 +229,7 @@ class SchemaValidator(
         } catch (ex: Exception) {
             results.error(
                 "$contextString invalid regex pattern in 'pattern': $pattern (${ex.message})",
-                asyncApiContext.getLine(node, node::pattern),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::pattern),
             )
         }
     }
@@ -241,23 +241,23 @@ class SchemaValidator(
         if (minItems < 0) {
             results.error(
                 "$contextString 'minItems' ($minItems) cannot be a negative value.",
-                asyncApiContext.getLine(node, node::minItems),
-                "https://www.learnjsonschema.com/draft7/validation/minitems/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::minItems),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minitems/",
             )
         }
         if (maxItems < 0) {
             results.error(
                 "$contextString 'maxItems' ($maxItems) cannot be a negative value.",
-                asyncApiContext.getLine(node, node::maxItems),
-                "https://www.learnjsonschema.com/draft7/validation/maxitems/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::maxItems),
+                doc = "https://www.learnjsonschema.com/draft7/validation/maxitems/",
             )
         }
         if (minItems > maxItems) {
             results.error(
                 "$contextString 'minItems' ($minItems) cannot be greater than 'maxItems' ($maxItems).",
-                asyncApiContext.getLine(node, node::minItems),
-                "https://www.learnjsonschema.com/draft7/validation/minitems/, " +
-                    "https://www.learnjsonschema.com/draft7/validation/maxitems/"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::minItems),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minitems/, " +
+                    "https://www.learnjsonschema.com/draft7/validation/maxitems/",
             )
         }
     }
@@ -268,22 +268,22 @@ class SchemaValidator(
         if (minProps != null && minProps < 0) {
             results.error(
                 "$contextString 'minProperties' ($minProps) cannot be a negative value.",
-                asyncApiContext.getLine(node, node::minProperties),
-                "https://www.learnjsonschema.com/draft7/validation/minproperties/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::minProperties),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minproperties/",
             )
         }
         if (maxProps != null && maxProps < 0) {
             results.error(
                 "$contextString 'maxProperties' ($maxProps) cannot be a negative value.",
-                asyncApiContext.getLine(node, node::maxProperties),
-                "https://www.learnjsonschema.com/draft7/validation/maxproperties/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::maxProperties),
+                doc = "https://www.learnjsonschema.com/draft7/validation/maxproperties/",
             )
         }
         if (minProps != null && maxProps != null && minProps > maxProps) {
             results.error(
                 "$contextString 'minProperties' ($minProps) cannot be greater than 'maxProperties' ($maxProps).",
-                asyncApiContext.getLine(node, node::minProperties),
-                "https://www.learnjsonschema.com/draft7/validation/minproperties/, " +
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::minProperties),
+                doc = "https://www.learnjsonschema.com/draft7/validation/minproperties/, " +
                     "https://www.learnjsonschema.com/draft7/validation/maxproperties/",
             )
         }
@@ -294,7 +294,7 @@ class SchemaValidator(
                 if (schema != null && schema.defaultSet && schema.default == null) {
                     results.error(
                         "$contextString property '$propName' is required but has default: null.",
-                        asyncApiContext.getLine(schema, schema::default),
+                        sourceLocation = asyncApiContext.getSourceLocation(schema, schema::default),
                     )
                 }
             }
@@ -302,15 +302,15 @@ class SchemaValidator(
         if (required.isEmpty()) {
             results.warn(
                 "$contextString defines an empty 'required' list — omit it if unused.",
-                asyncApiContext.getLine(node, node::required),
-                "https://www.learnjsonschema.com/draft7/validation/required/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::required),
+                doc = "https://www.learnjsonschema.com/draft7/validation/required/",
             )
         }
         if (required.distinct().size != required.size) {
             results.error(
                 "$contextString 'required' contains duplicate property names.",
-                asyncApiContext.getLine(node, node::required),
-                "https://www.learnjsonschema.com/draft7/validation/required/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::required),
+                doc = "https://www.learnjsonschema.com/draft7/validation/required/",
             )
         }
         val definedProperties = node.properties?.keys ?: emptySet()
@@ -321,8 +321,8 @@ class SchemaValidator(
             results.warn(
                 "$contextString lists required properties $missing that are not defined in 'properties'. Ensure " +
                     "they are defined in 'allOf' or 'additionalProperties', otherwise generation may fail.",
-                asyncApiContext.getLine(node, node::required),
-                "https://www.learnjsonschema.com/draft7/validation/required/",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::required),
+                doc = "https://www.learnjsonschema.com/draft7/validation/required/",
             )
         }
     }
@@ -333,7 +333,7 @@ class SchemaValidator(
             results.warn(
                 "$contextString uses multiple composition keywords ('allOf', 'anyOf', 'oneOf'). This can lead to " +
                     "ambiguous validation behavior.",
-                asyncApiContext.getLine(node, node::allOf),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::allOf),
             )
         }
     }
@@ -344,7 +344,7 @@ class SchemaValidator(
         if (!isDefaultCompatible(default, type)) {
             results.error(
                 "$contextString default value '$default' does not match declared type '$type'.",
-                asyncApiContext.getLine(node, node::default),
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::default),
             )
         }
     }
@@ -357,8 +357,8 @@ class SchemaValidator(
             if (!it) {
                 results.error(
                     "$contextString discriminator property '$discriminator' must be listed in 'required'.",
-                    asyncApiContext.getLine(node, node::discriminator),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#schemaObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::discriminator),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#schemaObject",
                 )
             }
         }
@@ -366,8 +366,8 @@ class SchemaValidator(
             if (!it) {
                 results.error(
                     "$contextString discriminator property '$discriminator' must exist in 'properties'.",
-                    asyncApiContext.getLine(node, node::discriminator),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#schemaObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::discriminator),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#schemaObject",
                 )
             }
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/security/SecuritySchemeValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/security/SecuritySchemeValidator.kt
@@ -40,14 +40,14 @@ class SecuritySchemeValidator(
         if (type.isBlank()) {
             results.error(
                 "$contextString 'type' field in SecurityScheme is required.",
-                asyncApiContext.getLine(node, node::type),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::type),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
             )
         } else if (type !in validTypes) {
             results.error(
                 "$contextString invalid type '$type'. Expected one of: ${validTypes.joinToString(", ")}",
-                asyncApiContext.getLine(node, node::type),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::type),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
             )
         }
     }
@@ -58,8 +58,8 @@ class SecuritySchemeValidator(
         if (type == "httpApiKey" && name.isNullOrBlank()) {
             results.error(
                 "$contextString of type 'httpApiKey' requires non-empty 'name'.",
-                asyncApiContext.getLine(node, node::name),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::name),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
             )
         }
     }
@@ -75,8 +75,8 @@ class SecuritySchemeValidator(
         if (inField !in validInValues) {
             results.error(
                 "$contextString invalid 'in' value '$inField' for type '$type'. Expected one of: ${validInValues.joinToString(", ")}",
-                asyncApiContext.getLine(node, node::inField),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::inField),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
             )
         }
     }
@@ -87,8 +87,8 @@ class SecuritySchemeValidator(
         if (type == "http" && scheme.isNullOrBlank()) {
             results.error(
                 "$contextString of type 'http' requires non-empty 'scheme'.",
-                asyncApiContext.getLine(node, node::scheme),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::scheme),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
             )
         }
     }
@@ -99,7 +99,7 @@ class SecuritySchemeValidator(
         if (type == "http" && node.scheme == "bearer" && bearerFormat.isNullOrBlank()) {
             results.warn(
                 "$contextString of type 'http' with scheme 'bearer' has an empty 'bearerFormat'.",
-                asyncApiContext.getLine(node, node::bearerFormat)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::bearerFormat),
             )
         }
     }
@@ -112,8 +112,8 @@ class SecuritySchemeValidator(
                 results.error(
                     "$contextString of type 'oauth2' requires at least one OAuth2 flow (implicit, password, " +
                         "clientCredentials, or authorizationCode).",
-                    asyncApiContext.getLine(node, node::flows),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::flows),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
                 )
                 return
             }
@@ -125,8 +125,8 @@ class SecuritySchemeValidator(
             ) {
                 results.error(
                     "$contextString of type 'oauth2' requires at least one OAuth2 flow.",
-                    asyncApiContext.getLine(node, node::flows),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::flows),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
                 )
             }
         }
@@ -140,16 +140,16 @@ class SecuritySchemeValidator(
             if (url.isNullOrBlank()) {
                 results.error(
                     "$contextString of type 'openIdConnect' must provide a valid absolute 'openIdConnectUrl'.",
-                    asyncApiContext.getLine(node, node::openIdConnectUrl),
-                    "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::openIdConnectUrl),
+                    doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
                 )
             } else {
                 if (!URL.matches(url)) {
                     results.error(
                         "$contextString of type 'openIdConnect' must provide a valid absolute 'openIdConnectUrl'. " +
                             "Got '$url'.",
-                        asyncApiContext.getLine(node, node::openIdConnectUrl),
-                        "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
+                        sourceLocation = asyncApiContext.getSourceLocation(node, node::openIdConnectUrl),
+                        doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject",
                     )
                 }
             }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/servers/ServerValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/servers/ServerValidator.kt
@@ -54,22 +54,22 @@ class ServerValidator(
         if (host.isBlank()) {
             results.error(
                 "$contextString must define a non-empty 'host'.",
-                asyncApiContext.getLine(node, node::host),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::host),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject",
             )
         } else {
             if (host.startsWith("http://") || host.startsWith("https://")) {
                 results.warn(
                     "$contextString host '$host' includes scheme/protocol. 'host' should typically be the hostname " +
                         "(e.g. api.example.com) as protocol is defined separately.",
-                    asyncApiContext.getLine(node, node::host)
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::host),
                 )
             }
             if (!HOSTNAME.matches(host)) {
                 results.warn(
                     "$contextString host '$host' looks unusual. Expected format 'hostname[:port]' or URL with " +
                         "variables/path. Found invalid characters.",
-                    asyncApiContext.getLine(node, node::host)
+                    sourceLocation = asyncApiContext.getSourceLocation(node, node::host),
                 )
             }
         }
@@ -83,8 +83,8 @@ class ServerValidator(
         if (missing.isNotEmpty()) {
             results.error(
                 "$contextString host uses variables $missing which are not defined in 'variables'.",
-                asyncApiContext.getLine(node, node::host),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::host),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject",
             )
         }
 
@@ -92,7 +92,7 @@ class ServerValidator(
         if (unused.isNotEmpty()) {
             results.warn(
                 "$contextString defines variables $unused which are not used in the host '$host'.",
-                asyncApiContext.getLine(node, node::variables)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::variables),
             )
         }
     }
@@ -102,8 +102,8 @@ class ServerValidator(
         if (protocol.isBlank()) {
             results.error(
                 "$contextString must define the 'protocol' it supports.",
-                asyncApiContext.getLine(node, node::protocol),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::protocol),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject",
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/servers/ServerVariableValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/servers/ServerVariableValidator.kt
@@ -20,7 +20,7 @@ class ServerVariableValidator(
         if (enum.distinct().size != enum.size) {
             results.warn(
                 "$contextString 'enum' contains duplicate values.",
-                asyncApiContext.getLine(node, node::enum)
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::enum),
             )
         }
     }
@@ -31,16 +31,16 @@ class ServerVariableValidator(
         if (default == null) {
             results.error(
                 "$contextString must specify a 'default' value.",
-                asyncApiContext.getLine(node, node::default),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::default),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
             )
             return
         }
         if (enum != null && !enum.contains(default)) {
             results.error(
                 "$contextString 'default' ('$default') is not one of the allowed enum values.",
-                asyncApiContext.getLine(node, node::default),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::default),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
             )
         }
     }
@@ -50,16 +50,16 @@ class ServerVariableValidator(
         if (examples.isEmpty()) {
             results.warn(
                 "$contextString 'examples' list is empty — omit it if unused.",
-                asyncApiContext.getLine(node, node::examples),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::examples),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
             )
         }
         val enum = node.enum?.map { enum -> enum.let(::sanitizeString) }
         if (enum != null && examples.any { it !in enum }) {
             results.warn(
                 "$contextString, some 'examples' values are not included in the allowed enum values.",
-                asyncApiContext.getLine(node, node::examples),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::examples),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverVariableObject",
             )
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/tags/TagValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/tags/TagValidator.kt
@@ -28,8 +28,8 @@ class TagValidator(
         if (name.isBlank()) {
             results.error(
                 "$contextString 'name' is required and cannot be empty.",
-                asyncApiContext.getLine(node, node::name),
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#tagObject"
+                sourceLocation = asyncApiContext.getSourceLocation(node, node::name),
+                doc = "https://www.asyncapi.com/docs/reference/specification/v3.0.0#tagObject",
             )
         }
         validateExternalDocs(node, contextString, results)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationFindingFormatter.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationFindingFormatter.kt
@@ -1,0 +1,41 @@
+package dev.banking.asyncapi.generator.core.validator.util
+
+import dev.banking.asyncapi.generator.core.context.AsyncApiContext
+import dev.banking.asyncapi.generator.core.model.validator.ValidationFinding
+
+/**
+ * Formats validation findings for exceptions and logs.
+ *
+ * Expected behavior is covered by:
+ * - `ValidationResultsTest`
+ * - validator package tests
+ */
+object ValidationFindingFormatter {
+
+    fun format(
+        title: String,
+        findings: List<ValidationFinding>,
+        asyncApiContext: AsyncApiContext,
+    ): String = buildString {
+        appendLine(title)
+        appendLine()
+        findings.forEach { finding ->
+            appendLine(">> ${finding.message}")
+            appendLine()
+            appendLine(snippet(finding, asyncApiContext))
+            appendLine()
+            if (finding.doc != null) appendLine("See documentation: ${finding.doc}")
+            appendLine("---------------------------------------------------------------------------------------------------------------------")
+            appendLine()
+        }
+    }
+
+    private fun snippet(
+        finding: ValidationFinding,
+        asyncApiContext: AsyncApiContext,
+    ): String {
+        finding.sourceLocation?.let { return asyncApiContext.sourceSnippet(it) }
+        finding.path?.let { return asyncApiContext.pathSnippet(it) }
+        return "(no source location available)"
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResults.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResults.kt
@@ -3,9 +3,20 @@ package dev.banking.asyncapi.generator.core.validator.util
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
 import dev.banking.asyncapi.generator.core.model.validator.ValidationError
+import dev.banking.asyncapi.generator.core.model.validator.ValidationFinding
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.model.validator.ValidationWarning
+import dev.banking.asyncapi.generator.core.reader.SourceLocation
 import org.slf4j.LoggerFactory
 
+/**
+ * Collects validation findings produced by the validator stage.
+ *
+ * Expected behavior is covered by:
+ * - `ValidationResultsTest`
+ * - validator package tests
+ */
 class ValidationResults(
     val asyncApiContext: AsyncApiContext,
 ) {
@@ -13,16 +24,48 @@ class ValidationResults(
 
     private val _errors = mutableListOf<ValidationError>()
     private val _warnings = mutableListOf<ValidationWarning>()
+    private val _findings = mutableListOf<ValidationFinding>()
 
     val errors: List<ValidationError> get() = _errors
     val warnings: List<ValidationWarning> get() = _warnings
+    val findings: List<ValidationFinding> get() = _findings
 
-    fun error(message: String, line: Int? = null, doc: String? = null) {
-        _errors += ValidationError(message, line, doc)
+    fun error(
+        message: String,
+        line: Int? = null,
+        doc: String? = null,
+        sourceLocation: SourceLocation? = null,
+        path: String? = sourceLocation?.path,
+    ) {
+        val finding = ValidationFinding(
+            severity = ERROR,
+            message = message,
+            sourceLocation = sourceLocation,
+            path = path,
+            line = line ?: sourceLocation?.line,
+            doc = doc,
+        )
+        _findings += finding
+        _errors += ValidationError(message, finding.line, doc)
     }
 
-    fun warn(message: String, line: Int? = null, doc: String? = null) {
-        _warnings += ValidationWarning(message, line, doc)
+    fun warn(
+        message: String,
+        line: Int? = null,
+        doc: String? = null,
+        sourceLocation: SourceLocation? = null,
+        path: String? = sourceLocation?.path,
+    ) {
+        val finding = ValidationFinding(
+            severity = WARNING,
+            message = message,
+            sourceLocation = sourceLocation,
+            path = path,
+            line = line ?: sourceLocation?.line,
+            doc = doc,
+        )
+        _findings += finding
+        _warnings += ValidationWarning(message, finding.line, doc)
     }
 
     fun hasErrors() = _errors.isNotEmpty()

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResults.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResults.kt
@@ -2,12 +2,11 @@ package dev.banking.asyncapi.generator.core.validator.util
 
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
-import dev.banking.asyncapi.generator.core.model.validator.ValidationError
 import dev.banking.asyncapi.generator.core.model.validator.ValidationFinding
 import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
 import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
-import dev.banking.asyncapi.generator.core.model.validator.ValidationWarning
 import dev.banking.asyncapi.generator.core.reader.SourceLocation
+import dev.banking.asyncapi.generator.core.validator.util.ValidationFindingFormatter.format
 import org.slf4j.LoggerFactory
 
 /**
@@ -22,12 +21,10 @@ class ValidationResults(
 ) {
     private val logger = LoggerFactory.getLogger(ValidationResults::class.java)
 
-    private val _errors = mutableListOf<ValidationError>()
-    private val _warnings = mutableListOf<ValidationWarning>()
     private val _findings = mutableListOf<ValidationFinding>()
 
-    val errors: List<ValidationError> get() = _errors
-    val warnings: List<ValidationWarning> get() = _warnings
+    val errors: List<ValidationFinding> get() = _findings.filter { it.severity == ERROR }
+    val warnings: List<ValidationFinding> get() = _findings.filter { it.severity == WARNING }
     val findings: List<ValidationFinding> get() = _findings
 
     fun error(
@@ -46,7 +43,6 @@ class ValidationResults(
             doc = doc,
         )
         _findings += finding
-        _errors += ValidationError(message, finding.line, doc)
     }
 
     fun warn(
@@ -65,35 +61,28 @@ class ValidationResults(
             doc = doc,
         )
         _findings += finding
-        _warnings += ValidationWarning(message, finding.line, doc)
     }
 
-    fun hasErrors() = _errors.isNotEmpty()
+    fun hasErrors() = errors.isNotEmpty()
 
-    fun hasWarnings() = _warnings.isNotEmpty()
+    fun hasWarnings() = warnings.isNotEmpty()
 
     fun throwErrors() {
-        if (_errors.isNotEmpty()) {
-            throw AsyncApiValidateException.ValidateError(_errors, asyncApiContext)
+        val errors = errors
+        if (errors.isNotEmpty()) {
+            throw AsyncApiValidateException.ValidateError(errors, asyncApiContext)
         }
     }
 
     fun logWarnings() {
-        if (_warnings.isNotEmpty()) {
+        val warnings = warnings
+        if (warnings.isNotEmpty()) {
             logger.warn(
-                buildString {
-                    appendLine("Validation found ${_warnings.size} warning(s):")
-                    appendLine()
-                    _warnings.forEach { warning ->
-                        appendLine(">> ${warning.message}")
-                        appendLine()
-                        appendLine(asyncApiContext.validatorSnippet(warning.line ?: -1))
-                        appendLine()
-                        if (warning.doc != null) appendLine("See documentation: ${warning.doc}")
-                        appendLine("---------------------------------------------------------------------------------------------------------------------")
-                        appendLine()
-                    }
-                }
+                format(
+                    title = "Validation found ${warnings.size} warning(s):",
+                    findings = warnings,
+                    asyncApiContext = asyncApiContext,
+                )
             )
         }
     }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/AbstractValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/AbstractValidatorTest.kt
@@ -3,6 +3,12 @@ package dev.banking.asyncapi.generator.core.validator
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.fixtures.ValidatorFixtures
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+import dev.banking.asyncapi.generator.core.model.validator.ValidationFinding
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity
+import dev.banking.asyncapi.generator.core.validator.util.ValidationResults
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.fail
 
 abstract class AbstractValidatorTest {
 
@@ -17,5 +23,42 @@ abstract class AbstractValidatorTest {
      */
     protected fun parse(path: String): AsyncApiDocument {
         return validatorFixtures.document(path)
+    }
+
+    protected fun validate(path: String): ValidationResults {
+        return validatorFixtures.validate(path)
+    }
+
+    protected fun assertNoFindings(results: ValidationResults) {
+        assertFalse(results.hasErrors(), "Found validation errors: ${results.errors}")
+        assertFalse(results.hasWarnings(), "Found validation warnings: ${results.warnings}")
+        assertEquals(emptyList(), results.findings, "Found validation findings: ${results.findings}")
+    }
+
+    protected fun assertFinding(
+        results: ValidationResults,
+        severity: ValidationSeverity,
+        messageContains: String,
+        sourceFile: String? = null,
+        path: String? = null,
+        line: Int? = null,
+    ): ValidationFinding {
+        val finding = results.findings.singleOrNull { finding ->
+            finding.severity == severity && finding.message.contains(messageContains)
+        } ?: fail(
+            "Expected one $severity finding containing '$messageContains', " +
+                "but found: ${results.findings}"
+        )
+
+        if (sourceFile != null) {
+            assertEquals(sourceFile, finding.sourceLocation?.file?.name)
+        }
+        if (path != null) {
+            assertEquals(path, finding.path)
+        }
+        if (line != null) {
+            assertEquals(line, finding.line)
+        }
+        return finding
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/AbstractValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/AbstractValidatorTest.kt
@@ -44,7 +44,11 @@ abstract class AbstractValidatorTest {
         line: Int? = null,
     ): ValidationFinding {
         val finding = results.findings.singleOrNull { finding ->
-            finding.severity == severity && finding.message.contains(messageContains)
+            finding.severity == severity &&
+                finding.message.contains(messageContains) &&
+                (sourceFile == null || finding.sourceLocation?.file?.name == sourceFile) &&
+                (path == null || finding.path == path) &&
+                (line == null || finding.line == line)
         } ?: fail(
             "Expected one $severity finding containing '$messageContains', " +
                 "but found: ${results.findings}"

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/asyncapi/AsyncApiValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/asyncapi/AsyncApiValidatorTest.kt
@@ -2,7 +2,9 @@ package dev.banking.asyncapi.generator.core.validator.asyncapi
 
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
+import dev.banking.asyncapi.generator.core.validator.ValidationStage
 import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
 
 class AsyncApiValidatorTest : AbstractValidatorTest() {
 
@@ -14,5 +16,16 @@ class AsyncApiValidatorTest : AbstractValidatorTest() {
         val validationResults = asyncApiValidator.validate(asyncApiDocument)
         validationResults.logWarnings()
         validationResults.throwErrors()
+    }
+
+    @Test
+    fun `validates parsed document through validator stage contract`() {
+        val asyncApiDocument = parse("validator/info/asyncapi_validator_info_valid_simple.yaml")
+        val validationStage: ValidationStage = asyncApiValidator
+
+        val validationResults = validationStage.validate(asyncApiDocument)
+
+        assertFalse(validationResults.hasErrors(), "Expected no validation errors.")
+        assertFalse(validationResults.hasWarnings(), "Expected no validation warnings.")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/asyncapi/AsyncApiValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/asyncapi/AsyncApiValidatorTest.kt
@@ -1,10 +1,11 @@
 package dev.banking.asyncapi.generator.core.validator.asyncapi
 
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import dev.banking.asyncapi.generator.core.validator.ValidationStage
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFalse
+import kotlin.test.assertEquals
 
 class AsyncApiValidatorTest : AbstractValidatorTest() {
 
@@ -25,7 +26,39 @@ class AsyncApiValidatorTest : AbstractValidatorTest() {
 
         val validationResults = validationStage.validate(asyncApiDocument)
 
-        assertFalse(validationResults.hasErrors(), "Expected no validation errors.")
-        assertFalse(validationResults.hasWarnings(), "Expected no validation warnings.")
+        assertNoFindings(validationResults)
+    }
+
+    @Test
+    fun `validation findings include source locations for top level document diagnostics`() {
+        val validationResults = validate("validator/asyncapi/asyncapi_validator_document_invalid.yaml")
+
+        assertEquals(3, validationResults.errors.size)
+        assertEquals(3, validationResults.findings.size)
+
+        assertFinding(
+            validationResults,
+            severity = ERROR,
+            messageContains = "AsyncAPI version '2.6.0' is not be supported",
+            sourceFile = "asyncapi_validator_document_invalid.yaml",
+            path = "asyncapi_validator_document_invalid.root.asyncapi",
+            line = 1,
+        )
+        assertFinding(
+            validationResults,
+            severity = ERROR,
+            messageContains = "The 'id' field must conform to the URI format",
+            sourceFile = "asyncapi_validator_document_invalid.yaml",
+            path = "asyncapi_validator_document_invalid.root.id",
+            line = 2,
+        )
+        assertFinding(
+            validationResults,
+            severity = ERROR,
+            messageContains = "Invalid 'defaultContentType' format",
+            sourceFile = "asyncapi_validator_document_invalid.yaml",
+            path = "asyncapi_validator_document_invalid.root.defaultContentType",
+            line = 3,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/bindings/BindingValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/bindings/BindingValidatorTest.kt
@@ -1,5 +1,6 @@
 package dev.banking.asyncapi.generator.core.validator.bindings
 
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -18,6 +19,22 @@ class BindingValidatorTest : AbstractValidatorTest() {
 
         val warnings = results.warnings.map { it.message }
         assertEquals(3, warnings.size, "Expected 3 warnings for invalid bindings.")
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "is empty",
+            sourceFile = "asyncapi_validator_binding_invalid.yaml",
+            path = "asyncapi_validator_binding_invalid.root.components.channelBindings.EmptyBinding",
+            line = 8,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "Property 'protocol'",
+            sourceFile = "asyncapi_validator_binding_invalid.yaml",
+            path = "asyncapi_validator_binding_invalid.root.components.channelBindings.BindingWithNullProperty",
+            line = 11,
+        )
     }
 
     @Test
@@ -25,7 +42,6 @@ class BindingValidatorTest : AbstractValidatorTest() {
         val document = parse("validator/bindings/asyncapi_validator_binding_valid.yaml")
         val results = asyncApiValidator.validate(document)
 
-        assertFalse(results.hasErrors(), "Expected no errors for valid binding.")
-        assertFalse(results.hasWarnings(), "Expected no warnings for valid binding.")
+        assertNoFindings(results)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/channels/ChannelValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/channels/ChannelValidatorTest.kt
@@ -1,6 +1,8 @@
 package dev.banking.asyncapi.generator.core.validator.channels
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -21,6 +23,14 @@ class ChannelValidatorTest : AbstractValidatorTest() {
             validationResults.throwErrors()
         }
         assertEquals(1, exception.errors.size, "Expected 1 error for missing parameter definition.")
+        assertFinding(
+            validationResults,
+            severity = ERROR,
+            messageContains = "address uses parameters [userId]",
+            sourceFile = "asyncapi_validator_channel_parameter_mismatch.yaml",
+            path = "asyncapi_validator_channel_parameter_mismatch.root.channels.userUpdates.address",
+            line = 7,
+        )
     }
 
     @Test
@@ -33,6 +43,14 @@ class ChannelValidatorTest : AbstractValidatorTest() {
 
         val warnings = validationResults.warnings.map { it.message }
         assertEquals(1, warnings.size, "Expected 1 warning for unused parameter.")
+        assertFinding(
+            validationResults,
+            severity = WARNING,
+            messageContains = "defines parameters [userId]",
+            sourceFile = "asyncapi_validator_channel_unused_parameter.yaml",
+            path = "asyncapi_validator_channel_unused_parameter.root.channels.userUpdates.parameters",
+            line = 12,
+        )
     }
 
     @Test
@@ -45,5 +63,13 @@ class ChannelValidatorTest : AbstractValidatorTest() {
 
         val warnings = validationResults.warnings.map { it.message }
         assertEquals(1, warnings.size, "Expected 1 warnings.")
+        assertFinding(
+            validationResults,
+            severity = WARNING,
+            messageContains = "contains ambiguous messages",
+            sourceFile = "asyncapi_validator_channel_message_ambiguity.yaml",
+            path = "asyncapi_validator_channel_message_ambiguity.root.channels.userUpdates.messages",
+            line = 8,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/correlations/CorrelationIdValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/correlations/CorrelationIdValidatorTest.kt
@@ -1,5 +1,6 @@
 package dev.banking.asyncapi.generator.core.validator.correlations
 
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -18,13 +19,20 @@ class CorrelationIdValidatorTest : AbstractValidatorTest() {
 
         val warnings = results.warnings
         assertEquals(1, warnings.size, "Expected 1 warning.")
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "does not follow valid runtime expression",
+            sourceFile = "asyncapi_validator_correlation_invalid.yaml",
+            path = "asyncapi_validator_correlation_invalid.root.components.correlationIds.InvalidLocationRegex.location",
+            line = 10,
+        )
     }
 
     @Test
     fun `valid correlation ID passes validation`() {
         val document = parse("validator/correlations/asyncapi_validator_correlation_valid.yaml")
         val results = asyncApiValidator.validate(document)
-        assertFalse(results.hasErrors(), "Expected no errors for valid correlation ID.")
-        assertFalse(results.hasWarnings(), "Expected no warnings for valid correlation ID.")
+        assertNoFindings(results)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/externaldocs/ExternalDocsValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/externaldocs/ExternalDocsValidatorTest.kt
@@ -1,12 +1,12 @@
 package dev.banking.asyncapi.generator.core.validator.externaldocs
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 
 class ExternalDocsValidatorTest : AbstractValidatorTest() {
 
@@ -20,5 +20,13 @@ class ExternalDocsValidatorTest : AbstractValidatorTest() {
             results.throwErrors()
         }
         assertEquals(1, exception.errors.size, "Expected 1 error (invalid URL).")
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'url' must be a valid absolute URL",
+            sourceFile = "asyncapi_validator_externaldocs_invalid.yaml",
+            path = "asyncapi_validator_externaldocs_invalid.root.components.schemas.InvalidExternalDoc.externalDocs.url",
+            line = 10,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/info/InfoValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/info/InfoValidatorTest.kt
@@ -1,13 +1,12 @@
 package dev.banking.asyncapi.generator.core.validator.info
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class InfoValidatorTest : AbstractValidatorTest() {
 
@@ -18,8 +17,7 @@ class InfoValidatorTest : AbstractValidatorTest() {
         val asyncApiDocument = parse("validator/info/asyncapi_validator_info_valid_simple.yaml")
         val validationResults = asyncApiValidator.validate(asyncApiDocument)
 
-        assertFalse(validationResults.hasErrors(), "Found validation errors: ${validationResults.errors}")
-        assertFalse(validationResults.hasWarnings(), "Found validation warnings: ${validationResults.warnings}")
+        assertNoFindings(validationResults)
     }
 
     @Test
@@ -42,5 +40,39 @@ class InfoValidatorTest : AbstractValidatorTest() {
         }
 
         assertEquals(4, exception.errors.size, "Expected 4 validation errors.")
+        assertEquals(4, results.findings.size)
+
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'url' field must be a valid absolute URL",
+            sourceFile = "asyncapi_validator_info_components_invalid.yaml",
+            path = "asyncapi_validator_info_components_invalid.root.info.contact.url",
+            line = 7,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'email' field must be a valid email address",
+            sourceFile = "asyncapi_validator_info_components_invalid.yaml",
+            path = "asyncapi_validator_info_components_invalid.root.info.contact.email",
+            line = 8,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'name' field is required and cannot be empty",
+            sourceFile = "asyncapi_validator_info_components_invalid.yaml",
+            path = "asyncapi_validator_info_components_invalid.root.info.license.name",
+            line = 10,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'url' field must be a valid absolute URL",
+            sourceFile = "asyncapi_validator_info_components_invalid.yaml",
+            path = "asyncapi_validator_info_components_invalid.root.info.license.url",
+            line = 11,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/messages/MessageTraitValidatorTest.kt
@@ -1,6 +1,8 @@
 package dev.banking.asyncapi.generator.core.validator.messages
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -22,14 +24,30 @@ class MessageTraitValidatorTest : AbstractValidatorTest() {
         }
         assertEquals(1, exception.errors.size, "Expected 1 error (content type).")
         assertTrue(results.hasWarnings(), "Should have warnings.")
+
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "invalid 'contentType' value",
+            sourceFile = "asyncapi_validator_messagetrait_invalid.yaml",
+            path = "asyncapi_validator_messagetrait_invalid.root.components.messageTraits.InvalidContentType.contentType",
+            line = 10,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "provides neither 'headers', 'bindings', 'correlationId', nor 'contentType'",
+            sourceFile = "asyncapi_validator_messagetrait_invalid.yaml",
+            path = "asyncapi_validator_messagetrait_invalid.root.components.messageTraits.MeaninglessTrait",
+            line = 15,
+        )
     }
 
     @Test
     fun `message trait headers ref to component schema passes validation`() {
         val document = parse("validator/messages/asyncapi_validator_messagetrait_headers_ref_valid.yaml")
         val results = asyncApiValidator.validate(document)
-        assertFalse(results.hasErrors(), "Expected no errors for valid message trait headers ref.")
-        assertFalse(results.hasWarnings(), "Expected no warnings for valid message trait headers ref.")
+        assertNoFindings(results)
     }
 
     @Test

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/operations/OperationValidatorTest.kt
@@ -1,6 +1,7 @@
 package dev.banking.asyncapi.generator.core.validator.operations
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -19,6 +20,14 @@ class OperationValidatorTest : AbstractValidatorTest() {
             validationResults.throwErrors()
         }
         assertEquals(1, exception.errors.size, "Expected 1 error for invalid action.")
+        assertFinding(
+            validationResults,
+            severity = ERROR,
+            messageContains = "has invalid action 'invalidAction'",
+            sourceFile = "asyncapi_validator_operations_invalid_action.yaml",
+            path = "asyncapi_validator_operations_invalid_action.root.operations.testOperation.action",
+            line = 18,
+        )
     }
 
     @Test
@@ -29,6 +38,14 @@ class OperationValidatorTest : AbstractValidatorTest() {
             validationResults.throwErrors()
         }
         assertEquals(1, exception.errors.size, "Expected 1 error for broken channel reference.")
+        assertFinding(
+            validationResults,
+            severity = ERROR,
+            messageContains = "reference '#/channels/nonExistentChannel' could not be resolved",
+            sourceFile = "asyncapi_validator_operations_broken_channel_ref.yaml",
+            path = "asyncapi_validator_operations_broken_channel_ref.root.operations.testOperation.channel",
+            line = 9,
+        )
     }
 
     @Test
@@ -39,5 +56,13 @@ class OperationValidatorTest : AbstractValidatorTest() {
             validationResults.throwErrors()
         }
         assertEquals(1, exception.errors.size, "Expected 1 error: channel type mismatch.")
+        assertFinding(
+            validationResults,
+            severity = ERROR,
+            messageContains = "channel reference must point to a Channel Object",
+            sourceFile = "asyncapi_validator_operations_channel_ref_type_mismatch.yaml",
+            path = "asyncapi_validator_operations_channel_ref_type_mismatch.root.operations.testOperation.channel",
+            line = 18,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/parameters/ParameterValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/parameters/ParameterValidatorTest.kt
@@ -1,6 +1,8 @@
 package dev.banking.asyncapi.generator.core.validator.parameters
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -25,5 +27,39 @@ class ParameterValidatorTest : AbstractValidatorTest() {
         assertTrue(results.hasWarnings(), "Expected warnings for non-critical issues.")
         val warnings = results.warnings.map { it.message }
         assertEquals(2, warnings.size, "Expected 2 validation warnings.")
+        assertEquals(4, results.findings.size)
+
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'default' value ('C') is not included",
+            sourceFile = "asyncapi_validator_parameter_invalid.yaml",
+            path = "asyncapi_validator_parameter_invalid.root.components.parameters.DefaultNotInEnum.default",
+            line = 11,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "invalid 'location' expression",
+            sourceFile = "asyncapi_validator_parameter_invalid.yaml",
+            path = "asyncapi_validator_parameter_invalid.root.components.parameters.InvalidLocation.location",
+            line = 38,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "'enum' contains duplicate values",
+            sourceFile = "asyncapi_validator_parameter_invalid.yaml",
+            path = "asyncapi_validator_parameter_invalid.root.components.parameters.DuplicateEnum.enum",
+            line = 16,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "'examples' are not part of the defined enum values",
+            sourceFile = "asyncapi_validator_parameter_invalid.yaml",
+            path = "asyncapi_validator_parameter_invalid.root.components.parameters.ExampleNotInEnum.examples",
+            line = 24,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/schemas/SchemaValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/schemas/SchemaValidatorTest.kt
@@ -1,12 +1,13 @@
 package dev.banking.asyncapi.generator.core.validator.schemas
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SchemaValidatorTest : AbstractValidatorTest() {
@@ -18,8 +19,7 @@ class SchemaValidatorTest : AbstractValidatorTest() {
         val document = parse("validator/schemas/asyncapi_validator_schema_valid_simple.yaml")
         val results = asyncApiValidator.validate(document)
 
-        assertFalse(results.hasErrors(), "Expected no validation errors, found: ${results.errors}")
-        assertFalse(results.hasWarnings(), "Expected no validation warnings, found: ${results.warnings}")
+        assertNoFindings(results)
     }
 
     @Test
@@ -42,6 +42,39 @@ class SchemaValidatorTest : AbstractValidatorTest() {
             results.throwErrors()
         }
         assertEquals(3, exception.errors.size, "Expected 3 validation errors for invalid constraints.")
+    }
+
+    @Test
+    fun `schema validation findings include source locations for nested schema errors`() {
+        val results = validate("validator/schemas/asyncapi_validator_schema_invalid_constraints.yaml")
+
+        assertEquals(3, results.errors.size)
+        assertEquals(3, results.findings.size)
+
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'minimum' (10.0) cannot be greater than 'maximum' (5.0)",
+            sourceFile = "asyncapi_validator_schema_invalid_constraints.yaml",
+            path = "asyncapi_validator_schema_invalid_constraints.root.components.schemas.InvalidNumericRange.minimum",
+            line = 9,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'multipleOf' must be greater than zero",
+            sourceFile = "asyncapi_validator_schema_invalid_constraints.yaml",
+            path = "asyncapi_validator_schema_invalid_constraints.root.components.schemas.InvalidMultipleOf.multipleOf",
+            line = 14,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'minLength' (10) cannot be greater than 'maxLength' (5)",
+            sourceFile = "asyncapi_validator_schema_invalid_constraints.yaml",
+            path = "asyncapi_validator_schema_invalid_constraints.root.components.schemas.InvalidStringLength.minLength",
+            line = 18,
+        )
     }
 
     @Test
@@ -87,6 +120,30 @@ class SchemaValidatorTest : AbstractValidatorTest() {
 
         val warnings = results.warnings
         assertEquals(2, warnings.size, "Expected 2 warnings for incompatible composition values.")
+    }
+
+    @Test
+    fun `schema validation findings include source locations for nested schema warnings`() {
+        val results = validate("validator/schemas/asyncapi_validator_schema_warnings.yaml")
+
+        assertEquals(2, results.warnings.size)
+
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "uses multiple composition keywords",
+            sourceFile = "asyncapi_validator_schema_warnings.yaml",
+            path = "asyncapi_validator_schema_warnings.root.components.schemas.AmbiguousComposition.allOf",
+            line = 9,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "defines an empty 'required' list",
+            sourceFile = "asyncapi_validator_schema_warnings.yaml",
+            path = "asyncapi_validator_schema_warnings.root.components.schemas.EmptyRequiredObject.required",
+            line = 17,
+        )
     }
 
     @Test

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/security/SecuritySchemeValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/security/SecuritySchemeValidatorTest.kt
@@ -1,6 +1,8 @@
 package dev.banking.asyncapi.generator.core.validator.security
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -18,6 +20,30 @@ class SecuritySchemeValidatorTest : AbstractValidatorTest() {
         val results = asyncApiValidator.validate(document)
         val exception = assertFailsWith<AsyncApiValidateException.ValidateError> { results.throwErrors() }
         assertEquals(6, exception.errors.size, "Expected 6 validation errors.")
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "of type 'http' requires non-empty 'scheme'",
+            sourceFile = "asyncapi_validator_security_invalid.yaml",
+            path = "asyncapi_validator_security_invalid.root.components.securitySchemes.InvalidHttp",
+            line = 9,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "invalid 'in' value 'header'",
+            sourceFile = "asyncapi_validator_security_invalid.yaml",
+            path = "asyncapi_validator_security_invalid.root.components.securitySchemes.InvalidApiKey",
+            line = 24,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "invalid type 'alien_technology'",
+            sourceFile = "asyncapi_validator_security_invalid.yaml",
+            path = "asyncapi_validator_security_invalid.root.components.securitySchemes.UnknownType.type",
+            line = 36,
+        )
     }
 
     @Test
@@ -29,5 +55,21 @@ class SecuritySchemeValidatorTest : AbstractValidatorTest() {
         }
         assertEquals(1, exception.errors.size, "Expected 1 error (missing name).")
         assertTrue(results.hasWarnings(), "Should have warnings.")
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "requires non-empty 'name'",
+            sourceFile = "asyncapi_validator_security_warnings.yaml",
+            path = "asyncapi_validator_security_warnings.root.components.securitySchemes.MissingNameHttpApiKey",
+            line = 24,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "has an empty 'bearerFormat'",
+            sourceFile = "asyncapi_validator_security_warnings.yaml",
+            path = "asyncapi_validator_security_warnings.root.components.securitySchemes.MissingBearerFormat",
+            line = 8,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/servers/ServerValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/servers/ServerValidatorTest.kt
@@ -1,6 +1,8 @@
 package dev.banking.asyncapi.generator.core.validator.servers
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
@@ -24,6 +26,30 @@ class ServerValidatorTest : AbstractValidatorTest() {
         assertTrue(results.hasWarnings(), "Should have warnings.")
         val warnings = results.warnings
         assertEquals(1, warnings.size, "Expected 1 validation warning.")
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "must define the 'protocol'",
+            sourceFile = "asyncapi_validator_server_invalid.yaml",
+            path = "asyncapi_validator_server_invalid.root.servers.emptyProtocolServer.protocol",
+            line = 9,
+        )
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'default' ('staging') is not one of the allowed enum values",
+            sourceFile = "asyncapi_validator_server_invalid.yaml",
+            path = "asyncapi_validator_server_invalid.root.servers.invalidVariableServer.variables.env.default",
+            line = 23,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "includes scheme/protocol",
+            sourceFile = "asyncapi_validator_server_invalid.yaml",
+            path = "asyncapi_validator_server_invalid.root.servers.invalidHostServer.host",
+            line = 13,
+        )
     }
 
     @Test
@@ -38,5 +64,21 @@ class ServerValidatorTest : AbstractValidatorTest() {
         assertTrue(results.hasWarnings(), "Should have warnings.")
         val warnings = results.warnings
         assertEquals(1, warnings.size, "Expected 1 warning for missing variable definition.")
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "host uses variables [region]",
+            sourceFile = "asyncapi_validator_server_variable_mismatch.yaml",
+            path = "asyncapi_validator_server_variable_mismatch.root.servers.missingVariableDefServer.host",
+            line = 8,
+        )
+        assertFinding(
+            results,
+            severity = WARNING,
+            messageContains = "defines variables [region]",
+            sourceFile = "asyncapi_validator_server_variable_mismatch.yaml",
+            path = "asyncapi_validator_server_variable_mismatch.root.servers.unusedVariableServer.variables",
+            line = 16,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/tags/TagValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/tags/TagValidatorTest.kt
@@ -1,12 +1,12 @@
 package dev.banking.asyncapi.generator.core.validator.tags
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
 import dev.banking.asyncapi.generator.core.validator.AbstractValidatorTest
 import dev.banking.asyncapi.generator.core.validator.AsyncApiValidator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 
 class TagValidatorTest : AbstractValidatorTest() {
 
@@ -20,5 +20,13 @@ class TagValidatorTest : AbstractValidatorTest() {
             results.throwErrors()
         }
         assertEquals(1, exception.errors.size, "Expected 1 error (empty name).")
+        assertFinding(
+            results,
+            severity = ERROR,
+            messageContains = "'name' is required and cannot be empty",
+            sourceFile = "asyncapi_validator_tag_invalid.yaml",
+            path = "asyncapi_validator_tag_invalid.root.components.tags.InvalidTag.name",
+            line = 9,
+        )
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResultsTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResultsTest.kt
@@ -1,0 +1,80 @@
+package dev.banking.asyncapi.generator.core.validator.util
+
+import dev.banking.asyncapi.generator.core.context.AsyncApiContext
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
+import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
+import dev.banking.asyncapi.generator.core.reader.SourceLocation
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ValidationResultsTest {
+
+    @Test
+    fun `records error finding while preserving error list`() {
+        val results = ValidationResults(AsyncApiContext())
+
+        results.error(
+            message = "The 'asyncapi' field is required.",
+            line = 12,
+            doc = "https://example.com/asyncapi",
+            path = "streetlights.root.asyncapi",
+        )
+
+        val finding = results.findings.single()
+        assertEquals(ERROR, finding.severity)
+        assertEquals("The 'asyncapi' field is required.", finding.message)
+        assertEquals(12, finding.line)
+        assertEquals("https://example.com/asyncapi", finding.doc)
+        assertNull(finding.sourceLocation)
+        assertEquals("streetlights.root.asyncapi", finding.path)
+
+        val error = results.errors.single()
+        assertEquals(finding.message, error.message)
+        assertEquals(finding.line, error.line)
+        assertEquals(finding.doc, error.doc)
+    }
+
+    @Test
+    fun `records warning finding with source location while preserving warning list`() {
+        val results = ValidationResults(AsyncApiContext())
+        val sourceLocation = SourceLocation(
+            sourceId = "streetlights",
+            file = File("streetlights.yaml"),
+            path = "streetlights.root.info.id",
+            line = 8,
+            column = 5,
+        )
+
+        results.warn(
+            message = "It is recommended to use a URN.",
+            doc = "https://example.com/urn",
+            sourceLocation = sourceLocation,
+        )
+
+        val finding = results.findings.single()
+        assertEquals(WARNING, finding.severity)
+        assertEquals("It is recommended to use a URN.", finding.message)
+        assertEquals(sourceLocation, finding.sourceLocation)
+        assertEquals("streetlights.root.info.id", finding.path)
+        assertEquals(8, finding.line)
+        assertEquals("https://example.com/urn", finding.doc)
+
+        val warning = results.warnings.single()
+        assertEquals(finding.message, warning.message)
+        assertEquals(finding.line, warning.line)
+        assertEquals(finding.doc, warning.doc)
+    }
+
+    @Test
+    fun `keeps findings in validation order`() {
+        val results = ValidationResults(AsyncApiContext())
+
+        results.warn("First warning", line = 2)
+        results.error("Second error", line = 3)
+
+        assertEquals(listOf(WARNING, ERROR), results.findings.map { it.severity })
+        assertEquals(listOf("First warning", "Second error"), results.findings.map { it.message })
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResultsTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/validator/util/ValidationResultsTest.kt
@@ -1,18 +1,21 @@
 package dev.banking.asyncapi.generator.core.validator.util
 
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiValidateException
 import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.ERROR
 import dev.banking.asyncapi.generator.core.model.validator.ValidationSeverity.WARNING
 import dev.banking.asyncapi.generator.core.reader.SourceLocation
 import org.junit.jupiter.api.Test
 import java.io.File
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class ValidationResultsTest {
 
     @Test
-    fun `records error finding while preserving error list`() {
+    fun `records error finding and exposes errors as filtered findings`() {
         val results = ValidationResults(AsyncApiContext())
 
         results.error(
@@ -31,13 +34,11 @@ class ValidationResultsTest {
         assertEquals("streetlights.root.asyncapi", finding.path)
 
         val error = results.errors.single()
-        assertEquals(finding.message, error.message)
-        assertEquals(finding.line, error.line)
-        assertEquals(finding.doc, error.doc)
+        assertEquals(finding, error)
     }
 
     @Test
-    fun `records warning finding with source location while preserving warning list`() {
+    fun `records warning finding and exposes warnings as filtered findings`() {
         val results = ValidationResults(AsyncApiContext())
         val sourceLocation = SourceLocation(
             sourceId = "streetlights",
@@ -62,9 +63,7 @@ class ValidationResultsTest {
         assertEquals("https://example.com/urn", finding.doc)
 
         val warning = results.warnings.single()
-        assertEquals(finding.message, warning.message)
-        assertEquals(finding.line, warning.line)
-        assertEquals(finding.doc, warning.doc)
+        assertEquals(finding, warning)
     }
 
     @Test
@@ -76,5 +75,46 @@ class ValidationResultsTest {
 
         assertEquals(listOf(WARNING, ERROR), results.findings.map { it.severity })
         assertEquals(listOf("First warning", "Second error"), results.findings.map { it.message })
+    }
+
+    @Test
+    fun `throws validation errors rendered from source locations`() {
+        val asyncApiContext = AsyncApiContext()
+        val file = File("streetlights.yaml")
+        asyncApiContext.registerSource(
+            file,
+            """
+            asyncapi: 2.6.0
+            info:
+              title: Streetlights
+            """.trimIndent()
+        )
+        val sourceLocation = SourceLocation(
+            sourceId = "streetlights",
+            file = file,
+            path = "streetlights.root.asyncapi",
+            line = 1,
+            column = 1,
+        )
+        asyncApiContext.registerSourceLocation(sourceLocation.path, sourceLocation)
+
+        val results = ValidationResults(asyncApiContext)
+        results.error(
+            message = "Unsupported AsyncAPI version.",
+            doc = "https://example.com/asyncapi",
+            sourceLocation = sourceLocation,
+        )
+
+        val exception = assertFailsWith<AsyncApiValidateException.ValidateError> {
+            results.throwErrors()
+        }
+
+        assertEquals(results.errors, exception.errors)
+        val message = exception.message.orEmpty()
+        assertContains(message, "Validation failed with 1 error(s):")
+        assertContains(message, ">> Unsupported AsyncAPI version.")
+        assertContains(message, "streetlights.yaml (streetlights.root.asyncapi)")
+        assertContains(message, "→    1 | asyncapi: 2.6.0")
+        assertContains(message, "See documentation: https://example.com/asyncapi")
     }
 }

--- a/asyncapi-generator-core/src/test/resources/validator/asyncapi/asyncapi_validator_document_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/validator/asyncapi/asyncapi_validator_document_invalid.yaml
@@ -1,0 +1,6 @@
+asyncapi: 2.6.0
+id: not-a-uri
+defaultContentType: not-a-mime-type
+info:
+  title: Invalid AsyncAPI Document
+  version: 1.0.0


### PR DESCRIPTION
- Closes #99 
- Closes #100 
- Closes #101 
- Closes #102 

The previous validator flow stored validation output mostly as separate error and warning lists with line-based source information. This worked for simple single-file validation, but it made the validator stage less precise than the parser and reader stages we have already improved.

The main issue was that validation diagnostics did not consistently carry the full source location. A validation message could include a line number, but it did not always know the source file, logical path, or source location that produced the problem. That becomes fragile when documents are split across files, when references are resolved, or when validation output needs to explain exactly where a problem came from.

For the proposed solution, the validator stage now has an explicit `ValidationStage` contract. `AsyncApiValidator` implements that contract and returns `ValidationResults`, which gives us a clearer input-output boundary for validation.

Validation output is now centered around `ValidationFinding`. A finding contains the severity, message, source location, logical path, line, and documentation link when available. The older separate `ValidationError` and `ValidationWarning` models were removed, and `ValidationResults.errors` and `ValidationResults.warnings` now behave as filtered views over the structured findings.

The validators were migrated from line-only diagnostics to source-location diagnostics. Instead of calling `getLine(...)`, validator diagnostics now use `getSourceLocation(...)`, so findings can preserve the correct file and logical path. This migration covers the top-level AsyncAPI validator, schema validation, channel validation, operation validation, server validation, server variable validation, binding validation, security scheme validation, info/contact/license validation, parameters, messages, tags, external docs, correlation IDs, operation replies, and unresolved references.

The validation rendering path was also updated. Validation exceptions and warning logs now render from `ValidationFinding`, using the stored source location to show the correct snippet. This means rendered diagnostics can now point to the correct source file and logical path instead of relying on a mutable current-file line lookup.

One source-location edge case was fixed in operation validation. When validating that an operation channel reference points to a channel object, the validator now captures the reference source location before resolving the reference, because resolution mutates the reference object.

The tests were expanded around the new diagnostic contract. Validator tests now assert that findings include the expected severity, file, path, and line for representative errors and warnings across the validator areas. `ValidationResultsTest` was also updated to verify that errors and warnings are filtered finding views and that validation exceptions render source-location snippets correctly.
