### PR TITLE
feature/bundler contract

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/AsyncApiBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/AsyncApiBundler.kt
@@ -7,7 +7,18 @@ import dev.banking.asyncapi.generator.core.bundler.operations.OperationBundler
 import dev.banking.asyncapi.generator.core.bundler.servers.ServerBundler
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 
-class AsyncApiBundler {
+/**
+ * Bundles a parsed and validated [AsyncApiDocument].
+ *
+ * The bundler stage resolves already-registered references into the model shape
+ * expected by generator stages. It does not read files, parse YAML or JSON,
+ * validate AsyncAPI semantics, or generate code.
+ *
+ * Expected behavior is covered by:
+ * - `AsyncApiBundlerContractTest`
+ * - `AsyncApiBundlerTest`
+ */
+class AsyncApiBundler : BundlingStage {
 
     private val infoBundler = InfoBundler()
     private val serverBundler = ServerBundler()
@@ -15,7 +26,7 @@ class AsyncApiBundler {
     private val operationBundler = OperationBundler()
     private val componentBundler = ComponentBundler()
 
-    fun bundle(document: AsyncApiDocument): AsyncApiDocument {
+    override fun bundle(document: AsyncApiDocument): AsyncApiDocument {
         val visited = emptySet<String>()
         return document.copy(
             info = infoBundler.bundle(document.info, visited),

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/AsyncApiBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/AsyncApiBundler.kt
@@ -27,13 +27,13 @@ class AsyncApiBundler : BundlingStage {
     private val componentBundler = ComponentBundler()
 
     override fun bundle(document: AsyncApiDocument): AsyncApiDocument {
-        val visited = emptySet<String>()
+        val context = BundlingContext.empty()
         return document.copy(
-            info = infoBundler.bundle(document.info, visited),
-            servers = serverBundler.bundleServers(document.servers, visited),
-            channels = channelBundler.bundleMap(document.channels, visited),
-            operations = operationBundler.bundleMap(document.operations, visited),
-            components = componentBundler.bundleComponents(document.components, visited),
+            info = infoBundler.bundle(document.info, context),
+            servers = serverBundler.bundleServers(document.servers, context),
+            channels = channelBundler.bundleMap(document.channels, context),
+            operations = operationBundler.bundleMap(document.operations, context),
+            components = componentBundler.bundleComponents(document.components, context),
         )
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/BundlingContext.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/BundlingContext.kt
@@ -1,0 +1,35 @@
+package dev.banking.asyncapi.generator.core.bundler
+
+import dev.banking.asyncapi.generator.core.model.references.Reference
+
+/**
+ * Carries traversal state while the bundler walks an AsyncAPI document.
+ *
+ * The context keeps reference-visit tracking in one dedicated model instead of
+ * passing bare sets through every bundler. This makes circular-reference
+ * handling explicit while object-specific bundlers still control their own
+ * traversal rules.
+ *
+ * Expected behavior is covered by:
+ * - `BundlingContextTest`
+ */
+class BundlingContext private constructor(
+    private val visitedReferences: Set<String>,
+) {
+
+    fun hasVisited(reference: Reference): Boolean = hasVisited(reference.ref)
+
+    fun hasVisited(reference: String): Boolean = reference in visitedReferences
+
+    fun enter(reference: Reference): BundlingContext = enter(reference.ref)
+
+    fun enter(reference: String): BundlingContext =
+        BundlingContext(visitedReferences + reference)
+
+    companion object {
+        fun empty(): BundlingContext = BundlingContext(emptySet())
+
+        fun from(visitedReferences: Set<String>): BundlingContext =
+            BundlingContext(visitedReferences)
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/BundlingStage.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/BundlingStage.kt
@@ -1,0 +1,18 @@
+package dev.banking.asyncapi.generator.core.bundler
+
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+
+/**
+ * Contract for bundler-stage implementations.
+ *
+ * A bundling stage receives an already parsed and validated AsyncAPI model and
+ * returns a bundled AsyncAPI model. It must not read input files, parse
+ * documents, validate AsyncAPI rules, or generate output.
+ *
+ * Expected behavior is covered by:
+ * - `AsyncApiBundlerContractTest`
+ * - `AsyncApiBundlerTest`
+ */
+interface BundlingStage {
+    fun bundle(document: AsyncApiDocument): AsyncApiDocument
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundler.kt
@@ -1,0 +1,26 @@
+package dev.banking.asyncapi.generator.core.bundler
+
+import dev.banking.asyncapi.generator.core.model.references.Reference
+
+/**
+ * Shared reference-bundling behavior used by object-specific bundlers.
+ *
+ * Object-specific bundlers should decide which fields to traverse. This helper
+ * keeps common reference state changes, such as marking an unvisited reference
+ * as inline, in one place.
+ *
+ * Expected behavior is covered by:
+ * - `ReferenceBundlerTest`
+ */
+object ReferenceBundler {
+
+    fun inlineIfUnvisited(
+        reference: Reference,
+        context: BundlingContext,
+    ): Reference {
+        if (!context.hasVisited(reference)) {
+            reference.inline()
+        }
+        return reference
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundler.kt
@@ -23,4 +23,18 @@ object ReferenceBundler {
         }
         return reference
     }
+
+    inline fun <reified T> bundleReferencedModel(
+        reference: Reference,
+        context: BundlingContext,
+        bundle: (T, BundlingContext) -> T,
+    ): Reference {
+        if (!context.hasVisited(reference)) {
+            val model = reference.requireModel<T>()
+            val bundled = bundle(model, context.enter(reference))
+            reference.model = bundled
+            reference.inline()
+        }
+        return reference
+    }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/bindings/BindingBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/bindings/BindingBundler.kt
@@ -1,31 +1,43 @@
 package dev.banking.asyncapi.generator.core.bundler.bindings
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.bindings.BindingInterface
 
 
+/**
+ * Bundles binding objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `BindingBundlerTest`
+ */
 class BindingBundler {
 
     fun bundleMap(
         bindings: Map<String, BindingInterface>?,
         visited: Set<String>
     ): Map<String, BindingInterface>? =
+        bundleMap(bindings, BundlingContext.from(visited))
+
+    fun bundleMap(
+        bindings: Map<String, BindingInterface>?,
+        context: BundlingContext,
+    ): Map<String, BindingInterface>? =
         bindings?.mapValues { (_, binding) ->
-            bundle(binding, visited)
+            bundle(binding, context)
         }
 
     fun bundle(binding: BindingInterface, visited: Set<String>): BindingInterface =
+        bundle(binding, BundlingContext.from(visited))
+
+    fun bundle(binding: BindingInterface, context: BundlingContext): BindingInterface =
         when (binding) {
             is BindingInterface.BindingInline -> {
                 binding
             }
             is BindingInterface.BindingReference -> {
-                val ref = binding.reference.ref
-                if (visited.contains(ref)) {
-                    binding
-                } else {
-                    binding.reference.inline()
-                    binding
-                }
+                ReferenceBundler.inlineIfUnvisited(binding.reference, context)
+                binding
             }
         }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/channels/ChannelBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/channels/ChannelBundler.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler.channels
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
 import dev.banking.asyncapi.generator.core.bundler.messages.MessagesBundler
@@ -8,6 +10,12 @@ import dev.banking.asyncapi.generator.core.bundler.tags.TagBundler
 import dev.banking.asyncapi.generator.core.model.channels.Channel
 import dev.banking.asyncapi.generator.core.model.channels.ChannelInterface
 
+/**
+ * Bundles channel objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `ChannelBundlerTest`
+ */
 class ChannelBundler {
 
     private val messagesBundler: MessagesBundler = MessagesBundler()
@@ -16,38 +24,45 @@ class ChannelBundler {
     private val externalDocsBundler: ExternalDocsBundler = ExternalDocsBundler()
     private val bindingBundler = BindingBundler()
 
-    fun bundleMap(channels: Map<String, ChannelInterface>?, visited: Set<String>): Map<String, ChannelInterface>? {
+    fun bundleMap(channels: Map<String, ChannelInterface>?, visited: Set<String>): Map<String, ChannelInterface>? =
+        bundleMap(channels, BundlingContext.from(visited))
+
+    fun bundleMap(channels: Map<String, ChannelInterface>?, context: BundlingContext): Map<String, ChannelInterface>? {
         if (channels == null) return null
         return channels.mapValues { (_, channelInterface) ->
-            when (channelInterface) {
-                is ChannelInterface.ChannelInline ->
-                    ChannelInterface.ChannelInline(
-                        bundleChannel(channelInterface.channel, visited)
-                    )
-                is ChannelInterface.ChannelReference -> {
-                    val ref = channelInterface.reference.ref
-                    if (visited.contains(ref)) {
-                        channelInterface
-                    } else {
-                        val channelModel = channelInterface.reference.requireModel<Channel>()
-                        val newVisited = visited + ref
-                        val bundled = bundleChannel(channelModel, newVisited)
-                        channelInterface.reference.model = bundled
-                        channelInterface.reference.inline()
-                        channelInterface
-
-                    }
-                }
-            }
+            bundle(channelInterface, context)
         }
     }
 
-    fun bundleChannel(channel: Channel, visited: Set<String>): Channel {
-        val bundledMessages = messagesBundler.bundleMap(channel.messages, visited)
-        val bundledParameters = parameterBundler.bundleMap(channel.parameters, visited)
-        val bundledTags = tagBundler.bundleList(channel.tags, visited)
-        val bundledExternalDocs = channel.externalDocs?.let { externalDocsBundler.bundle(it, visited)}
-        val bundledBindings = bindingBundler.bundleMap(channel.bindings, visited)
+    fun bundle(channelInterface: ChannelInterface, visited: Set<String>): ChannelInterface =
+        bundle(channelInterface, BundlingContext.from(visited))
+
+    fun bundle(channelInterface: ChannelInterface, context: BundlingContext): ChannelInterface =
+        when (channelInterface) {
+            is ChannelInterface.ChannelInline ->
+                ChannelInterface.ChannelInline(
+                    bundleChannel(channelInterface.channel, context)
+                )
+            is ChannelInterface.ChannelReference -> {
+                ReferenceBundler.bundleReferencedModel<Channel>(
+                    reference = channelInterface.reference,
+                    context = context,
+                ) { channel, nextContext ->
+                    bundleChannel(channel, nextContext)
+                }
+                channelInterface
+            }
+        }
+
+    fun bundleChannel(channel: Channel, visited: Set<String>): Channel =
+        bundleChannel(channel, BundlingContext.from(visited))
+
+    fun bundleChannel(channel: Channel, context: BundlingContext): Channel {
+        val bundledMessages = messagesBundler.bundleMap(channel.messages, context)
+        val bundledParameters = parameterBundler.bundleMap(channel.parameters, context)
+        val bundledTags = tagBundler.bundleList(channel.tags, context)
+        val bundledExternalDocs = channel.externalDocs?.let { externalDocsBundler.bundle(it, context)}
+        val bundledBindings = bindingBundler.bundleMap(channel.bindings, context)
         return channel.copy(
             messages = bundledMessages,
             parameters = bundledParameters,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/components/ComponentBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/components/ComponentBundler.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler.components
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.channels.ChannelBundler
 import dev.banking.asyncapi.generator.core.bundler.correlations.CorrelationIdBundler
@@ -19,6 +21,12 @@ import dev.banking.asyncapi.generator.core.bundler.tags.TagBundler
 import dev.banking.asyncapi.generator.core.model.components.Component
 import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
 
+/**
+ * Bundles component objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `ComponentBundlerTest`
+ */
 class ComponentBundler {
 
     private val schemaBundler = SchemaBundler()
@@ -41,50 +49,55 @@ class ComponentBundler {
     fun bundleComponents(
         components: ComponentInterface?,
         visited: Set<String>,
+    ): ComponentInterface? =
+        bundleComponents(components, BundlingContext.from(visited))
+
+    fun bundleComponents(
+        components: ComponentInterface?,
+        context: BundlingContext,
     ): ComponentInterface? {
         if (components == null) return null
         return when (components) {
             is ComponentInterface.ComponentInline ->
                 ComponentInterface.ComponentInline(
-                    bundleComponent(components.component, visited)
+                    bundleComponent(components.component, context)
                 )
 
             is ComponentInterface.ComponentReference -> {
-                val ref = components.reference.ref
-                if (visited.contains(ref)) {
-                    components
-                } else {
-                    val model = components.reference.requireModel<Component>()
-                    val newVisited = visited + ref
-                    val bundled = bundleComponent(model, newVisited)
-                    components.reference.model = bundled
-                    components.reference.inline()
-                    components
+                ReferenceBundler.bundleReferencedModel<Component>(
+                    reference = components.reference,
+                    context = context,
+                ) { component, nextContext ->
+                    bundleComponent(component, nextContext)
                 }
+                components
             }
         }
     }
 
-    fun bundleComponent(component: Component, visited: Set<String>): Component {
-        val bundledSchemas = schemaBundler.bundleMap(component.schemas, visited)
-        val bundledServers = component.servers?.let { serverBundler.bundleServers(it, visited) }
-        val bundledChannels = component.channels?.let { channelBundler.bundleMap(it, visited) }
-        val bundledOperations = component.operations?.let { operationBundler.bundleMap(it, visited) }
-        val bundledMessages = messagesBundler.bundleMap(component.messages, visited)
-        val bundledSecuritySchemes = securitySchemeBundler.bundleMap(component.securitySchemes, visited)
-        val bundledServerVariables = serverVariableBundler.bundleMap(component.serverVariables, visited)
-        val bundledParameters = parameterBundler.bundleMap(component.parameters, visited)
-        val bundledCorrelationIds = correlationIdBundler.bundleMap(component.correlationIds, visited)
-        val bundledReplies = operationReplyBundler.bundleMap(component.replies, visited)
-        val bundledReplyAddresses = operationReplyAddressBundler.bundleMap(component.replyAddresses, visited)
-        val bundledExternalDocs = externalDocsBundler.bundleMap(component.externalDocs, visited)
-        val bundledTags = tagBundler.bundleMap(component.tags, visited)
-        val bundledOperationTraits = operationTraitBundler.bundleMap(component.operationTraits, visited)
-        val bundledMessageTraits = messageTraitsBundler.bundleMap(component.messageTraits, visited)
-        val bundledServerBindings = bindingBundler.bundleMap(component.serverBindings, visited)
-        val bundledChannelBindings = bindingBundler.bundleMap(component.channelBindings, visited)
-        val bundledOperationBindings = bindingBundler.bundleMap(component.operationBindings, visited)
-        val bundledMessageBindings = bindingBundler.bundleMap(component.messageBindings, visited)
+    fun bundleComponent(component: Component, visited: Set<String>): Component =
+        bundleComponent(component, BundlingContext.from(visited))
+
+    fun bundleComponent(component: Component, context: BundlingContext): Component {
+        val bundledSchemas = schemaBundler.bundleMap(component.schemas, context)
+        val bundledServers = component.servers?.let { serverBundler.bundleServers(it, context) }
+        val bundledChannels = component.channels?.let { channelBundler.bundleMap(it, context) }
+        val bundledOperations = component.operations?.let { operationBundler.bundleMap(it, context) }
+        val bundledMessages = messagesBundler.bundleMap(component.messages, context)
+        val bundledSecuritySchemes = securitySchemeBundler.bundleMap(component.securitySchemes, context)
+        val bundledServerVariables = serverVariableBundler.bundleMap(component.serverVariables, context)
+        val bundledParameters = parameterBundler.bundleMap(component.parameters, context)
+        val bundledCorrelationIds = correlationIdBundler.bundleMap(component.correlationIds, context)
+        val bundledReplies = operationReplyBundler.bundleMap(component.replies, context)
+        val bundledReplyAddresses = operationReplyAddressBundler.bundleMap(component.replyAddresses, context)
+        val bundledExternalDocs = externalDocsBundler.bundleMap(component.externalDocs, context)
+        val bundledTags = tagBundler.bundleMap(component.tags, context)
+        val bundledOperationTraits = operationTraitBundler.bundleMap(component.operationTraits, context)
+        val bundledMessageTraits = messageTraitsBundler.bundleMap(component.messageTraits, context)
+        val bundledServerBindings = bindingBundler.bundleMap(component.serverBindings, context)
+        val bundledChannelBindings = bindingBundler.bundleMap(component.channelBindings, context)
+        val bundledOperationBindings = bindingBundler.bundleMap(component.operationBindings, context)
+        val bundledMessageBindings = bindingBundler.bundleMap(component.messageBindings, context)
         return component.copy(
             schemas = bundledSchemas,
             servers = bundledServers,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/correlations/CorrelationIdBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/correlations/CorrelationIdBundler.kt
@@ -1,41 +1,40 @@
 package dev.banking.asyncapi.generator.core.bundler.correlations
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.correlations.CorrelationIdInterface
 
+/**
+ * Bundles correlation ID objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `CorrelationIdBundlerTest`
+ */
 class CorrelationIdBundler {
 
     fun bundleMap(
         correlationIds: Map<String, CorrelationIdInterface>?,
         visited: Set<String>,
     ): Map<String, CorrelationIdInterface>? =
-        correlationIds?.mapValues { (_, correlationId) ->
-            when (correlationId) {
-                is CorrelationIdInterface.CorrelationIdReference -> {
-                    val ref = correlationId.reference.ref
-                    if (visited.contains(ref)) {
-                        correlationId
-                    } else {
-                        correlationId.reference.inline()
-                        correlationId
+        bundleMap(correlationIds, BundlingContext.from(visited))
 
-                    }
-                }
-                else -> correlationId
-            }
+    fun bundleMap(
+        correlationIds: Map<String, CorrelationIdInterface>?,
+        context: BundlingContext,
+    ): Map<String, CorrelationIdInterface>? =
+        correlationIds?.mapValues { (_, correlationId) ->
+            bundle(correlationId, context)
         }
 
-    fun bundle(correlationId: CorrelationIdInterface, visited: Set<String>): CorrelationIdInterface {
-        return when (correlationId) {
+    fun bundle(correlationId: CorrelationIdInterface, visited: Set<String>): CorrelationIdInterface =
+        bundle(correlationId, BundlingContext.from(visited))
+
+    fun bundle(correlationId: CorrelationIdInterface, context: BundlingContext): CorrelationIdInterface =
+        when (correlationId) {
             is CorrelationIdInterface.CorrelationIdReference -> {
-                val ref = correlationId.reference.ref
-                if (visited.contains(ref)) {
-                    correlationId
-                } else {
-                    correlationId.reference.inline()
-                    correlationId
-                }
+                ReferenceBundler.inlineIfUnvisited(correlationId.reference, context)
+                correlationId
             }
             else -> correlationId
         }
-    }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/externaldocs/ExternalDocsBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/externaldocs/ExternalDocsBundler.kt
@@ -1,24 +1,38 @@
 package dev.banking.asyncapi.generator.core.bundler.externaldocs
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.externaldocs.ExternalDocInterface
 
+/**
+ * Bundles external documentation objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `ExternalDocsBundlerTest`
+ */
 class ExternalDocsBundler {
 
     fun bundleMap(
         externalDocs: Map<String, ExternalDocInterface>?,
         visited: Set<String>,
+    ): Map<String, ExternalDocInterface>? =
+        bundleMap(externalDocs, BundlingContext.from(visited))
+
+    fun bundleMap(
+        externalDocs: Map<String, ExternalDocInterface>?,
+        context: BundlingContext,
     ): Map<String, ExternalDocInterface>? {
         if (externalDocs == null) return null
-        return externalDocs.mapValues { (_, external) -> bundle(external, visited) }
+        return externalDocs.mapValues { (_, external) -> bundle(external, context) }
     }
 
     fun bundle(externalDoc: ExternalDocInterface, visited: Set<String>): ExternalDocInterface =
+        bundle(externalDoc, BundlingContext.from(visited))
+
+    fun bundle(externalDoc: ExternalDocInterface, context: BundlingContext): ExternalDocInterface =
         when (externalDoc) {
             is ExternalDocInterface.ExternalDocReference -> {
-                val ref = externalDoc.reference.ref
-                if (!visited.contains(ref)) {
-                    externalDoc.reference.inline()
-                }
+                ReferenceBundler.inlineIfUnvisited(externalDoc.reference, context)
                 externalDoc
             }
             else -> externalDoc

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/info/InfoBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/info/InfoBundler.kt
@@ -1,17 +1,27 @@
 package dev.banking.asyncapi.generator.core.bundler.info
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
 import dev.banking.asyncapi.generator.core.bundler.tags.TagBundler
 import dev.banking.asyncapi.generator.core.model.info.Info
 
+/**
+ * Bundles info metadata references.
+ *
+ * Expected behavior is covered by:
+ * - `InfoBundlerTest`
+ */
 class InfoBundler {
 
     private val tagBundler = TagBundler()
     private val externalDocsBundler = ExternalDocsBundler()
 
-    fun bundle(info: Info, visited: Set<String>): Info {
-        val bundledTags = tagBundler.bundleList(info.tags, visited)
-        val bundledExternalDocs = info.externalDocs?.let { externalDocsBundler.bundle(it, visited) }
+    fun bundle(info: Info, visited: Set<String>): Info =
+        bundle(info, BundlingContext.from(visited))
+
+    fun bundle(info: Info, context: BundlingContext): Info {
+        val bundledTags = tagBundler.bundleList(info.tags, context)
+        val bundledExternalDocs = info.externalDocs?.let { externalDocsBundler.bundle(it, context) }
         return info.copy(
             tags = bundledTags,
             externalDocs = bundledExternalDocs,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessageTraitBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessageTraitBundler.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler.messages
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.correlations.CorrelationIdBundler
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
@@ -8,6 +10,12 @@ import dev.banking.asyncapi.generator.core.bundler.tags.TagBundler
 import dev.banking.asyncapi.generator.core.model.messages.MessageTrait
 import dev.banking.asyncapi.generator.core.model.messages.MessageTraitInterface
 
+/**
+ * Bundles message trait objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `MessageTraitBundlerTest`
+ */
 class MessageTraitBundler {
 
     private val schemaBundler = SchemaBundler()
@@ -20,42 +28,52 @@ class MessageTraitBundler {
         traits: Map<String, MessageTraitInterface>?,
         visited: Set<String>
     ): Map<String, MessageTraitInterface>? =
-        traits?.mapValues { (_, trait) -> bundle(trait, visited) }
+        bundleMap(traits, BundlingContext.from(visited))
+
+    fun bundleMap(
+        traits: Map<String, MessageTraitInterface>?,
+        context: BundlingContext,
+    ): Map<String, MessageTraitInterface>? =
+        traits?.mapValues { (_, trait) -> bundle(trait, context) }
 
     fun bundleList(
         traits: List<MessageTraitInterface>?,
         visited: Set<String>
     ): List<MessageTraitInterface>? =
-        traits?.map { trait -> bundle(trait, visited) }
+        bundleList(traits, BundlingContext.from(visited))
 
-    fun bundle(traitInterface: MessageTraitInterface, visited: Set<String>): MessageTraitInterface {
-        return when (traitInterface) {
+    fun bundleList(
+        traits: List<MessageTraitInterface>?,
+        context: BundlingContext,
+    ): List<MessageTraitInterface>? =
+        traits?.map { trait -> bundle(trait, context) }
+
+    fun bundle(traitInterface: MessageTraitInterface, visited: Set<String>): MessageTraitInterface =
+        bundle(traitInterface, BundlingContext.from(visited))
+
+    fun bundle(traitInterface: MessageTraitInterface, context: BundlingContext): MessageTraitInterface =
+        when (traitInterface) {
             is MessageTraitInterface.InlineMessageTrait ->
                 MessageTraitInterface.InlineMessageTrait(
-                    bundleTrait(traitInterface.trait, visited)
+                    bundleTrait(traitInterface.trait, context)
                 )
             is MessageTraitInterface.ReferenceMessageTrait -> {
-                val ref = traitInterface.reference.ref
-                if (visited.contains(ref)) {
-                    traitInterface
-                } else {
-                    val model = traitInterface.reference.requireModel<MessageTrait>()
-                    val newVisited = visited + ref
-                    val bundled = bundleTrait(model, newVisited)
-                    traitInterface.reference.model = bundled
-                    traitInterface.reference.inline()
-                    traitInterface
+                ReferenceBundler.bundleReferencedModel<MessageTrait>(
+                    reference = traitInterface.reference,
+                    context = context,
+                ) { trait, nextContext ->
+                    bundleTrait(trait, nextContext)
                 }
+                traitInterface
             }
         }
-    }
 
-    private fun bundleTrait(trait: MessageTrait, visited: Set<String>): MessageTrait {
-        val bundledHeaders =  trait.headers?.let { schemaBundler.bundle(it, visited) }
-        val bundledCorrelationId = trait.correlationId?.let { correlationIdBundler.bundle(it, visited) }
-        val bundledTags = tagBundler.bundleList(trait.tags, visited)
-        val bundledExternalDocs = trait.externalDocs?.let { externalDocsBundler.bundle(it, visited) }
-        val bundledBindings = bindingBundler.bundleMap(trait.bindings, visited)
+    private fun bundleTrait(trait: MessageTrait, context: BundlingContext): MessageTrait {
+        val bundledHeaders =  trait.headers?.let { schemaBundler.bundle(it, context) }
+        val bundledCorrelationId = trait.correlationId?.let { correlationIdBundler.bundle(it, context) }
+        val bundledTags = tagBundler.bundleList(trait.tags, context)
+        val bundledExternalDocs = trait.externalDocs?.let { externalDocsBundler.bundle(it, context) }
+        val bundledBindings = bindingBundler.bundleMap(trait.bindings, context)
         return trait.copy(
             headers = bundledHeaders,
             correlationId = bundledCorrelationId,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessagesBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessagesBundler.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler.messages
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.correlations.CorrelationIdBundler
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
@@ -9,6 +11,12 @@ import dev.banking.asyncapi.generator.core.model.messages.Message
 import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
 import dev.banking.asyncapi.generator.core.model.tags.TagInterface
 
+/**
+ * Bundles message objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `MessagesBundlerTest`
+ */
 class MessagesBundler {
 
     private val schemaBundler = SchemaBundler()
@@ -19,41 +27,42 @@ class MessagesBundler {
     private val messageTraitBundler = MessageTraitBundler()
 
     fun bundleMap(messages: Map<String, MessageInterface>?, visited: Set<String>): Map<String, MessageInterface>? =
+        bundleMap(messages, BundlingContext.from(visited))
+
+    fun bundleMap(messages: Map<String, MessageInterface>?, context: BundlingContext): Map<String, MessageInterface>? =
         messages?.mapValues { (_, message) ->
-            bundleMessageInterface(message, visited)
+            bundle(message, context)
         }
 
-    private fun bundleMessageInterface(message: MessageInterface, visited: Set<String>): MessageInterface =
+    fun bundle(message: MessageInterface, visited: Set<String>): MessageInterface =
+        bundle(message, BundlingContext.from(visited))
+
+    fun bundle(message: MessageInterface, context: BundlingContext): MessageInterface =
         when (message) {
             is MessageInterface.MessageInline -> {
                 MessageInterface.MessageInline(
-                    bundleMessage(message.message, visited)
+                    bundleMessage(message.message, context)
                 )
             }
             is MessageInterface.MessageReference -> {
-                val ref = message.reference.ref
-                if (visited.contains(ref)) {
-                    message
-                } else {
-                    val model = message.reference.requireModel<Message>()
-                    val newVisited = visited + ref
-                    val bundled = bundleMessage(model, newVisited)
-                    message.reference.model = bundled
-                    message.reference.inline()
-                    message
-
+                ReferenceBundler.bundleReferencedModel<Message>(
+                    reference = message.reference,
+                    context = context,
+                ) { messageModel, nextContext ->
+                    bundleMessage(messageModel, nextContext)
                 }
+                message
             }
         }
 
-    private fun bundleMessage(message: Message, visited: Set<String>): Message {
-        val bundledHeaders =  message.headers?.let { schemaBundler.bundle(it, visited) }
-        val bundledPayload = message.payload?.let { schemaBundler.bundle(it, visited) }
-        val bundledCorrelationId = message.correlationId?.let { correlationIdBundler.bundle(it, visited) }
-        val bundledTags: List<TagInterface>? = tagBundler.bundleList(message.tags, visited)
-        val bundledExternalDocs = message.externalDocs?.let { externalDocsBundler.bundle(it, visited) }
-        val bundledBindings = bindingBundler.bundleMap(message.bindings, visited)
-        val bundledTraits = messageTraitBundler.bundleList(message.traits, visited)
+    private fun bundleMessage(message: Message, context: BundlingContext): Message {
+        val bundledHeaders =  message.headers?.let { schemaBundler.bundle(it, context) }
+        val bundledPayload = message.payload?.let { schemaBundler.bundle(it, context) }
+        val bundledCorrelationId = message.correlationId?.let { correlationIdBundler.bundle(it, context) }
+        val bundledTags: List<TagInterface>? = tagBundler.bundleList(message.tags, context)
+        val bundledExternalDocs = message.externalDocs?.let { externalDocsBundler.bundle(it, context) }
+        val bundledBindings = bindingBundler.bundleMap(message.bindings, context)
+        val bundledTraits = messageTraitBundler.bundleList(message.traits, context)
         val bundledExamples = message.examples
         return message.copy(
             headers = bundledHeaders,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationBundler.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler.operations
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
 import dev.banking.asyncapi.generator.core.bundler.security.SecuritySchemeBundler
@@ -7,6 +9,12 @@ import dev.banking.asyncapi.generator.core.bundler.tags.TagBundler
 import dev.banking.asyncapi.generator.core.model.operations.Operation
 import dev.banking.asyncapi.generator.core.model.operations.OperationInterface
 
+/**
+ * Bundles operation objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `OperationBundlerTest`
+ */
 class OperationBundler {
 
     private val tagBundler = TagBundler()
@@ -19,39 +27,50 @@ class OperationBundler {
     fun bundleMap(
         operations: Map<String, OperationInterface>?,
         visited: Set<String>,
+    ): Map<String, OperationInterface>? =
+        bundleMap(operations, BundlingContext.from(visited))
+
+    fun bundleMap(
+        operations: Map<String, OperationInterface>?,
+        context: BundlingContext,
     ): Map<String, OperationInterface>? {
         if (operations == null) return null
         return operations.mapValues { (_, opInterface) ->
-            when (opInterface) {
-                is OperationInterface.OperationInline ->
-                    OperationInterface.OperationInline(
-                        bundleOperation(opInterface.operation, visited)
-                    )
-
-                is OperationInterface.OperationReference -> {
-                    val ref = opInterface.reference.ref
-                    if (visited.contains(ref)) {
-                        opInterface
-                    } else {
-                        val opModel = opInterface.reference.requireModel<Operation>()
-                        val newVisited = visited + ref
-                        val bundledOp = bundleOperation(opModel, newVisited)
-                        opInterface.reference.model = bundledOp
-                        opInterface.reference.inline()
-                        opInterface
-                    }
-                }
-            }
+            bundle(opInterface, context)
         }
     }
 
-    fun bundleOperation(operation: Operation, visited: Set<String>): Operation {
-        val bundledBindings = bindingBundler.bundleMap(operation.bindings, visited)
-        val bundledTraits = operationTraitBundler.bundleList(operation.traits, visited)
-        val bundledTags = tagBundler.bundleList(operation.tags, visited)
-        val bundledExternalDocs = operation.externalDocs?.let { externalDocsBundler.bundle(it, visited) }
-        val bundledReply = operation.reply?.let { operationReplyBundler.bundle(it, visited) }
-        val bundledSecurity = securitySchemeBundler.bundleList(operation.security, visited)
+    fun bundle(operationInterface: OperationInterface, visited: Set<String>): OperationInterface =
+        bundle(operationInterface, BundlingContext.from(visited))
+
+    fun bundle(operationInterface: OperationInterface, context: BundlingContext): OperationInterface =
+        when (operationInterface) {
+            is OperationInterface.OperationInline ->
+                OperationInterface.OperationInline(
+                    bundleOperation(operationInterface.operation, context)
+                )
+
+            is OperationInterface.OperationReference -> {
+                ReferenceBundler.bundleReferencedModel<Operation>(
+                    reference = operationInterface.reference,
+                    context = context,
+                ) { operation, nextContext ->
+                    bundleOperation(operation, nextContext)
+                }
+                operationInterface
+            }
+        }
+
+    fun bundleOperation(operation: Operation, visited: Set<String>): Operation =
+        bundleOperation(operation, BundlingContext.from(visited))
+
+    fun bundleOperation(operation: Operation, context: BundlingContext): Operation {
+        val bundledBindings = bindingBundler.bundleMap(operation.bindings, context)
+        val bundledTraits = operationTraitBundler.bundleList(operation.traits, context)
+        val bundledTags = tagBundler.bundleList(operation.tags, context)
+        val bundledExternalDocs = operation.externalDocs?.let { externalDocsBundler.bundle(it, context) }
+        val bundledReply = operation.reply?.let { operationReplyBundler.bundle(it, context) }
+        val bundledSecurity = securitySchemeBundler.bundleList(operation.security, context)
         return operation.copy(
             bindings = bundledBindings,
             traits = bundledTraits,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyAddressBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyAddressBundler.kt
@@ -1,26 +1,38 @@
 package dev.banking.asyncapi.generator.core.bundler.operations
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
 
+/**
+ * Bundles operation reply address objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `OperationReplyAddressBundlerTest`
+ */
 class OperationReplyAddressBundler {
 
     fun bundleMap(
         addresses: Map<String, OperationReplyAddressInterface>?,
         visited: Set<String>
     ): Map<String, OperationReplyAddressInterface>? =
-        addresses?.mapValues { (_, addr) -> bundle(addr, visited) }
+        bundleMap(addresses, BundlingContext.from(visited))
+
+    fun bundleMap(
+        addresses: Map<String, OperationReplyAddressInterface>?,
+        context: BundlingContext,
+    ): Map<String, OperationReplyAddressInterface>? =
+        addresses?.mapValues { (_, addr) -> bundle(addr, context) }
 
     fun bundle(address: OperationReplyAddressInterface, visited: Set<String>): OperationReplyAddressInterface =
+        bundle(address, BundlingContext.from(visited))
+
+    fun bundle(address: OperationReplyAddressInterface, context: BundlingContext): OperationReplyAddressInterface =
         when (address) {
             is OperationReplyAddressInterface.OperationReplyAddressInline -> address
             is OperationReplyAddressInterface.OperationReplyAddressReference -> {
-                val ref = address.reference.ref
-                if (visited.contains(ref)) {
-                    address
-                } else {
-                    address.reference.inline()
-                    address
-                }
+                ReferenceBundler.inlineIfUnvisited(address.reference, context)
+                address
             }
         }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyBundler.kt
@@ -1,8 +1,16 @@
 package dev.banking.asyncapi.generator.core.bundler.operations
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.operations.OperationReply
 import dev.banking.asyncapi.generator.core.model.operations.OperationReplyInterface
 
+/**
+ * Bundles operation reply objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `OperationReplyBundlerTest`
+ */
 class OperationReplyBundler {
 
     private val operationReplyAddressBundler = OperationReplyAddressBundler()
@@ -11,35 +19,39 @@ class OperationReplyBundler {
         replies: Map<String, OperationReplyInterface>?,
         visited: Set<String>,
     ): Map<String, OperationReplyInterface>? =
-        replies?.mapValues { (_, reply) -> bundle(reply, visited) }
+        bundleMap(replies, BundlingContext.from(visited))
 
-    fun bundle(replyInterface: OperationReplyInterface, visited: Set<String>): OperationReplyInterface {
-        return when (replyInterface) {
+    fun bundleMap(
+        replies: Map<String, OperationReplyInterface>?,
+        context: BundlingContext,
+    ): Map<String, OperationReplyInterface>? =
+        replies?.mapValues { (_, reply) -> bundle(reply, context) }
+
+    fun bundle(replyInterface: OperationReplyInterface, visited: Set<String>): OperationReplyInterface =
+        bundle(replyInterface, BundlingContext.from(visited))
+
+    fun bundle(replyInterface: OperationReplyInterface, context: BundlingContext): OperationReplyInterface =
+        when (replyInterface) {
             is OperationReplyInterface.OperationReplyInline ->
                 OperationReplyInterface.OperationReplyInline(
-                    bundleReply(replyInterface.operationReply, visited)
+                    bundleReply(replyInterface.operationReply, context)
                 )
 
             is OperationReplyInterface.OperationReplyReference -> {
-                val ref = replyInterface.reference.ref
-                if (visited.contains(ref)) {
-                    replyInterface
-                } else {
-                    val model = replyInterface.reference.requireModel<OperationReply>()
-                    val newVisited = visited + ref
-                    val bundled = bundleReply(model, newVisited)
-                    replyInterface.reference.model = bundled
-                    replyInterface.reference.inline()
-                    replyInterface
+                ReferenceBundler.bundleReferencedModel<OperationReply>(
+                    reference = replyInterface.reference,
+                    context = context,
+                ) { reply, nextContext ->
+                    bundleReply(reply, nextContext)
                 }
+                replyInterface
             }
         }
-    }
 
-    private fun bundleReply(reply: OperationReply, visited: Set<String>): OperationReply {
-        val bundledAddress = reply.address?.let { operationReplyAddressBundler.bundle(it, visited) }
-        reply.channel?.let { if (!visited.contains(it.ref)) it.inline() }
-        reply.messages?.forEach { if (!visited.contains(it.ref)) it.inline() }
+    private fun bundleReply(reply: OperationReply, context: BundlingContext): OperationReply {
+        val bundledAddress = reply.address?.let { operationReplyAddressBundler.bundle(it, context) }
+        reply.channel?.let { ReferenceBundler.inlineIfUnvisited(it, context) }
+        reply.messages?.forEach { ReferenceBundler.inlineIfUnvisited(it, context) }
 
         return reply.copy(
             address = bundledAddress

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationTraitBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationTraitBundler.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler.operations
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
 import dev.banking.asyncapi.generator.core.bundler.security.SecuritySchemeBundler
@@ -7,6 +9,12 @@ import dev.banking.asyncapi.generator.core.bundler.tags.TagBundler
 import dev.banking.asyncapi.generator.core.model.operations.OperationTrait
 import dev.banking.asyncapi.generator.core.model.operations.OperationTraitInterface
 
+/**
+ * Bundles operation trait objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `OperationTraitBundlerTest`
+ */
 class OperationTraitBundler {
 
     private val tagBundler = TagBundler()
@@ -18,41 +26,51 @@ class OperationTraitBundler {
         traits: Map<String, OperationTraitInterface>?,
         visited: Set<String>
     ): Map<String, OperationTraitInterface>? =
-        traits?.mapValues { (_, trait) -> bundle(trait, visited) }
+        bundleMap(traits, BundlingContext.from(visited))
+
+    fun bundleMap(
+        traits: Map<String, OperationTraitInterface>?,
+        context: BundlingContext,
+    ): Map<String, OperationTraitInterface>? =
+        traits?.mapValues { (_, trait) -> bundle(trait, context) }
 
     fun bundleList(
         traits: List<OperationTraitInterface>?,
         visited: Set<String>
     ): List<OperationTraitInterface>? =
-        traits?.map { trait -> bundle(trait, visited) }
+        bundleList(traits, BundlingContext.from(visited))
 
-    fun bundle(traitInterface: OperationTraitInterface, visited: Set<String>): OperationTraitInterface {
-        return when (traitInterface) {
+    fun bundleList(
+        traits: List<OperationTraitInterface>?,
+        context: BundlingContext,
+    ): List<OperationTraitInterface>? =
+        traits?.map { trait -> bundle(trait, context) }
+
+    fun bundle(traitInterface: OperationTraitInterface, visited: Set<String>): OperationTraitInterface =
+        bundle(traitInterface, BundlingContext.from(visited))
+
+    fun bundle(traitInterface: OperationTraitInterface, context: BundlingContext): OperationTraitInterface =
+        when (traitInterface) {
             is OperationTraitInterface.OperationTraitInline ->
                 OperationTraitInterface.OperationTraitInline(
-                    bundleTrait(traitInterface.operationTrait, visited)
+                    bundleTrait(traitInterface.operationTrait, context)
                 )
             is OperationTraitInterface.OperationTraitReference -> {
-                val ref = traitInterface.reference.ref
-                if (visited.contains(ref)) {
-                    traitInterface
-                } else {
-                    val model = traitInterface.reference.requireModel<OperationTrait>()
-                    val newVisited = visited + ref
-                    val bundled = bundleTrait(model, newVisited)
-                    traitInterface.reference.model = bundled
-                    traitInterface.reference.inline()
-                    traitInterface
+                ReferenceBundler.bundleReferencedModel<OperationTrait>(
+                    reference = traitInterface.reference,
+                    context = context,
+                ) { trait, nextContext ->
+                    bundleTrait(trait, nextContext)
                 }
+                traitInterface
             }
         }
-    }
 
-    private fun bundleTrait(trait: OperationTrait, visited: Set<String>): OperationTrait {
-        val bundledTags = tagBundler.bundleList(trait.tags, visited)
-        val bundledExternalDocs = trait.externalDocs?.let { externalDocsBundler.bundle(it, visited) }
-        val bundledSecurity = securitySchemeBundler.bundleMap(trait.security, visited)
-        val bundledBindings = bindingBundler.bundleMap(trait.bindings, visited)
+    private fun bundleTrait(trait: OperationTrait, context: BundlingContext): OperationTrait {
+        val bundledTags = tagBundler.bundleList(trait.tags, context)
+        val bundledExternalDocs = trait.externalDocs?.let { externalDocsBundler.bundle(it, context) }
+        val bundledSecurity = securitySchemeBundler.bundleMap(trait.security, context)
+        val bundledBindings = bindingBundler.bundleMap(trait.bindings, context)
         return trait.copy(
             tags = bundledTags,
             externalDocs = bundledExternalDocs,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/parameters/ParameterBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/parameters/ParameterBundler.kt
@@ -1,25 +1,37 @@
 package dev.banking.asyncapi.generator.core.bundler.parameters
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.parameters.ParameterInterface
 
+/**
+ * Bundles parameter objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `ParameterBundlerTest`
+ */
 class ParameterBundler {
 
     fun bundleMap(
         parameters: Map<String, ParameterInterface>?,
         visited: Set<String>,
     ): Map<String, ParameterInterface>? =
+        bundleMap(parameters, BundlingContext.from(visited))
+
+    fun bundleMap(
+        parameters: Map<String, ParameterInterface>?,
+        context: BundlingContext,
+    ): Map<String, ParameterInterface>? =
         parameters?.mapValues { (_, param) ->
-            when (param) {
-                is ParameterInterface.ParameterReference -> {
-                    val ref = param.reference.ref
-                    if (visited.contains(ref)) {
-                        param
-                    } else {
-                        param.reference.inline()
-                        param
-                    }
-                }
-                else -> param
+            bundle(param, context)
+        }
+
+    fun bundle(parameter: ParameterInterface, context: BundlingContext): ParameterInterface =
+        when (parameter) {
+            is ParameterInterface.ParameterReference -> {
+                ReferenceBundler.inlineIfUnvisited(parameter.reference, context)
+                parameter
             }
+            else -> parameter
         }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/schemas/SchemaBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/schemas/SchemaBundler.kt
@@ -1,82 +1,110 @@
 package dev.banking.asyncapi.generator.core.bundler.schemas
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
+/**
+ * Bundles schema objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `SchemaBundlerTest`
+ */
 class SchemaBundler {
 
     private val externalDocsBundler = ExternalDocsBundler()
     private val bindingsBundler = BindingBundler()
 
     fun bundleMap(schemas: Map<String, SchemaInterface>?, visited: Set<String>): Map<String, SchemaInterface>? =
+        bundleMap(schemas, BundlingContext.from(visited))
+
+    fun bundleMap(schemas: Map<String, SchemaInterface>?, context: BundlingContext): Map<String, SchemaInterface>? =
         schemas?.mapValues { (_, schemaInterface) ->
-            bundle(schemaInterface, visited)
+            bundle(schemaInterface, context)
         }
 
     fun bundleList(schemas: List<SchemaInterface>?, visited: Set<String>): List<SchemaInterface>? =
-        schemas?.map { schemaInterface -> bundle(schemaInterface, visited) }
+        bundleList(schemas, BundlingContext.from(visited))
+
+    fun bundleList(schemas: List<SchemaInterface>?, context: BundlingContext): List<SchemaInterface>? =
+        schemas?.map { schemaInterface -> bundle(schemaInterface, context) }
 
     fun bundle(schemaInterface: SchemaInterface?, visited: Set<String>): SchemaInterface =
+        bundle(schemaInterface, BundlingContext.from(visited))
+
+    fun bundle(schemaInterface: SchemaInterface?, context: BundlingContext): SchemaInterface =
         when (schemaInterface) {
             null ->
                 throw IllegalArgumentException("Schema Interface $schemaInterface is not recognized")
 
             is SchemaInterface.SchemaInline ->
                 SchemaInterface.SchemaInline(
-                    bundleSchema(schemaInterface.schema, visited)
+                    bundleSchema(schemaInterface.schema, context)
                 )
-            is SchemaInterface.SchemaReference -> {
-                val ref = schemaInterface.reference.ref
-                val keepAsReference = isComponentSchemaRef(ref)
-                if (visited.contains(ref)) {
-                    if (keepAsReference) {
-                        schemaInterface
-                    } else {
-                        val model = schemaInterface.reference.requireModel<Schema>()
-                        SchemaInterface.SchemaInline(model)
-                    }
-                } else {
-                    val model = schemaInterface.reference.requireModel<Schema>()
-                    val newVisited = visited + ref
-                    val bundled = bundleSchema(model, newVisited)
-                    if (keepAsReference) {
-                        schemaInterface.reference.model = bundled
-                        schemaInterface.reference.inline()
-                        schemaInterface
-                    } else {
-                        SchemaInterface.SchemaInline(bundled)
-                    }
-                }
-            }
+            is SchemaInterface.SchemaReference ->
+                bundleReference(schemaInterface, context)
             is SchemaInterface.MultiFormatSchemaInline ->
                 schemaInterface
             is SchemaInterface.BooleanSchema ->
                 schemaInterface
         }
 
-    private fun bundleSchema(schema: Schema, visited: Set<String>): Schema {
-        val bundledItems = schema.items?.let { bundle(it, visited) }
-        val bundledAdditionalItems = schema.additionalItems?.let { bundle(it, visited) }
-        val bundledContains = schema.contains?.let { bundle(it, visited) }
+    private fun bundleReference(
+        schemaInterface: SchemaInterface.SchemaReference,
+        context: BundlingContext,
+    ): SchemaInterface {
+        val reference = schemaInterface.reference
+        val keepAsReference = isComponentSchemaRef(reference.ref)
 
-        val bundledProperties = bundleMap(schema.properties, visited)
-        val bundledPatternProperties = bundleMap(schema.patternProperties, visited)
-        val bundledAdditionalProperties = schema.additionalProperties?.let { bundle(it, visited) }
-        val bundledPropertyNames = schema.propertyNames?.let { bundle(it, visited) }
-        val bundledDefinitions = bundleMap(schema.definitions, visited)
+        if (context.hasVisited(reference)) {
+            return if (keepAsReference) {
+                schemaInterface
+            } else {
+                SchemaInterface.SchemaInline(reference.requireModel<Schema>())
+            }
+        }
 
-        val bundledAllOf = bundleList(schema.allOf, visited)
-        val bundledAnyOf = bundleList(schema.anyOf, visited)
-        val bundledOneOf = bundleList(schema.oneOf, visited)
-        val bundledNot = schema.not?.let { bundle(it, visited) }
-        val bundledIf = schema.ifSchema?.let { bundle(it, visited) }
-        val bundledThen = schema.thenSchema?.let { bundle(it, visited) }
-        val bundledElse = schema.elseSchema?.let { bundle(it, visited) }
+        if (keepAsReference) {
+            ReferenceBundler.bundleReferencedModel<Schema>(
+                reference = reference,
+                context = context,
+            ) { schema, nextContext ->
+                bundleSchema(schema, nextContext)
+            }
+            return schemaInterface
+        }
 
-        val bundledExternalDocs = schema.externalDocs?.let { externalDocsBundler.bundle(it, visited) }
-        val bundledBindings = bindingsBundler.bundleMap(schema.bindings, visited)
+        val bundled = bundleSchema(
+            schema = reference.requireModel(),
+            context = context.enter(reference),
+        )
+        return SchemaInterface.SchemaInline(bundled)
+    }
+
+    private fun bundleSchema(schema: Schema, context: BundlingContext): Schema {
+        val bundledItems = schema.items?.let { bundle(it, context) }
+        val bundledAdditionalItems = schema.additionalItems?.let { bundle(it, context) }
+        val bundledContains = schema.contains?.let { bundle(it, context) }
+
+        val bundledProperties = bundleMap(schema.properties, context)
+        val bundledPatternProperties = bundleMap(schema.patternProperties, context)
+        val bundledAdditionalProperties = schema.additionalProperties?.let { bundle(it, context) }
+        val bundledPropertyNames = schema.propertyNames?.let { bundle(it, context) }
+        val bundledDefinitions = bundleMap(schema.definitions, context)
+
+        val bundledAllOf = bundleList(schema.allOf, context)
+        val bundledAnyOf = bundleList(schema.anyOf, context)
+        val bundledOneOf = bundleList(schema.oneOf, context)
+        val bundledNot = schema.not?.let { bundle(it, context) }
+        val bundledIf = schema.ifSchema?.let { bundle(it, context) }
+        val bundledThen = schema.thenSchema?.let { bundle(it, context) }
+        val bundledElse = schema.elseSchema?.let { bundle(it, context) }
+
+        val bundledExternalDocs = schema.externalDocs?.let { externalDocsBundler.bundle(it, context) }
+        val bundledBindings = bindingsBundler.bundleMap(schema.bindings, context)
         return schema.copy(
             items = bundledItems,
             additionalItems = bundledAdditionalItems,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/security/SecuritySchemeBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/security/SecuritySchemeBundler.kt
@@ -1,34 +1,45 @@
 package dev.banking.asyncapi.generator.core.bundler.security
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.security.SecuritySchemeInterface
 
+/**
+ * Bundles security scheme objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `SecuritySchemeBundlerTest`
+ */
 class SecuritySchemeBundler {
 
     fun bundleMap(schemes: Map<String, SecuritySchemeInterface>?, visited: Set<String>): Map<String, SecuritySchemeInterface>? =
+        bundleMap(schemes, BundlingContext.from(visited))
+
+    fun bundleMap(
+        schemes: Map<String, SecuritySchemeInterface>?,
+        context: BundlingContext,
+    ): Map<String, SecuritySchemeInterface>? =
         schemes?.mapValues { (_, scheme) ->
-            when (scheme) {
-                is SecuritySchemeInterface.SecuritySchemeReference -> {
-                    val ref = scheme.reference.ref
-                    if (!visited.contains(ref)) {
-                        scheme.reference.inline()
-                    }
-                    scheme
-                }
-                else -> scheme
-            }
+            bundle(scheme, context)
         }
 
     fun bundleList(schemes: List<SecuritySchemeInterface>?, visited: Set<String>): List<SecuritySchemeInterface>? =
+        bundleList(schemes, BundlingContext.from(visited))
+
+    fun bundleList(
+        schemes: List<SecuritySchemeInterface>?,
+        context: BundlingContext,
+    ): List<SecuritySchemeInterface>? =
         schemes?.map { scheme ->
-            when (scheme) {
-                is SecuritySchemeInterface.SecuritySchemeReference -> {
-                    val ref = scheme.reference.ref
-                    if (!visited.contains(ref)) {
-                        scheme.reference.inline()
-                    }
-                    scheme
-                }
-                else -> scheme
+            bundle(scheme, context)
+        }
+
+    fun bundle(scheme: SecuritySchemeInterface, context: BundlingContext): SecuritySchemeInterface =
+        when (scheme) {
+            is SecuritySchemeInterface.SecuritySchemeReference -> {
+                ReferenceBundler.inlineIfUnvisited(scheme.reference, context)
+                scheme
             }
+            else -> scheme
         }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerBundler.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler.servers
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.bundler.bindings.BindingBundler
 import dev.banking.asyncapi.generator.core.bundler.externaldocs.ExternalDocsBundler
 import dev.banking.asyncapi.generator.core.bundler.security.SecuritySchemeBundler
@@ -7,6 +9,12 @@ import dev.banking.asyncapi.generator.core.bundler.tags.TagBundler
 import dev.banking.asyncapi.generator.core.model.servers.Server
 import dev.banking.asyncapi.generator.core.model.servers.ServerInterface
 
+/**
+ * Bundles server objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `ServerBundlerTest`
+ */
 class ServerBundler {
 
     private val tagBundler = TagBundler()
@@ -18,6 +26,12 @@ class ServerBundler {
     fun bundleServers(
         servers: Map<String, ServerInterface>?,
         visited: Set<String>,
+    ): Map<String, ServerInterface>? =
+        bundleServers(servers, BundlingContext.from(visited))
+
+    fun bundleServers(
+        servers: Map<String, ServerInterface>?,
+        context: BundlingContext,
     ): Map<String, ServerInterface>? {
         if (servers == null) return null
 
@@ -25,32 +39,31 @@ class ServerBundler {
             when (serverInterface) {
                 is ServerInterface.ServerInline ->
                     ServerInterface.ServerInline(
-                        bundleServer(serverInterface.server, visited)
+                        bundleServer(serverInterface.server, context)
                     )
 
                 is ServerInterface.ServerReference -> {
-                    val ref = serverInterface.reference.ref
-                    if (visited.contains(ref)) {
-                        serverInterface
-                    } else {
-                        val serverModel = serverInterface.reference.requireModel<Server>()
-                        val newVisited = visited + ref
-                        val bundledServer = bundleServer(serverModel, newVisited)
-                        serverInterface.reference.model = bundledServer
-                        serverInterface.reference.inline()
-                        serverInterface
+                    ReferenceBundler.bundleReferencedModel<Server>(
+                        reference = serverInterface.reference,
+                        context = context,
+                    ) { server, nextContext ->
+                        bundleServer(server, nextContext)
                     }
+                    serverInterface
                 }
             }
         }
     }
 
-    fun bundleServer(server: Server, visited: Set<String>): Server {
-        val bundledVariables = serverVariableBundler.bundleMap(server.variables, visited)
-        val bundledSecurity = securitySchemeBundler.bundleList(server.security, visited)
-        val bundledTags = tagBundler.bundleList(server.tags, visited)
-        val bundledExternalDocs = server.externalDocs?.let { externalDocsBundler.bundle(it, visited) }
-        val bundledBindings = bindingBundler.bundleMap(server.bindings, visited)
+    fun bundleServer(server: Server, visited: Set<String>): Server =
+        bundleServer(server, BundlingContext.from(visited))
+
+    fun bundleServer(server: Server, context: BundlingContext): Server {
+        val bundledVariables = serverVariableBundler.bundleMap(server.variables, context)
+        val bundledSecurity = securitySchemeBundler.bundleList(server.security, context)
+        val bundledTags = tagBundler.bundleList(server.tags, context)
+        val bundledExternalDocs = server.externalDocs?.let { externalDocsBundler.bundle(it, context) }
+        val bundledBindings = bindingBundler.bundleMap(server.bindings, context)
         return server.copy(
             variables = bundledVariables,
             security = bundledSecurity,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerVariableBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerVariableBundler.kt
@@ -1,30 +1,42 @@
 package dev.banking.asyncapi.generator.core.bundler.servers
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.servers.ServerVariableInterface
 
+/**
+ * Bundles server variable objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `ServerVariableBundlerTest`
+ */
 class ServerVariableBundler {
 
     fun bundleMap(
         variables: Map<String, ServerVariableInterface>?,
         visited: Set<String>
     ): Map<String, ServerVariableInterface>? =
+        bundleMap(variables, BundlingContext.from(visited))
+
+    fun bundleMap(
+        variables: Map<String, ServerVariableInterface>?,
+        context: BundlingContext,
+    ): Map<String, ServerVariableInterface>? =
         variables?.mapValues { (_, variable) ->
-            bundle(variable, visited)
+            bundle(variable, context)
         }
 
     fun bundle(variable: ServerVariableInterface, visited: Set<String>): ServerVariableInterface =
+        bundle(variable, BundlingContext.from(visited))
+
+    fun bundle(variable: ServerVariableInterface, context: BundlingContext): ServerVariableInterface =
         when (variable) {
             is ServerVariableInterface.ServerVariableInline -> {
                 variable
             }
             is ServerVariableInterface.ServerVariableReference -> {
-                val ref = variable.reference.ref
-                if (visited.contains(ref)) {
-                    variable
-                } else {
-                    variable.reference.inline()
-                    variable
-                }
+                ReferenceBundler.inlineIfUnvisited(variable.reference, context)
+                variable
             }
         }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/tags/TagBundler.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/bundler/tags/TagBundler.kt
@@ -1,34 +1,39 @@
 package dev.banking.asyncapi.generator.core.bundler.tags
 
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.bundler.ReferenceBundler
 import dev.banking.asyncapi.generator.core.model.tags.TagInterface
 
+/**
+ * Bundles tag objects and references.
+ *
+ * Expected behavior is covered by:
+ * - `TagBundlerTest`
+ */
 class TagBundler {
 
     fun bundleMap(tags: Map<String, TagInterface>?, visited: Set<String>): Map<String, TagInterface>? =
+        bundleMap(tags, BundlingContext.from(visited))
+
+    fun bundleMap(tags: Map<String, TagInterface>?, context: BundlingContext): Map<String, TagInterface>? =
         tags?.mapValues { (_, tag) ->
-            when (tag) {
-                is TagInterface.TagReference -> {
-                    val ref = tag.reference.ref
-                    if (!visited.contains(ref)) {
-                        tag.reference.inline()
-                    }
-                    tag
-                }
-                else -> tag
-            }
+            bundle(tag, context)
         }
 
     fun bundleList(tags: List<TagInterface>?, visited: Set<String>): List<TagInterface>? =
+        bundleList(tags, BundlingContext.from(visited))
+
+    fun bundleList(tags: List<TagInterface>?, context: BundlingContext): List<TagInterface>? =
         tags?.map { tag ->
-            when (tag) {
-                is TagInterface.TagReference -> {
-                    val ref = tag.reference.ref
-                    if (!visited.contains(ref)) {
-                        tag.reference.inline()
-                    }
-                    tag
-                }
-                else -> tag
+            bundle(tag, context)
+        }
+
+    fun bundle(tag: TagInterface, context: BundlingContext): TagInterface =
+        when (tag) {
+            is TagInterface.TagReference -> {
+                ReferenceBundler.inlineIfUnvisited(tag.reference, context)
+                tag
             }
+            else -> tag
         }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/AsyncApiBundlerContractTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/AsyncApiBundlerContractTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler
+
+import dev.banking.asyncapi.generator.core.fixtures.BundlerFixtures
+import dev.banking.asyncapi.generator.core.fixtures.TestResources
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AsyncApiBundlerContractTest {
+
+    private val bundlerFixtures = BundlerFixtures()
+    private val bundlingStage: BundlingStage = AsyncApiBundler()
+
+    @Test
+    fun `bundling stage consumes a parsed and validated document`() {
+        val document = bundlerFixtures.validatedDocument(TestResources.file("asyncapi_kafka_single_file_example.yaml"))
+
+        val bundled = bundlingStage.bundle(document)
+
+        assertThat(bundled)
+            .usingRecursiveComparison()
+            .ignoringFieldsMatchingRegexes(".*sourceId", ".*inline")
+            .isEqualTo(document)
+    }
+
+    @Test
+    fun `bundling stage handles an already validated multi-file document`() {
+        val document = bundlerFixtures.validatedDocument("bundler/multi/asyncapi_multifile_example_main.yaml")
+
+        val bundled = bundlingStage.bundle(document)
+
+        assertThat(bundled.channels).isNotNull
+        assertThat(bundled.components).isNotNull
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/BundlingContextTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/BundlingContextTest.kt
@@ -1,0 +1,27 @@
+package dev.banking.asyncapi.generator.core.bundler
+
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BundlingContextTest {
+
+    @Test
+    fun `empty context has no visited references`() {
+        val reference = Reference("#/components/schemas/User")
+
+        val context = BundlingContext.empty()
+
+        assertThat(context.hasVisited(reference)).isFalse()
+    }
+
+    @Test
+    fun `enter returns a context with the visited reference`() {
+        val original = BundlingContext.empty()
+
+        val next = original.enter("#/components/schemas/User")
+
+        assertThat(original.hasVisited("#/components/schemas/User")).isFalse()
+        assertThat(next.hasVisited("#/components/schemas/User")).isTrue()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundlerTest.kt
@@ -1,6 +1,7 @@
 package dev.banking.asyncapi.generator.core.bundler
 
 import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.servers.Server
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -22,5 +23,38 @@ class ReferenceBundlerTest {
         ReferenceBundler.inlineIfUnvisited(reference, BundlingContext.empty().enter(reference))
 
         assertThat(reference.inline).isFalse()
+    }
+
+    @Test
+    fun `bundleReferencedModel bundles and inlines an unvisited referenced model`() {
+        val reference = Reference(
+            ref = "#/components/servers/production",
+            model = Server(host = "kafka.example.com", protocol = "kafka"),
+        )
+
+        ReferenceBundler.bundleReferencedModel<Server>(reference, BundlingContext.empty()) { server, context ->
+            assertThat(context.hasVisited(reference)).isTrue()
+            server.copy(description = "Bundled server")
+        }
+
+        assertThat(reference.inline).isTrue()
+        assertThat(reference.model)
+            .isEqualTo(Server(host = "kafka.example.com", protocol = "kafka", description = "Bundled server"))
+    }
+
+    @Test
+    fun `bundleReferencedModel keeps a visited referenced model unchanged`() {
+        val model = Server(host = "kafka.example.com", protocol = "kafka")
+        val reference = Reference(
+            ref = "#/components/servers/production",
+            model = model,
+        )
+
+        ReferenceBundler.bundleReferencedModel<Server>(reference, BundlingContext.empty().enter(reference)) { server, _ ->
+            server.copy(description = "Should not be applied")
+        }
+
+        assertThat(reference.inline).isFalse()
+        assertThat(reference.model).isSameAs(model)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/ReferenceBundlerTest.kt
@@ -1,0 +1,26 @@
+package dev.banking.asyncapi.generator.core.bundler
+
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ReferenceBundlerTest {
+
+    @Test
+    fun `inlineIfUnvisited marks an unvisited reference as inline`() {
+        val reference = Reference("#/components/externalDocs/api")
+
+        ReferenceBundler.inlineIfUnvisited(reference, BundlingContext.empty())
+
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `inlineIfUnvisited keeps a visited reference unchanged`() {
+        val reference = Reference("#/components/externalDocs/api")
+
+        ReferenceBundler.inlineIfUnvisited(reference, BundlingContext.empty().enter(reference))
+
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/bindings/BindingBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/bindings/BindingBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.bindings
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.bindings.BindingInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BindingBundlerTest {
+
+    private val bundler = BindingBundler()
+
+    @Test
+    fun `bundle marks an unvisited binding reference as inline`() {
+        val reference = Reference("#/components/messageBindings/kafka")
+        val binding = BindingInterface.BindingReference(reference)
+
+        val bundled = bundler.bundle(binding, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(binding)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited binding reference unchanged`() {
+        val reference = Reference("#/components/messageBindings/kafka")
+        val binding = BindingInterface.BindingReference(reference)
+
+        val bundled = bundler.bundle(binding, BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).isSameAs(binding)
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/channels/ChannelBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/channels/ChannelBundlerTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.bundler.channels
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.channels.Channel
+import dev.banking.asyncapi.generator.core.model.channels.ChannelInterface
+import dev.banking.asyncapi.generator.core.model.messages.Message
+import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ChannelBundlerTest {
+
+    private val bundler = ChannelBundler()
+
+    @Test
+    fun `bundle bundles and inlines an unvisited channel reference`() {
+        val messageReference = Reference("#/components/messages/userUpdated", model = Message(name = "userUpdated"))
+        val channel = Channel(
+            address = "users.updated",
+            messages = mapOf("userUpdated" to MessageInterface.MessageReference(messageReference)),
+        )
+        val channelReference = Reference("#/channels/userUpdated", model = channel)
+        val channelInterface = ChannelInterface.ChannelReference(channelReference)
+
+        val bundled = bundler.bundle(channelInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(channelInterface)
+        assertThat(channelReference.inline).isTrue()
+        assertThat(channelReference.model).isInstanceOf(Channel::class.java)
+        assertThat(messageReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited channel reference unchanged`() {
+        val channel = Channel(address = "users.updated")
+        val channelReference = Reference("#/channels/userUpdated", model = channel)
+        val channelInterface = ChannelInterface.ChannelReference(channelReference)
+
+        val bundled = bundler.bundle(channelInterface, BundlingContext.empty().enter(channelReference))
+
+        assertThat(bundled).isSameAs(channelInterface)
+        assertThat(channelReference.inline).isFalse()
+        assertThat(channelReference.model).isSameAs(channel)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/components/ComponentBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/components/ComponentBundlerTest.kt
@@ -1,0 +1,45 @@
+package dev.banking.asyncapi.generator.core.bundler.components
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.components.Component
+import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ComponentBundlerTest {
+
+    private val bundler = ComponentBundler()
+
+    @Test
+    fun `bundleComponents bundles and inlines an unvisited component reference`() {
+        val schemaReference = Reference("#/components/schemas/User", model = Schema(type = "object"))
+        val component = Component(
+            schemas = mapOf("User" to SchemaInterface.SchemaReference(schemaReference)),
+        )
+        val componentReference = Reference("#/components", model = component)
+        val componentInterface = ComponentInterface.ComponentReference(componentReference)
+
+        val bundled = bundler.bundleComponents(componentInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(componentInterface)
+        assertThat(componentReference.inline).isTrue()
+        assertThat(componentReference.model).isInstanceOf(Component::class.java)
+        assertThat(schemaReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundleComponents keeps a visited component reference unchanged`() {
+        val component = Component()
+        val componentReference = Reference("#/components", model = component)
+        val componentInterface = ComponentInterface.ComponentReference(componentReference)
+
+        val bundled = bundler.bundleComponents(componentInterface, BundlingContext.empty().enter(componentReference))
+
+        assertThat(bundled).isSameAs(componentInterface)
+        assertThat(componentReference.inline).isFalse()
+        assertThat(componentReference.model).isSameAs(component)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/correlations/CorrelationIdBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/correlations/CorrelationIdBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.correlations
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.correlations.CorrelationIdInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CorrelationIdBundlerTest {
+
+    private val bundler = CorrelationIdBundler()
+
+    @Test
+    fun `bundle marks an unvisited correlation ID reference as inline`() {
+        val reference = Reference("#/components/correlationIds/user")
+        val correlationId = CorrelationIdInterface.CorrelationIdReference(reference)
+
+        val bundled = bundler.bundle(correlationId, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(correlationId)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundleMap keeps a visited correlation ID reference unchanged`() {
+        val reference = Reference("#/components/correlationIds/user")
+        val correlationId = CorrelationIdInterface.CorrelationIdReference(reference)
+
+        val bundled = bundler.bundleMap(mapOf("user" to correlationId), BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).containsEntry("user", correlationId)
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/externaldocs/ExternalDocsBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/externaldocs/ExternalDocsBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.externaldocs
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.externaldocs.ExternalDocInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExternalDocsBundlerTest {
+
+    private val bundler = ExternalDocsBundler()
+
+    @Test
+    fun `bundle marks an unvisited external documentation reference as inline`() {
+        val reference = Reference("#/components/externalDocs/api")
+        val externalDoc = ExternalDocInterface.ExternalDocReference(reference)
+
+        val bundled = bundler.bundle(externalDoc, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(externalDoc)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited external documentation reference unchanged`() {
+        val reference = Reference("#/components/externalDocs/api")
+        val externalDoc = ExternalDocInterface.ExternalDocReference(reference)
+
+        val bundled = bundler.bundle(externalDoc, BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).isSameAs(externalDoc)
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/info/InfoBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/info/InfoBundlerTest.kt
@@ -1,0 +1,48 @@
+package dev.banking.asyncapi.generator.core.bundler.info
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.externaldocs.ExternalDocInterface
+import dev.banking.asyncapi.generator.core.model.info.Info
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.tags.TagInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class InfoBundlerTest {
+
+    private val bundler = InfoBundler()
+
+    @Test
+    fun `bundle marks unvisited info references as inline`() {
+        val tagReference = Reference("#/components/tags/public")
+        val externalDocReference = Reference("#/components/externalDocs/api")
+        val info = Info(
+            title = "User API",
+            version = "1.0.0",
+            tags = listOf(TagInterface.TagReference(tagReference)),
+            externalDocs = ExternalDocInterface.ExternalDocReference(externalDocReference),
+        )
+
+        val bundled = bundler.bundle(info, BundlingContext.empty())
+
+        assertThat(bundled.tags).containsExactly(TagInterface.TagReference(tagReference))
+        assertThat(bundled.externalDocs).isEqualTo(ExternalDocInterface.ExternalDocReference(externalDocReference))
+        assertThat(tagReference.inline).isTrue()
+        assertThat(externalDocReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps visited info references unchanged`() {
+        val tagReference = Reference("#/components/tags/public")
+        val info = Info(
+            title = "User API",
+            version = "1.0.0",
+            tags = listOf(TagInterface.TagReference(tagReference)),
+        )
+
+        val bundled = bundler.bundle(info, BundlingContext.empty().enter(tagReference))
+
+        assertThat(bundled.tags).containsExactly(TagInterface.TagReference(tagReference))
+        assertThat(tagReference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessageTraitBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessageTraitBundlerTest.kt
@@ -1,0 +1,45 @@
+package dev.banking.asyncapi.generator.core.bundler.messages
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.bindings.BindingInterface
+import dev.banking.asyncapi.generator.core.model.messages.MessageTrait
+import dev.banking.asyncapi.generator.core.model.messages.MessageTraitInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MessageTraitBundlerTest {
+
+    private val bundler = MessageTraitBundler()
+
+    @Test
+    fun `bundle bundles and inlines an unvisited message trait reference`() {
+        val bindingReference = Reference("#/components/messageBindings/kafka")
+        val trait = MessageTrait(
+            bindings = mapOf("kafka" to BindingInterface.BindingReference(bindingReference)),
+        )
+        val traitReference = Reference("#/components/messageTraits/audit", model = trait)
+        val traitInterface = MessageTraitInterface.ReferenceMessageTrait(traitReference)
+
+        val bundled = bundler.bundle(traitInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(traitInterface)
+        assertThat(traitReference.inline).isTrue()
+        assertThat(traitReference.model).isInstanceOf(MessageTrait::class.java)
+        assertThat((traitReference.model as MessageTrait).bindings).containsKey("kafka")
+        assertThat(bindingReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited message trait reference unchanged`() {
+        val trait = MessageTrait(name = "audit")
+        val traitReference = Reference("#/components/messageTraits/audit", model = trait)
+        val traitInterface = MessageTraitInterface.ReferenceMessageTrait(traitReference)
+
+        val bundled = bundler.bundle(traitInterface, BundlingContext.empty().enter(traitReference))
+
+        assertThat(bundled).isSameAs(traitInterface)
+        assertThat(traitReference.inline).isFalse()
+        assertThat(traitReference.model).isSameAs(trait)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessagesBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/messages/MessagesBundlerTest.kt
@@ -1,0 +1,46 @@
+package dev.banking.asyncapi.generator.core.bundler.messages
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.messages.Message
+import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MessagesBundlerTest {
+
+    private val bundler = MessagesBundler()
+
+    @Test
+    fun `bundle bundles and inlines an unvisited message reference`() {
+        val payloadReference = Reference("#/components/schemas/User", model = Schema(type = "object"))
+        val message = Message(
+            name = "userUpdated",
+            payload = SchemaInterface.SchemaReference(payloadReference),
+        )
+        val messageReference = Reference("#/components/messages/userUpdated", model = message)
+        val messageInterface = MessageInterface.MessageReference(messageReference)
+
+        val bundled = bundler.bundle(messageInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(messageInterface)
+        assertThat(messageReference.inline).isTrue()
+        assertThat(messageReference.model).isInstanceOf(Message::class.java)
+        assertThat(((messageReference.model as Message).payload as SchemaInterface.SchemaReference).reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited message reference unchanged`() {
+        val message = Message(name = "userUpdated")
+        val messageReference = Reference("#/components/messages/userUpdated", model = message)
+        val messageInterface = MessageInterface.MessageReference(messageReference)
+
+        val bundled = bundler.bundle(messageInterface, BundlingContext.empty().enter(messageReference))
+
+        assertThat(bundled).isSameAs(messageInterface)
+        assertThat(messageReference.inline).isFalse()
+        assertThat(messageReference.model).isSameAs(message)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationBundlerTest.kt
@@ -1,0 +1,56 @@
+package dev.banking.asyncapi.generator.core.bundler.operations
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.operations.Operation
+import dev.banking.asyncapi.generator.core.model.operations.OperationInterface
+import dev.banking.asyncapi.generator.core.model.operations.OperationReply
+import dev.banking.asyncapi.generator.core.model.operations.OperationReplyInterface
+import dev.banking.asyncapi.generator.core.model.operations.OperationTrait
+import dev.banking.asyncapi.generator.core.model.operations.OperationTraitInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OperationBundlerTest {
+
+    private val bundler = OperationBundler()
+
+    @Test
+    fun `bundle bundles and inlines an unvisited operation reference`() {
+        val traitReference = Reference("#/components/operationTraits/audit", model = OperationTrait(title = "Audit"))
+        val replyChannelReference = Reference("#/channels/reply")
+        val replyReference = Reference(
+            ref = "#/components/replies/success",
+            model = OperationReply(channel = replyChannelReference),
+        )
+        val operation = Operation(
+            action = "send",
+            traits = listOf(OperationTraitInterface.OperationTraitReference(traitReference)),
+            reply = OperationReplyInterface.OperationReplyReference(replyReference),
+        )
+        val operationReference = Reference("#/operations/sendUserUpdated", model = operation)
+        val operationInterface = OperationInterface.OperationReference(operationReference)
+
+        val bundled = bundler.bundle(operationInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(operationInterface)
+        assertThat(operationReference.inline).isTrue()
+        assertThat(operationReference.model).isInstanceOf(Operation::class.java)
+        assertThat(traitReference.inline).isTrue()
+        assertThat(replyReference.inline).isTrue()
+        assertThat(replyChannelReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited operation reference unchanged`() {
+        val operation = Operation(action = "send")
+        val operationReference = Reference("#/operations/sendUserUpdated", model = operation)
+        val operationInterface = OperationInterface.OperationReference(operationReference)
+
+        val bundled = bundler.bundle(operationInterface, BundlingContext.empty().enter(operationReference))
+
+        assertThat(bundled).isSameAs(operationInterface)
+        assertThat(operationReference.inline).isFalse()
+        assertThat(operationReference.model).isSameAs(operation)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyAddressBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyAddressBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.operations
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OperationReplyAddressBundlerTest {
+
+    private val bundler = OperationReplyAddressBundler()
+
+    @Test
+    fun `bundle marks an unvisited operation reply address reference as inline`() {
+        val reference = Reference("#/components/replyAddresses/success")
+        val replyAddress = OperationReplyAddressInterface.OperationReplyAddressReference(reference)
+
+        val bundled = bundler.bundle(replyAddress, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(replyAddress)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundleMap keeps a visited operation reply address reference unchanged`() {
+        val reference = Reference("#/components/replyAddresses/success")
+        val replyAddress = OperationReplyAddressInterface.OperationReplyAddressReference(reference)
+
+        val bundled = bundler.bundleMap(mapOf("success" to replyAddress), BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).containsEntry("success", replyAddress)
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationReplyBundlerTest.kt
@@ -1,0 +1,50 @@
+package dev.banking.asyncapi.generator.core.bundler.operations
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.operations.OperationReply
+import dev.banking.asyncapi.generator.core.model.operations.OperationReplyAddressInterface
+import dev.banking.asyncapi.generator.core.model.operations.OperationReplyInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OperationReplyBundlerTest {
+
+    private val bundler = OperationReplyBundler()
+
+    @Test
+    fun `bundle bundles and inlines an unvisited operation reply reference`() {
+        val addressReference = Reference("#/components/replyAddresses/success")
+        val channelReference = Reference("#/channels/reply")
+        val messageReference = Reference("#/components/messages/reply")
+        val reply = OperationReply(
+            address = OperationReplyAddressInterface.OperationReplyAddressReference(addressReference),
+            channel = channelReference,
+            messages = listOf(messageReference),
+        )
+        val replyReference = Reference("#/components/replies/success", model = reply)
+        val replyInterface = OperationReplyInterface.OperationReplyReference(replyReference)
+
+        val bundled = bundler.bundle(replyInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(replyInterface)
+        assertThat(replyReference.inline).isTrue()
+        assertThat(replyReference.model).isInstanceOf(OperationReply::class.java)
+        assertThat(addressReference.inline).isTrue()
+        assertThat(channelReference.inline).isTrue()
+        assertThat(messageReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited operation reply reference unchanged`() {
+        val reply = OperationReply(channel = Reference("#/channels/reply"))
+        val replyReference = Reference("#/components/replies/success", model = reply)
+        val replyInterface = OperationReplyInterface.OperationReplyReference(replyReference)
+
+        val bundled = bundler.bundle(replyInterface, BundlingContext.empty().enter(replyReference))
+
+        assertThat(bundled).isSameAs(replyInterface)
+        assertThat(replyReference.inline).isFalse()
+        assertThat(replyReference.model).isSameAs(reply)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationTraitBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/operations/OperationTraitBundlerTest.kt
@@ -1,0 +1,45 @@
+package dev.banking.asyncapi.generator.core.bundler.operations
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.bindings.BindingInterface
+import dev.banking.asyncapi.generator.core.model.operations.OperationTrait
+import dev.banking.asyncapi.generator.core.model.operations.OperationTraitInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OperationTraitBundlerTest {
+
+    private val bundler = OperationTraitBundler()
+
+    @Test
+    fun `bundle bundles and inlines an unvisited operation trait reference`() {
+        val bindingReference = Reference("#/components/operationBindings/kafka")
+        val trait = OperationTrait(
+            bindings = mapOf("kafka" to BindingInterface.BindingReference(bindingReference)),
+        )
+        val traitReference = Reference("#/components/operationTraits/audit", model = trait)
+        val traitInterface = OperationTraitInterface.OperationTraitReference(traitReference)
+
+        val bundled = bundler.bundle(traitInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(traitInterface)
+        assertThat(traitReference.inline).isTrue()
+        assertThat(traitReference.model).isInstanceOf(OperationTrait::class.java)
+        assertThat((traitReference.model as OperationTrait).bindings).containsKey("kafka")
+        assertThat(bindingReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited operation trait reference unchanged`() {
+        val trait = OperationTrait(title = "Audit")
+        val traitReference = Reference("#/components/operationTraits/audit", model = trait)
+        val traitInterface = OperationTraitInterface.OperationTraitReference(traitReference)
+
+        val bundled = bundler.bundle(traitInterface, BundlingContext.empty().enter(traitReference))
+
+        assertThat(bundled).isSameAs(traitInterface)
+        assertThat(traitReference.inline).isFalse()
+        assertThat(traitReference.model).isSameAs(trait)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/parameters/ParameterBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/parameters/ParameterBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.parameters
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.parameters.ParameterInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ParameterBundlerTest {
+
+    private val bundler = ParameterBundler()
+
+    @Test
+    fun `bundleMap marks an unvisited parameter reference as inline`() {
+        val reference = Reference("#/components/parameters/userId")
+        val parameter = ParameterInterface.ParameterReference(reference)
+
+        val bundled = bundler.bundleMap(mapOf("userId" to parameter), BundlingContext.empty())
+
+        assertThat(bundled).containsEntry("userId", parameter)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited parameter reference unchanged`() {
+        val reference = Reference("#/components/parameters/userId")
+        val parameter = ParameterInterface.ParameterReference(reference)
+
+        val bundled = bundler.bundle(parameter, BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).isSameAs(parameter)
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/schemas/SchemaBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/schemas/SchemaBundlerTest.kt
@@ -1,0 +1,77 @@
+package dev.banking.asyncapi.generator.core.bundler.schemas
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.bindings.BindingInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SchemaBundlerTest {
+
+    private val bundler = SchemaBundler()
+
+    @Test
+    fun `bundle keeps an unvisited component schema reference and bundles its model`() {
+        val bindingReference = Reference("#/components/schemaBindings/kafka")
+        val schema = Schema(
+            type = "object",
+            bindings = mapOf("kafka" to BindingInterface.BindingReference(bindingReference)),
+        )
+        val schemaReference = Reference("#/components/schemas/User", model = schema)
+        val schemaInterface = SchemaInterface.SchemaReference(schemaReference)
+
+        val bundled = bundler.bundle(schemaInterface, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(schemaInterface)
+        assertThat(schemaReference.inline).isTrue()
+        assertThat(schemaReference.model).isInstanceOf(Schema::class.java)
+        assertThat((schemaReference.model as Schema).bindings).containsKey("kafka")
+        assertThat(bindingReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle keeps a visited component schema reference unchanged`() {
+        val schema = Schema(type = "object")
+        val schemaReference = Reference("#/components/schemas/User", model = schema)
+        val schemaInterface = SchemaInterface.SchemaReference(schemaReference)
+
+        val bundled = bundler.bundle(schemaInterface, BundlingContext.empty().enter(schemaReference))
+
+        assertThat(bundled).isSameAs(schemaInterface)
+        assertThat(schemaReference.inline).isFalse()
+        assertThat(schemaReference.model).isSameAs(schema)
+    }
+
+    @Test
+    fun `bundle inlines an unvisited non-component schema reference`() {
+        val bindingReference = Reference("#/components/schemaBindings/kafka")
+        val schema = Schema(
+            type = "object",
+            bindings = mapOf("kafka" to BindingInterface.BindingReference(bindingReference)),
+        )
+        val schemaReference = Reference("schemas.yaml#/shared/User", model = schema)
+        val schemaInterface = SchemaInterface.SchemaReference(schemaReference)
+
+        val bundled = bundler.bundle(schemaInterface, BundlingContext.empty())
+
+        assertThat(bundled).isInstanceOf(SchemaInterface.SchemaInline::class.java)
+        assertThat((bundled as SchemaInterface.SchemaInline).schema.bindings).containsKey("kafka")
+        assertThat(schemaReference.inline).isFalse()
+        assertThat(bindingReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundle returns the model for a visited non-component schema reference`() {
+        val schema = Schema(type = "object")
+        val schemaReference = Reference("schemas.yaml#/shared/User", model = schema)
+        val schemaInterface = SchemaInterface.SchemaReference(schemaReference)
+
+        val bundled = bundler.bundle(schemaInterface, BundlingContext.empty().enter(schemaReference))
+
+        assertThat(bundled).isEqualTo(SchemaInterface.SchemaInline(schema))
+        assertThat(schemaReference.inline).isFalse()
+        assertThat(schemaReference.model).isSameAs(schema)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/security/SecuritySchemeBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/security/SecuritySchemeBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.security
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.security.SecuritySchemeInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SecuritySchemeBundlerTest {
+
+    private val bundler = SecuritySchemeBundler()
+
+    @Test
+    fun `bundleList marks an unvisited security scheme reference as inline`() {
+        val reference = Reference("#/components/securitySchemes/sasl")
+        val securityScheme = SecuritySchemeInterface.SecuritySchemeReference(reference)
+
+        val bundled = bundler.bundleList(listOf(securityScheme), BundlingContext.empty())
+
+        assertThat(bundled).containsExactly(securityScheme)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundleMap keeps a visited security scheme reference unchanged`() {
+        val reference = Reference("#/components/securitySchemes/sasl")
+        val securityScheme = SecuritySchemeInterface.SecuritySchemeReference(reference)
+
+        val bundled = bundler.bundleMap(mapOf("sasl" to securityScheme), BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).containsEntry("sasl", securityScheme)
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerBundlerTest.kt
@@ -1,0 +1,50 @@
+package dev.banking.asyncapi.generator.core.bundler.servers
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.bindings.BindingInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.servers.Server
+import dev.banking.asyncapi.generator.core.model.servers.ServerInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ServerBundlerTest {
+
+    private val bundler = ServerBundler()
+
+    @Test
+    fun `bundleServers bundles and inlines an unvisited server reference`() {
+        val bindingReference = Reference("#/components/serverBindings/kafka")
+        val server = Server(
+            host = "kafka.example.com",
+            protocol = "kafka",
+            bindings = mapOf("kafka" to BindingInterface.BindingReference(bindingReference)),
+        )
+        val serverReference = Reference("#/components/servers/production", model = server)
+        val serverInterface = ServerInterface.ServerReference(serverReference)
+
+        val bundled = bundler.bundleServers(mapOf("production" to serverInterface), BundlingContext.empty())
+
+        assertThat(bundled).containsEntry("production", serverInterface)
+        assertThat(serverReference.inline).isTrue()
+        assertThat(serverReference.model)
+            .isEqualTo(server.copy(bindings = mapOf("kafka" to BindingInterface.BindingReference(bindingReference))))
+        assertThat(bindingReference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundleServers keeps a visited server reference unchanged`() {
+        val server = Server(host = "kafka.example.com", protocol = "kafka")
+        val serverReference = Reference("#/components/servers/production", model = server)
+        val serverInterface = ServerInterface.ServerReference(serverReference)
+
+        val bundled = bundler.bundleServers(
+            servers = mapOf("production" to serverInterface),
+            context = BundlingContext.empty().enter(serverReference),
+        )
+
+        assertThat(bundled).containsEntry("production", serverInterface)
+        assertThat(serverReference.inline).isFalse()
+        assertThat(serverReference.model).isSameAs(server)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerVariableBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/servers/ServerVariableBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.servers
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.servers.ServerVariableInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ServerVariableBundlerTest {
+
+    private val bundler = ServerVariableBundler()
+
+    @Test
+    fun `bundle marks an unvisited server variable reference as inline`() {
+        val reference = Reference("#/components/serverVariables/environment")
+        val serverVariable = ServerVariableInterface.ServerVariableReference(reference)
+
+        val bundled = bundler.bundle(serverVariable, BundlingContext.empty())
+
+        assertThat(bundled).isSameAs(serverVariable)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundleMap keeps a visited server variable reference unchanged`() {
+        val reference = Reference("#/components/serverVariables/environment")
+        val serverVariable = ServerVariableInterface.ServerVariableReference(reference)
+
+        val bundled = bundler.bundleMap(mapOf("environment" to serverVariable), BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).containsEntry("environment", serverVariable)
+        assertThat(reference.inline).isFalse()
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/tags/TagBundlerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/bundler/tags/TagBundlerTest.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.bundler.tags
+
+import dev.banking.asyncapi.generator.core.bundler.BundlingContext
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.tags.TagInterface
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TagBundlerTest {
+
+    private val bundler = TagBundler()
+
+    @Test
+    fun `bundleList marks an unvisited tag reference as inline`() {
+        val reference = Reference("#/components/tags/audit")
+        val tag = TagInterface.TagReference(reference)
+
+        val bundled = bundler.bundleList(listOf(tag), BundlingContext.empty())
+
+        assertThat(bundled).containsExactly(tag)
+        assertThat(reference.inline).isTrue()
+    }
+
+    @Test
+    fun `bundleMap keeps a visited tag reference unchanged`() {
+        val reference = Reference("#/components/tags/audit")
+        val tag = TagInterface.TagReference(reference)
+
+        val bundled = bundler.bundleMap(mapOf("audit" to tag), BundlingContext.empty().enter(reference))
+
+        assertThat(bundled).containsEntry("audit", tag)
+        assertThat(reference.inline).isFalse()
+    }
+}


### PR DESCRIPTION
- Closes #104 
- Closes #105 
- Closes #106 

The previous bundler implementation already worked as a separate package, but the stage boundary was not explicit and common reference handling was repeated across many bundler classes.

This made the bundler harder to maintain because each object-specific bundler had its own version of the same logic: check whether a reference had already been visited, retrieve the referenced model, bundle the referenced model, assign it back to the reference, and mark the reference as inline.

For the proposed solution, a dedicated `BundlingStage` contract has been introduced. `AsyncApiBundler` now implements this contract and clearly documents that the bundler receives an already parsed and validated AsyncAPI model and returns a bundled model. The bundler does not read input files, parse YAML or JSON, validate AsyncAPI rules, or generate code.

A shared `BundlingContext` has also been introduced to carry visited-reference state through the bundling process. This replaces the previous pattern of passing a bare `Set<String>` through the bundler graph as the main implementation path.

Reference behavior has been centralized in `ReferenceBundler`. This helper now owns the common reference mechanics, including marking unvisited references as inline and bundling referenced models while updating the reference model. Object-specific bundlers still decide which fields to traverse, but they no longer duplicate the low-level reference handling logic.

The migration was applied across the bundler graph, including schemas, servers, messages, message traits, channels, operation replies, operation traits, operations, components, and info metadata. `AsyncApiBundler` now starts the stage with `BundlingContext.empty()` and passes that context through the bundler tree.

This keeps the existing bundling behavior, but makes the implementation simpler and more reliable because circular-reference tracking and inline-reference behavior now live in one place.

Direct tests were added for the new contract and shared helpers:

`AsyncApiBundlerContractTest`, `BundlingContextTest`, and `ReferenceBundlerTest`.

Focused bundler tests were also added for the migrated bundlers, including schemas, servers, channels, messages, message traits, operation replies, operation traits, operations, components, info metadata, and the smaller reference-only bundlers.