### PR TITLE
feature/generator model contract

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -93,7 +93,7 @@ class AsyncApiGenerator {
                     kotlinModelPreparer.prepare(
                         input = generationInput,
                         packageName = task.packageName,
-                        annotation = generatorOptions.configOptions["model.annotation"],
+                        annotation = task.annotation,
                     )
                 val generator =
                     KotlinGenerator(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -4,15 +4,12 @@ import dev.banking.asyncapi.generator.core.generator.avro.AvroGenerator
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInputFactory
 import dev.banking.asyncapi.generator.core.generator.java.JavaGenerator
 import dev.banking.asyncapi.generator.core.generator.java.JavaModelPreparer
-import dev.banking.asyncapi.generator.core.generator.java.factory.JavaGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaGenerator
 import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaSimpleGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinModelPreparer
-import dev.banking.asyncapi.generator.core.generator.kotlin.factory.KotlinGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaSimpleGenerator
-import dev.banking.asyncapi.generator.core.generator.loader.HeaderSchemaCollector
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
@@ -68,19 +65,13 @@ class AsyncApiGenerator {
                     }
                     val clientType = generatorOptions.configOptions["client.type"]
                     if (clientType != "spring-kafka-simple") {
-                        val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
-                        if (headerSchemas.isNotEmpty()) {
-                            val headerFactory =
-                                KotlinGeneratorModelFactory(
-                                    packageName = "${generatorOptions.clientPackage}.header",
-                                    context = generationInput.schemaContextWith(headerSchemas),
-                                    polymorphicRelationships = generationInput.polymorphicRelationships,
-                                    annotation = null,
-                                )
-                            val headerModels =
-                                headerSchemas.mapNotNull { (name, schema) ->
-                                    headerFactory.create(name, schema)
-                                }
+                        val headerModels =
+                            kotlinModelPreparer.prepareHeaders(
+                                input = generationInput,
+                                asyncApiDocument = asyncApiDocument,
+                                packageName = "${generatorOptions.clientPackage}.header",
+                            )
+                        if (headerModels.isNotEmpty()) {
                             val headerGenerator =
                                 KotlinGenerator(
                                     packageName = "${generatorOptions.clientPackage}.header",
@@ -137,18 +128,13 @@ class AsyncApiGenerator {
                     }
                     val clientType = generatorOptions.configOptions["client.type"]
                     if (clientType != "spring-kafka-simple") {
-                        val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
-                        if (headerSchemas.isNotEmpty()) {
-                            val headerFactory =
-                                JavaGeneratorModelFactory(
-                                    packageName = "${generatorOptions.clientPackage}.header",
-                                    context = generationInput.schemaContextWith(headerSchemas),
-                                    polymorphicRelationships = generationInput.polymorphicRelationships,
-                                )
-                            val headerModels =
-                                headerSchemas.mapNotNull { (name, schema) ->
-                                    headerFactory.create(name, schema)
-                                }
+                        val headerModels =
+                            javaModelPreparer.prepareHeaders(
+                                input = generationInput,
+                                asyncApiDocument = asyncApiDocument,
+                                packageName = "${generatorOptions.clientPackage}.header",
+                            )
+                        if (headerModels.isNotEmpty()) {
                             val headerGenerator =
                                 JavaGenerator(
                                     packageName = "${generatorOptions.clientPackage}.header",

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -1,9 +1,7 @@
 package dev.banking.asyncapi.generator.core.generator
 
-import dev.banking.asyncapi.generator.core.generator.analyzer.ChannelAnalyzer
-import dev.banking.asyncapi.generator.core.generator.analyzer.SchemaAnalyzer
 import dev.banking.asyncapi.generator.core.generator.avro.AvroGenerator
-import dev.banking.asyncapi.generator.core.generator.context.GeneratorContext
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInputFactory
 import dev.banking.asyncapi.generator.core.generator.java.JavaGenerator
 import dev.banking.asyncapi.generator.core.generator.java.factory.JavaGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaGenerator
@@ -12,12 +10,10 @@ import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.factory.KotlinGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaSimpleGenerator
-import dev.banking.asyncapi.generator.core.generator.loader.AsyncApiSchemaLoader
 import dev.banking.asyncapi.generator.core.generator.loader.HeaderSchemaCollector
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
-import dev.banking.asyncapi.generator.core.generator.normalizer.SchemaNormalizer
 import dev.banking.asyncapi.generator.core.generator.output.FileSystemGeneratedArtifactWriter
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 import org.slf4j.LoggerFactory
@@ -31,21 +27,13 @@ import org.slf4j.LoggerFactory
 class AsyncApiGenerator {
     private val log = LoggerFactory.getLogger(AsyncApiGenerator::class.java)
 
-    private val schemaAnalyzer = SchemaAnalyzer()
-    private val schemaNormalizer = SchemaNormalizer()
+    private val generationInputFactory = GenerationInputFactory()
 
     fun generate(
         asyncApiDocument: AsyncApiDocument,
         generatorOptions: GeneratorOptions,
     ) {
-        val schemas = AsyncApiSchemaLoader.load(asyncApiDocument)
-        val normalizedSchemas = schemaNormalizer.normalize(schemas)
-        val (analyzedSchemas, polymorphic) = schemaAnalyzer.analyze(normalizedSchemas)
-
-        val context = GeneratorContext(analyzedSchemas)
-
-        val channelAnalyzer = ChannelAnalyzer()
-        val analyzedChannels = channelAnalyzer.analyze(asyncApiDocument).channels
+        val generationInput = generationInputFactory.create(asyncApiDocument)
         val artifactWriter =
             FileSystemGeneratedArtifactWriter(
                 sourceOutputDirectory = generatorOptions.codegenOutputDirectory,
@@ -59,12 +47,12 @@ class AsyncApiGenerator {
                     val factory =
                         KotlinGeneratorModelFactory(
                             generatorOptions.modelPackage,
-                            context,
-                            polymorphic,
+                            generationInput.schemaContext,
+                            generationInput.polymorphicRelationships,
                             annotation,
                         )
                     val kotlinGenerationModel =
-                        analyzedSchemas.mapNotNull { (name, schema) ->
+                        generationInput.schemas.mapNotNull { (name, schema) ->
                             factory.create(name, schema)
                         }
                     val kotlinModelGenerator =
@@ -84,12 +72,11 @@ class AsyncApiGenerator {
                     if (clientType != "spring-kafka-simple") {
                         val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
                         if (headerSchemas.isNotEmpty()) {
-                            val headerContext = GeneratorContext(analyzedSchemas + headerSchemas)
                             val headerFactory =
                                 KotlinGeneratorModelFactory(
                                     packageName = "${generatorOptions.clientPackage}.header",
-                                    context = headerContext,
-                                    polymorphicRelationships = polymorphic,
+                                    context = generationInput.schemaContextWith(headerSchemas),
+                                    polymorphicRelationships = generationInput.polymorphicRelationships,
                                     annotation = null,
                                 )
                             val headerModels =
@@ -112,7 +99,7 @@ class AsyncApiGenerator {
                                 clientPackage = generatorOptions.clientPackage,
                                 modelPackage = generatorOptions.modelPackage,
                             )
-                        kafkaGenerator.generate(analyzedChannels)
+                        kafkaGenerator.generate(generationInput.channels)
                     } else {
                         val kafkaGenerator =
                             KotlinSpringKafkaGenerator(
@@ -122,7 +109,7 @@ class AsyncApiGenerator {
                                 topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
                                 resourceOutputDir = generatorOptions.resourceOutputDirectory,
                             )
-                        kafkaGenerator.generate(analyzedChannels)
+                        kafkaGenerator.generate(generationInput.channels)
                     }
                 }
 
@@ -133,9 +120,14 @@ class AsyncApiGenerator {
 
             JAVA -> {
                 if (generatorOptions.generateModels) {
-                    val factory = JavaGeneratorModelFactory(generatorOptions.modelPackage, context, polymorphic)
+                    val factory =
+                        JavaGeneratorModelFactory(
+                            generatorOptions.modelPackage,
+                            generationInput.schemaContext,
+                            generationInput.polymorphicRelationships,
+                        )
                     val javaGenerationModel =
-                        analyzedSchemas.mapNotNull { (name, schema) ->
+                        generationInput.schemas.mapNotNull { (name, schema) ->
                             factory.create(name, schema)
                         }
                     val javaGenerator =
@@ -154,12 +146,11 @@ class AsyncApiGenerator {
                     if (clientType != "spring-kafka-simple") {
                         val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
                         if (headerSchemas.isNotEmpty()) {
-                            val headerContext = GeneratorContext(analyzedSchemas + headerSchemas)
                             val headerFactory =
                                 JavaGeneratorModelFactory(
                                     packageName = "${generatorOptions.clientPackage}.header",
-                                    context = headerContext,
-                                    polymorphicRelationships = polymorphic,
+                                    context = generationInput.schemaContextWith(headerSchemas),
+                                    polymorphicRelationships = generationInput.polymorphicRelationships,
                                 )
                             val headerModels =
                                 headerSchemas.mapNotNull { (name, schema) ->
@@ -181,7 +172,7 @@ class AsyncApiGenerator {
                                 clientPackage = generatorOptions.clientPackage,
                                 modelPackage = generatorOptions.modelPackage,
                             )
-                        kafkaGenerator.generate(analyzedChannels)
+                        kafkaGenerator.generate(generationInput.channels)
                     } else {
                         val kafkaGenerator =
                             JavaSpringKafkaGenerator(
@@ -191,7 +182,7 @@ class AsyncApiGenerator {
                                 topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
                                 resourceOutputDir = generatorOptions.resourceOutputDirectory,
                             )
-                        kafkaGenerator.generate(analyzedChannels)
+                        kafkaGenerator.generate(generationInput.channels)
                     }
                 }
 
@@ -207,7 +198,7 @@ class AsyncApiGenerator {
                     outputDir = generatorOptions.resourceOutputDirectory,
                     packageName = generatorOptions.schemaPackage,
                 )
-            artifactWriter.write(avroGenerator.render(analyzedSchemas))
+            artifactWriter.write(avroGenerator.render(generationInput.schemas))
         }
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -3,10 +3,12 @@ package dev.banking.asyncapi.generator.core.generator
 import dev.banking.asyncapi.generator.core.generator.avro.AvroGenerator
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInputFactory
 import dev.banking.asyncapi.generator.core.generator.java.JavaGenerator
+import dev.banking.asyncapi.generator.core.generator.java.JavaModelPreparer
 import dev.banking.asyncapi.generator.core.generator.java.factory.JavaGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaGenerator
 import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaSimpleGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinGenerator
+import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinModelPreparer
 import dev.banking.asyncapi.generator.core.generator.kotlin.factory.KotlinGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaSimpleGenerator
@@ -28,6 +30,8 @@ class AsyncApiGenerator {
     private val log = LoggerFactory.getLogger(AsyncApiGenerator::class.java)
 
     private val generationInputFactory = GenerationInputFactory()
+    private val kotlinModelPreparer = KotlinModelPreparer()
+    private val javaModelPreparer = JavaModelPreparer()
 
     fun generate(
         asyncApiDocument: AsyncApiDocument,
@@ -43,18 +47,12 @@ class AsyncApiGenerator {
         when (generatorOptions.generatorName) {
             KOTLIN -> {
                 if (generatorOptions.generateModels) {
-                    val annotation = generatorOptions.configOptions["model.annotation"]
-                    val factory =
-                        KotlinGeneratorModelFactory(
-                            generatorOptions.modelPackage,
-                            generationInput.schemaContext,
-                            generationInput.polymorphicRelationships,
-                            annotation,
-                        )
                     val kotlinGenerationModel =
-                        generationInput.schemas.mapNotNull { (name, schema) ->
-                            factory.create(name, schema)
-                        }
+                        kotlinModelPreparer.prepare(
+                            input = generationInput,
+                            packageName = generatorOptions.modelPackage,
+                            annotation = generatorOptions.configOptions["model.annotation"],
+                        )
                     val kotlinModelGenerator =
                         KotlinGenerator(
                             packageName = generatorOptions.modelPackage,
@@ -120,16 +118,11 @@ class AsyncApiGenerator {
 
             JAVA -> {
                 if (generatorOptions.generateModels) {
-                    val factory =
-                        JavaGeneratorModelFactory(
-                            generatorOptions.modelPackage,
-                            generationInput.schemaContext,
-                            generationInput.polymorphicRelationships,
-                        )
                     val javaGenerationModel =
-                        generationInput.schemas.mapNotNull { (name, schema) ->
-                            factory.create(name, schema)
-                        }
+                        javaModelPreparer.prepare(
+                            input = generationInput,
+                            packageName = generatorOptions.modelPackage,
+                        )
                     val javaGenerator =
                         JavaGenerator(
                             packageName = generatorOptions.modelPackage,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -1,6 +1,7 @@
 package dev.banking.asyncapi.generator.core.generator
 
 import dev.banking.asyncapi.generator.core.generator.avro.AvroGenerator
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInputFactory
 import dev.banking.asyncapi.generator.core.generator.java.JavaGenerator
 import dev.banking.asyncapi.generator.core.generator.java.JavaModelPreparer
@@ -14,11 +15,15 @@ import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
 import dev.banking.asyncapi.generator.core.generator.output.FileSystemGeneratedArtifactWriter
+import dev.banking.asyncapi.generator.core.generator.output.GeneratedArtifactWriter
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationPlanner
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 import org.slf4j.LoggerFactory
 
 /**
- * Coordinates generator analysis and writes rendered artifacts to configured outputs.
+ * Coordinates generator input preparation, planning, rendering, and artifact writing.
  *
  * Expected behavior is covered by:
  * - `AsyncApiGeneratorOutputContractTest`
@@ -29,155 +34,205 @@ class AsyncApiGenerator {
     private val generationInputFactory = GenerationInputFactory()
     private val kotlinModelPreparer = KotlinModelPreparer()
     private val javaModelPreparer = JavaModelPreparer()
+    private val generationPlanner = GenerationPlanner()
 
     fun generate(
         asyncApiDocument: AsyncApiDocument,
         generatorOptions: GeneratorOptions,
     ) {
         val generationInput = generationInputFactory.create(asyncApiDocument)
+        val generationPlan = generationPlanner.plan(generatorOptions)
         val artifactWriter =
             FileSystemGeneratedArtifactWriter(
                 sourceOutputDirectory = generatorOptions.codegenOutputDirectory,
                 resourceOutputDirectory = generatorOptions.resourceOutputDirectory,
             )
 
-        when (generatorOptions.generatorName) {
-            KOTLIN -> {
-                if (generatorOptions.generateModels) {
-                    val kotlinGenerationModel =
-                        kotlinModelPreparer.prepare(
-                            input = generationInput,
-                            packageName = generatorOptions.modelPackage,
-                            annotation = generatorOptions.configOptions["model.annotation"],
-                        )
-                    val kotlinModelGenerator =
-                        KotlinGenerator(
-                            packageName = generatorOptions.modelPackage,
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            generationModel = kotlinGenerationModel,
-                        )
-                    artifactWriter.write(kotlinModelGenerator.render())
-                }
-
-                if (generatorOptions.generateSpringKafkaClient) {
-                    if (generatorOptions.kafkaTopicsPropertyPrefix.isBlank()) {
-                        throw IllegalArgumentException("kafka.topics.property.prefix cannot be empty")
-                    }
-                    val clientType = generatorOptions.configOptions["client.type"]
-                    if (clientType != "spring-kafka-simple") {
-                        val headerModels =
-                            kotlinModelPreparer.prepareHeaders(
-                                input = generationInput,
-                                asyncApiDocument = asyncApiDocument,
-                                packageName = "${generatorOptions.clientPackage}.header",
-                            )
-                        if (headerModels.isNotEmpty()) {
-                            val headerGenerator =
-                                KotlinGenerator(
-                                    packageName = "${generatorOptions.clientPackage}.header",
-                                    outputDir = generatorOptions.codegenOutputDirectory,
-                                    generationModel = headerModels,
-                                )
-                            artifactWriter.write(headerGenerator.render())
-                        }
-                    }
-                    if (clientType == "spring-kafka-simple") {
-                        val kafkaGenerator =
-                            KotlinSpringKafkaSimpleGenerator(
-                                outputDir = generatorOptions.codegenOutputDirectory,
-                                clientPackage = generatorOptions.clientPackage,
-                                modelPackage = generatorOptions.modelPackage,
-                            )
-                        kafkaGenerator.generate(generationInput.channels)
-                    } else {
-                        val kafkaGenerator =
-                            KotlinSpringKafkaGenerator(
-                                outputDir = generatorOptions.codegenOutputDirectory,
-                                clientPackage = generatorOptions.clientPackage,
-                                modelPackage = generatorOptions.modelPackage,
-                                topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
-                                resourceOutputDir = generatorOptions.resourceOutputDirectory,
-                            )
-                        kafkaGenerator.generate(generationInput.channels)
-                    }
-                }
-
-                if (generatorOptions.generateQuarkusKafkaClient) {
-                    log.info("Generate Kotlin Quarkus Kafka Client is not yet implemented. Skipping..")
-                }
+        generationPlan.tasks.forEach { task ->
+            when (task) {
+                is GenerationTask.ModelArtifacts ->
+                    writeModelArtifacts(
+                        task = task,
+                        generationInput = generationInput,
+                        generatorOptions = generatorOptions,
+                        artifactWriter = artifactWriter,
+                    )
+                is GenerationTask.HeaderModelArtifacts ->
+                    writeHeaderModelArtifacts(
+                        task = task,
+                        asyncApiDocument = asyncApiDocument,
+                        generationInput = generationInput,
+                        generatorOptions = generatorOptions,
+                        artifactWriter = artifactWriter,
+                    )
+                is GenerationTask.SpringKafkaClient ->
+                    generateSpringKafkaClient(
+                        task = task,
+                        generationInput = generationInput,
+                        generatorOptions = generatorOptions,
+                    )
+                is GenerationTask.QuarkusKafkaClient ->
+                    log.info("Generate ${task.language.name.titlecase()} Quarkus Kafka Client is not yet implemented. Skipping..")
+                is GenerationTask.AvroSchemaArtifacts ->
+                    writeAvroSchemaArtifacts(
+                        task = task,
+                        generationInput = generationInput,
+                        generatorOptions = generatorOptions,
+                        artifactWriter = artifactWriter,
+                    )
             }
-
-            JAVA -> {
-                if (generatorOptions.generateModels) {
-                    val javaGenerationModel =
-                        javaModelPreparer.prepare(
-                            input = generationInput,
-                            packageName = generatorOptions.modelPackage,
-                        )
-                    val javaGenerator =
-                        JavaGenerator(
-                            packageName = generatorOptions.modelPackage,
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            generationModel = javaGenerationModel,
-                        )
-                    artifactWriter.write(javaGenerator.render())
-                }
-                if (generatorOptions.generateSpringKafkaClient) {
-                    if (generatorOptions.kafkaTopicsPropertyPrefix.isBlank()) {
-                        throw IllegalArgumentException("kafka.topics.property.prefix cannot be empty")
-                    }
-                    val clientType = generatorOptions.configOptions["client.type"]
-                    if (clientType != "spring-kafka-simple") {
-                        val headerModels =
-                            javaModelPreparer.prepareHeaders(
-                                input = generationInput,
-                                asyncApiDocument = asyncApiDocument,
-                                packageName = "${generatorOptions.clientPackage}.header",
-                            )
-                        if (headerModels.isNotEmpty()) {
-                            val headerGenerator =
-                                JavaGenerator(
-                                    packageName = "${generatorOptions.clientPackage}.header",
-                                    outputDir = generatorOptions.codegenOutputDirectory,
-                                    generationModel = headerModels,
-                                )
-                            artifactWriter.write(headerGenerator.render())
-                        }
-                    }
-                    if (clientType == "spring-kafka-simple") {
-                        val kafkaGenerator =
-                            JavaSpringKafkaSimpleGenerator(
-                                outputDir = generatorOptions.codegenOutputDirectory,
-                                clientPackage = generatorOptions.clientPackage,
-                                modelPackage = generatorOptions.modelPackage,
-                            )
-                        kafkaGenerator.generate(generationInput.channels)
-                    } else {
-                        val kafkaGenerator =
-                            JavaSpringKafkaGenerator(
-                                outputDir = generatorOptions.codegenOutputDirectory,
-                                clientPackage = generatorOptions.clientPackage,
-                                modelPackage = generatorOptions.modelPackage,
-                                topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
-                                resourceOutputDir = generatorOptions.resourceOutputDirectory,
-                            )
-                        kafkaGenerator.generate(generationInput.channels)
-                    }
-                }
-
-                if (generatorOptions.generateQuarkusKafkaClient) {
-                    log.info("Generate Java Quarkus Kafka Client is not yet implemented. Skipping..")
-                }
-            }
-        }
-
-        if (generatorOptions.generateAvroSchema) {
-            val avroGenerator =
-                AvroGenerator(
-                    outputDir = generatorOptions.resourceOutputDirectory,
-                    packageName = generatorOptions.schemaPackage,
-                )
-            artifactWriter.write(avroGenerator.render(generationInput.schemas))
         }
     }
+
+    private fun writeModelArtifacts(
+        task: GenerationTask.ModelArtifacts,
+        generationInput: GenerationInput,
+        generatorOptions: GeneratorOptions,
+        artifactWriter: GeneratedArtifactWriter,
+    ) {
+        when (task.language) {
+            KOTLIN -> {
+                val generationModel =
+                    kotlinModelPreparer.prepare(
+                        input = generationInput,
+                        packageName = task.packageName,
+                        annotation = generatorOptions.configOptions["model.annotation"],
+                    )
+                val generator =
+                    KotlinGenerator(
+                        packageName = task.packageName,
+                        outputDir = generatorOptions.codegenOutputDirectory,
+                        generationModel = generationModel,
+                    )
+                artifactWriter.write(generator.render())
+            }
+            JAVA -> {
+                val generationModel =
+                    javaModelPreparer.prepare(
+                        input = generationInput,
+                        packageName = task.packageName,
+                    )
+                val generator =
+                    JavaGenerator(
+                        packageName = task.packageName,
+                        outputDir = generatorOptions.codegenOutputDirectory,
+                        generationModel = generationModel,
+                    )
+                artifactWriter.write(generator.render())
+            }
+        }
+    }
+
+    private fun writeHeaderModelArtifacts(
+        task: GenerationTask.HeaderModelArtifacts,
+        asyncApiDocument: AsyncApiDocument,
+        generationInput: GenerationInput,
+        generatorOptions: GeneratorOptions,
+        artifactWriter: GeneratedArtifactWriter,
+    ) {
+        when (task.language) {
+            KOTLIN -> {
+                val headerModels =
+                    kotlinModelPreparer.prepareHeaders(
+                        input = generationInput,
+                        asyncApiDocument = asyncApiDocument,
+                        packageName = task.packageName,
+                    )
+                if (headerModels.isNotEmpty()) {
+                    val generator =
+                        KotlinGenerator(
+                            packageName = task.packageName,
+                            outputDir = generatorOptions.codegenOutputDirectory,
+                            generationModel = headerModels,
+                        )
+                    artifactWriter.write(generator.render())
+                }
+            }
+            JAVA -> {
+                val headerModels =
+                    javaModelPreparer.prepareHeaders(
+                        input = generationInput,
+                        asyncApiDocument = asyncApiDocument,
+                        packageName = task.packageName,
+                    )
+                if (headerModels.isNotEmpty()) {
+                    val generator =
+                        JavaGenerator(
+                            packageName = task.packageName,
+                            outputDir = generatorOptions.codegenOutputDirectory,
+                            generationModel = headerModels,
+                        )
+                    artifactWriter.write(generator.render())
+                }
+            }
+        }
+    }
+
+    private fun generateSpringKafkaClient(
+        task: GenerationTask.SpringKafkaClient,
+        generationInput: GenerationInput,
+        generatorOptions: GeneratorOptions,
+    ) {
+        when (task.language) {
+            KOTLIN -> {
+                if (task.clientType == SpringKafkaClientType.SIMPLE) {
+                    val kafkaGenerator =
+                        KotlinSpringKafkaSimpleGenerator(
+                            outputDir = generatorOptions.codegenOutputDirectory,
+                            clientPackage = generatorOptions.clientPackage,
+                            modelPackage = generatorOptions.modelPackage,
+                        )
+                    kafkaGenerator.generate(generationInput.channels)
+                } else {
+                    val kafkaGenerator =
+                        KotlinSpringKafkaGenerator(
+                            outputDir = generatorOptions.codegenOutputDirectory,
+                            clientPackage = generatorOptions.clientPackage,
+                            modelPackage = generatorOptions.modelPackage,
+                            topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
+                            resourceOutputDir = generatorOptions.resourceOutputDirectory,
+                        )
+                    kafkaGenerator.generate(generationInput.channels)
+                }
+            }
+            JAVA -> {
+                if (task.clientType == SpringKafkaClientType.SIMPLE) {
+                    val kafkaGenerator =
+                        JavaSpringKafkaSimpleGenerator(
+                            outputDir = generatorOptions.codegenOutputDirectory,
+                            clientPackage = generatorOptions.clientPackage,
+                            modelPackage = generatorOptions.modelPackage,
+                        )
+                    kafkaGenerator.generate(generationInput.channels)
+                } else {
+                    val kafkaGenerator =
+                        JavaSpringKafkaGenerator(
+                            outputDir = generatorOptions.codegenOutputDirectory,
+                            clientPackage = generatorOptions.clientPackage,
+                            modelPackage = generatorOptions.modelPackage,
+                            topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
+                            resourceOutputDir = generatorOptions.resourceOutputDirectory,
+                        )
+                    kafkaGenerator.generate(generationInput.channels)
+                }
+            }
+        }
+    }
+
+    private fun writeAvroSchemaArtifacts(
+        task: GenerationTask.AvroSchemaArtifacts,
+        generationInput: GenerationInput,
+        generatorOptions: GeneratorOptions,
+        artifactWriter: GeneratedArtifactWriter,
+    ) {
+        val avroGenerator =
+            AvroGenerator(
+                outputDir = generatorOptions.resourceOutputDirectory,
+                packageName = task.packageName,
+            )
+        artifactWriter.write(avroGenerator.render(generationInput.schemas))
+    }
+
+    private fun String.titlecase(): String =
+        lowercase().replaceFirstChar { it.titlecase() }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -1,18 +1,11 @@
 package dev.banking.asyncapi.generator.core.generator
 
-import dev.banking.asyncapi.generator.core.generator.avro.AvroGenerator
-import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
+import dev.banking.asyncapi.generator.core.generator.artifact.AvroSchemaArtifactGeneration
+import dev.banking.asyncapi.generator.core.generator.artifact.ModelArtifactGeneration
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInputFactory
-import dev.banking.asyncapi.generator.core.generator.java.JavaGenerator
-import dev.banking.asyncapi.generator.core.generator.java.JavaModelPreparer
 import dev.banking.asyncapi.generator.core.generator.kafka.spring.SpringKafkaClientGeneration
-import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinGenerator
-import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinModelPreparer
-import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
-import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
 import dev.banking.asyncapi.generator.core.generator.output.FileSystemGeneratedArtifactWriter
-import dev.banking.asyncapi.generator.core.generator.output.GeneratedArtifactWriter
 import dev.banking.asyncapi.generator.core.generator.plan.GenerationPlanner
 import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
@@ -28,9 +21,9 @@ class AsyncApiGenerator {
     private val log = LoggerFactory.getLogger(AsyncApiGenerator::class.java)
 
     private val generationInputFactory = GenerationInputFactory()
-    private val kotlinModelPreparer = KotlinModelPreparer()
-    private val javaModelPreparer = JavaModelPreparer()
     private val generationPlanner = GenerationPlanner()
+    private val modelArtifactGeneration = ModelArtifactGeneration()
+    private val avroSchemaArtifactGeneration = AvroSchemaArtifactGeneration()
     private val springKafkaClientGeneration = SpringKafkaClientGeneration()
 
     fun generate(
@@ -48,18 +41,18 @@ class AsyncApiGenerator {
         generationPlan.tasks.forEach { task ->
             when (task) {
                 is GenerationTask.ModelArtifacts ->
-                    writeModelArtifacts(
+                    modelArtifactGeneration.generateModelArtifacts(
                         task = task,
                         generationInput = generationInput,
-                        generatorOptions = generatorOptions,
+                        sourceOutputDirectory = generatorOptions.codegenOutputDirectory,
                         artifactWriter = artifactWriter,
                     )
                 is GenerationTask.HeaderModelArtifacts ->
-                    writeHeaderModelArtifacts(
+                    modelArtifactGeneration.generateHeaderModelArtifacts(
                         task = task,
                         asyncApiDocument = asyncApiDocument,
                         generationInput = generationInput,
-                        generatorOptions = generatorOptions,
+                        sourceOutputDirectory = generatorOptions.codegenOutputDirectory,
                         artifactWriter = artifactWriter,
                     )
                 is GenerationTask.SpringKafkaClient ->
@@ -72,112 +65,14 @@ class AsyncApiGenerator {
                 is GenerationTask.QuarkusKafkaClient ->
                     log.info("Generate ${task.language.name.titlecase()} Quarkus Kafka Client is not yet implemented. Skipping..")
                 is GenerationTask.AvroSchemaArtifacts ->
-                    writeAvroSchemaArtifacts(
+                    avroSchemaArtifactGeneration.generate(
                         task = task,
                         generationInput = generationInput,
-                        generatorOptions = generatorOptions,
+                        resourceOutputDirectory = generatorOptions.resourceOutputDirectory,
                         artifactWriter = artifactWriter,
                     )
             }
         }
-    }
-
-    private fun writeModelArtifacts(
-        task: GenerationTask.ModelArtifacts,
-        generationInput: GenerationInput,
-        generatorOptions: GeneratorOptions,
-        artifactWriter: GeneratedArtifactWriter,
-    ) {
-        when (task.language) {
-            KOTLIN -> {
-                val generationModel =
-                    kotlinModelPreparer.prepare(
-                        input = generationInput,
-                        packageName = task.packageName,
-                        annotation = task.annotation,
-                    )
-                val generator =
-                    KotlinGenerator(
-                        packageName = task.packageName,
-                        outputDir = generatorOptions.codegenOutputDirectory,
-                        generationModel = generationModel,
-                    )
-                artifactWriter.write(generator.render())
-            }
-            JAVA -> {
-                val generationModel =
-                    javaModelPreparer.prepare(
-                        input = generationInput,
-                        packageName = task.packageName,
-                    )
-                val generator =
-                    JavaGenerator(
-                        packageName = task.packageName,
-                        outputDir = generatorOptions.codegenOutputDirectory,
-                        generationModel = generationModel,
-                    )
-                artifactWriter.write(generator.render())
-            }
-        }
-    }
-
-    private fun writeHeaderModelArtifacts(
-        task: GenerationTask.HeaderModelArtifacts,
-        asyncApiDocument: AsyncApiDocument,
-        generationInput: GenerationInput,
-        generatorOptions: GeneratorOptions,
-        artifactWriter: GeneratedArtifactWriter,
-    ) {
-        when (task.language) {
-            KOTLIN -> {
-                val headerModels =
-                    kotlinModelPreparer.prepareHeaders(
-                        input = generationInput,
-                        asyncApiDocument = asyncApiDocument,
-                        packageName = task.packageName,
-                    )
-                if (headerModels.isNotEmpty()) {
-                    val generator =
-                        KotlinGenerator(
-                            packageName = task.packageName,
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            generationModel = headerModels,
-                        )
-                    artifactWriter.write(generator.render())
-                }
-            }
-            JAVA -> {
-                val headerModels =
-                    javaModelPreparer.prepareHeaders(
-                        input = generationInput,
-                        asyncApiDocument = asyncApiDocument,
-                        packageName = task.packageName,
-                    )
-                if (headerModels.isNotEmpty()) {
-                    val generator =
-                        JavaGenerator(
-                            packageName = task.packageName,
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            generationModel = headerModels,
-                        )
-                    artifactWriter.write(generator.render())
-                }
-            }
-        }
-    }
-
-    private fun writeAvroSchemaArtifacts(
-        task: GenerationTask.AvroSchemaArtifacts,
-        generationInput: GenerationInput,
-        generatorOptions: GeneratorOptions,
-        artifactWriter: GeneratedArtifactWriter,
-    ) {
-        val avroGenerator =
-            AvroGenerator(
-                outputDir = generatorOptions.resourceOutputDirectory,
-                packageName = task.packageName,
-            )
-        artifactWriter.write(avroGenerator.render(generationInput.schemas))
     }
 
     private fun String.titlecase(): String =

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -5,12 +5,9 @@ import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInputFactory
 import dev.banking.asyncapi.generator.core.generator.java.JavaGenerator
 import dev.banking.asyncapi.generator.core.generator.java.JavaModelPreparer
-import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaGenerator
-import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaSimpleGenerator
+import dev.banking.asyncapi.generator.core.generator.kafka.spring.SpringKafkaClientGeneration
 import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinGenerator
 import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinModelPreparer
-import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaGenerator
-import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaSimpleGenerator
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
@@ -18,7 +15,6 @@ import dev.banking.asyncapi.generator.core.generator.output.FileSystemGeneratedA
 import dev.banking.asyncapi.generator.core.generator.output.GeneratedArtifactWriter
 import dev.banking.asyncapi.generator.core.generator.plan.GenerationPlanner
 import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
-import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 import org.slf4j.LoggerFactory
 
@@ -35,6 +31,7 @@ class AsyncApiGenerator {
     private val kotlinModelPreparer = KotlinModelPreparer()
     private val javaModelPreparer = JavaModelPreparer()
     private val generationPlanner = GenerationPlanner()
+    private val springKafkaClientGeneration = SpringKafkaClientGeneration()
 
     fun generate(
         asyncApiDocument: AsyncApiDocument,
@@ -66,7 +63,7 @@ class AsyncApiGenerator {
                         artifactWriter = artifactWriter,
                     )
                 is GenerationTask.SpringKafkaClient ->
-                    generateSpringKafkaClient(
+                    springKafkaClientGeneration.generate(
                         task = task,
                         generationInput = generationInput,
                         generatorOptions = generatorOptions,
@@ -163,57 +160,6 @@ class AsyncApiGenerator {
                             generationModel = headerModels,
                         )
                     artifactWriter.write(generator.render())
-                }
-            }
-        }
-    }
-
-    private fun generateSpringKafkaClient(
-        task: GenerationTask.SpringKafkaClient,
-        generationInput: GenerationInput,
-        generatorOptions: GeneratorOptions,
-    ) {
-        when (task.language) {
-            KOTLIN -> {
-                if (task.clientType == SpringKafkaClientType.SIMPLE) {
-                    val kafkaGenerator =
-                        KotlinSpringKafkaSimpleGenerator(
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            clientPackage = generatorOptions.clientPackage,
-                            modelPackage = generatorOptions.modelPackage,
-                        )
-                    kafkaGenerator.generate(generationInput.channels)
-                } else {
-                    val kafkaGenerator =
-                        KotlinSpringKafkaGenerator(
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            clientPackage = generatorOptions.clientPackage,
-                            modelPackage = generatorOptions.modelPackage,
-                            topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
-                            resourceOutputDir = generatorOptions.resourceOutputDirectory,
-                        )
-                    kafkaGenerator.generate(generationInput.channels)
-                }
-            }
-            JAVA -> {
-                if (task.clientType == SpringKafkaClientType.SIMPLE) {
-                    val kafkaGenerator =
-                        JavaSpringKafkaSimpleGenerator(
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            clientPackage = generatorOptions.clientPackage,
-                            modelPackage = generatorOptions.modelPackage,
-                        )
-                    kafkaGenerator.generate(generationInput.channels)
-                } else {
-                    val kafkaGenerator =
-                        JavaSpringKafkaGenerator(
-                            outputDir = generatorOptions.codegenOutputDirectory,
-                            clientPackage = generatorOptions.clientPackage,
-                            modelPackage = generatorOptions.modelPackage,
-                            topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
-                            resourceOutputDir = generatorOptions.resourceOutputDirectory,
-                        )
-                    kafkaGenerator.generate(generationInput.channels)
                 }
             }
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -66,7 +66,8 @@ class AsyncApiGenerator {
                     springKafkaClientGeneration.generate(
                         task = task,
                         generationInput = generationInput,
-                        generatorOptions = generatorOptions,
+                        sourceOutputDirectory = generatorOptions.codegenOutputDirectory,
+                        resourceOutputDirectory = generatorOptions.resourceOutputDirectory,
                     )
                 is GenerationTask.QuarkusKafkaClient ->
                     log.info("Generate ${task.language.name.titlecase()} Quarkus Kafka Client is not yet implemented. Skipping..")

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/AvroSchemaArtifactGeneration.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/AvroSchemaArtifactGeneration.kt
@@ -1,0 +1,29 @@
+package dev.banking.asyncapi.generator.core.generator.artifact
+
+import dev.banking.asyncapi.generator.core.generator.avro.AvroGenerator
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
+import dev.banking.asyncapi.generator.core.generator.output.GeneratedArtifactWriter
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import java.io.File
+
+/**
+ * Renders planned Avro schema artifacts before writing them.
+ *
+ * Expected behavior is covered by:
+ * - `AvroSchemaArtifactGenerationTest`
+ */
+class AvroSchemaArtifactGeneration {
+    fun generate(
+        task: GenerationTask.AvroSchemaArtifacts,
+        generationInput: GenerationInput,
+        resourceOutputDirectory: File,
+        artifactWriter: GeneratedArtifactWriter,
+    ) {
+        val avroGenerator =
+            AvroGenerator(
+                outputDir = resourceOutputDirectory,
+                packageName = task.packageName,
+            )
+        artifactWriter.write(avroGenerator.render(generationInput.schemas))
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/ModelArtifactGeneration.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/ModelArtifactGeneration.kt
@@ -1,0 +1,108 @@
+package dev.banking.asyncapi.generator.core.generator.artifact
+
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
+import dev.banking.asyncapi.generator.core.generator.java.JavaGenerator
+import dev.banking.asyncapi.generator.core.generator.java.JavaModelPreparer
+import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinGenerator
+import dev.banking.asyncapi.generator.core.generator.kotlin.KotlinModelPreparer
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
+import dev.banking.asyncapi.generator.core.generator.output.GeneratedArtifactWriter
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+import java.io.File
+
+/**
+ * Renders planned Kotlin and Java model artifacts before writing them.
+ *
+ * Expected behavior is covered by:
+ * - `ModelArtifactGenerationTest`
+ */
+class ModelArtifactGeneration(
+    private val kotlinModelPreparer: KotlinModelPreparer = KotlinModelPreparer(),
+    private val javaModelPreparer: JavaModelPreparer = JavaModelPreparer(),
+) {
+    fun generateModelArtifacts(
+        task: GenerationTask.ModelArtifacts,
+        generationInput: GenerationInput,
+        sourceOutputDirectory: File,
+        artifactWriter: GeneratedArtifactWriter,
+    ) {
+        when (task.language) {
+            KOTLIN -> {
+                val generationModel =
+                    kotlinModelPreparer.prepare(
+                        input = generationInput,
+                        packageName = task.packageName,
+                        annotation = task.annotation,
+                    )
+                val generator =
+                    KotlinGenerator(
+                        packageName = task.packageName,
+                        outputDir = sourceOutputDirectory,
+                        generationModel = generationModel,
+                    )
+                artifactWriter.write(generator.render())
+            }
+            JAVA -> {
+                val generationModel =
+                    javaModelPreparer.prepare(
+                        input = generationInput,
+                        packageName = task.packageName,
+                    )
+                val generator =
+                    JavaGenerator(
+                        packageName = task.packageName,
+                        outputDir = sourceOutputDirectory,
+                        generationModel = generationModel,
+                    )
+                artifactWriter.write(generator.render())
+            }
+        }
+    }
+
+    fun generateHeaderModelArtifacts(
+        task: GenerationTask.HeaderModelArtifacts,
+        asyncApiDocument: AsyncApiDocument,
+        generationInput: GenerationInput,
+        sourceOutputDirectory: File,
+        artifactWriter: GeneratedArtifactWriter,
+    ) {
+        when (task.language) {
+            KOTLIN -> {
+                val headerModels =
+                    kotlinModelPreparer.prepareHeaders(
+                        input = generationInput,
+                        asyncApiDocument = asyncApiDocument,
+                        packageName = task.packageName,
+                    )
+                if (headerModels.isNotEmpty()) {
+                    val generator =
+                        KotlinGenerator(
+                            packageName = task.packageName,
+                            outputDir = sourceOutputDirectory,
+                            generationModel = headerModels,
+                        )
+                    artifactWriter.write(generator.render())
+                }
+            }
+            JAVA -> {
+                val headerModels =
+                    javaModelPreparer.prepareHeaders(
+                        input = generationInput,
+                        asyncApiDocument = asyncApiDocument,
+                        packageName = task.packageName,
+                    )
+                if (headerModels.isNotEmpty()) {
+                    val generator =
+                        JavaGenerator(
+                            packageName = task.packageName,
+                            outputDir = sourceOutputDirectory,
+                            generationModel = headerModels,
+                        )
+                    artifactWriter.write(generator.render())
+                }
+            }
+        }
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInput.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInput.kt
@@ -1,0 +1,30 @@
+package dev.banking.asyncapi.generator.core.generator.input
+
+import dev.banking.asyncapi.generator.core.generator.analyzer.AnalyzedChannel
+import dev.banking.asyncapi.generator.core.generator.context.GeneratorContext
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+
+/**
+ * Analyzed AsyncAPI data consumed by language and schema generators.
+ *
+ * [GenerationInput] is produced after loading, normalizing, and analyzing the
+ * AsyncAPI document. It does not contain rendered artifacts or write targets.
+ *
+ * Expected behavior is covered by:
+ * - `GenerationInputTest`
+ * - `GenerationInputFactoryTest`
+ */
+data class GenerationInput(
+    val schemas: Map<String, Schema>,
+    val polymorphicRelationships: Map<String, List<String>>,
+    val channels: List<AnalyzedChannel>,
+) {
+    val schemaContext: GeneratorContext = GeneratorContext(schemas)
+
+    fun schemaContextWith(additionalSchemas: Map<String, Schema>): GeneratorContext =
+        if (additionalSchemas.isEmpty()) {
+            schemaContext
+        } else {
+            GeneratorContext(schemas + additionalSchemas)
+        }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactory.kt
@@ -1,0 +1,32 @@
+package dev.banking.asyncapi.generator.core.generator.input
+
+import dev.banking.asyncapi.generator.core.generator.analyzer.ChannelAnalyzer
+import dev.banking.asyncapi.generator.core.generator.analyzer.SchemaAnalyzer
+import dev.banking.asyncapi.generator.core.generator.loader.AsyncApiSchemaLoader
+import dev.banking.asyncapi.generator.core.generator.normalizer.SchemaNormalizer
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+
+/**
+ * Prepares AsyncAPI documents for generator model creation.
+ *
+ * Expected behavior is covered by:
+ * - `GenerationInputFactoryTest`
+ */
+class GenerationInputFactory(
+    private val schemaNormalizer: SchemaNormalizer = SchemaNormalizer(),
+    private val schemaAnalyzer: SchemaAnalyzer = SchemaAnalyzer(),
+    private val channelAnalyzer: ChannelAnalyzer = ChannelAnalyzer(),
+) {
+    fun create(asyncApiDocument: AsyncApiDocument): GenerationInput {
+        val schemas = AsyncApiSchemaLoader.load(asyncApiDocument)
+        val normalizedSchemas = schemaNormalizer.normalize(schemas)
+        val (analyzedSchemas, polymorphicRelationships) = schemaAnalyzer.analyze(normalizedSchemas)
+        val analyzedChannels = channelAnalyzer.analyze(asyncApiDocument).channels
+
+        return GenerationInput(
+            schemas = analyzedSchemas,
+            polymorphicRelationships = polymorphicRelationships,
+            channels = analyzedChannels,
+        )
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparer.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparer.kt
@@ -1,0 +1,29 @@
+package dev.banking.asyncapi.generator.core.generator.java
+
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
+import dev.banking.asyncapi.generator.core.generator.java.factory.JavaGeneratorModelFactory
+import dev.banking.asyncapi.generator.core.generator.java.model.GeneratorItem
+
+/**
+ * Prepares Java model items from analyzed generator input.
+ *
+ * Expected behavior is covered by:
+ * - `JavaModelPreparerTest`
+ */
+class JavaModelPreparer {
+    fun prepare(
+        input: GenerationInput,
+        packageName: String,
+    ): List<GeneratorItem> {
+        val factory =
+            JavaGeneratorModelFactory(
+                packageName = packageName,
+                context = input.schemaContext,
+                polymorphicRelationships = input.polymorphicRelationships,
+            )
+
+        return input.schemas.mapNotNull { (name, schema) ->
+            factory.create(name, schema)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparer.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparer.kt
@@ -3,6 +3,8 @@ package dev.banking.asyncapi.generator.core.generator.java
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
 import dev.banking.asyncapi.generator.core.generator.java.factory.JavaGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.java.model.GeneratorItem
+import dev.banking.asyncapi.generator.core.generator.loader.HeaderSchemaCollector
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 
 /**
  * Prepares Java model items from analyzed generator input.
@@ -23,6 +25,26 @@ class JavaModelPreparer {
             )
 
         return input.schemas.mapNotNull { (name, schema) ->
+            factory.create(name, schema)
+        }
+    }
+
+    fun prepareHeaders(
+        input: GenerationInput,
+        asyncApiDocument: AsyncApiDocument,
+        packageName: String,
+    ): List<GeneratorItem> {
+        val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
+        if (headerSchemas.isEmpty()) return emptyList()
+
+        val factory =
+            JavaGeneratorModelFactory(
+                packageName = packageName,
+                context = input.schemaContextWith(headerSchemas),
+                polymorphicRelationships = input.polymorphicRelationships,
+            )
+
+        return headerSchemas.mapNotNull { (name, schema) ->
             factory.create(name, schema)
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGeneration.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGeneration.kt
@@ -1,0 +1,86 @@
+package dev.banking.asyncapi.generator.core.generator.kafka.spring
+
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
+import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaGenerator
+import dev.banking.asyncapi.generator.core.generator.java.kafka.spring.JavaSpringKafkaSimpleGenerator
+import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaGenerator
+import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaSimpleGenerator
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
+
+/**
+ * Dispatches planned Spring Kafka client generation to the current implementations.
+ *
+ * This is the boundary for the existing Spring Kafka client generators while
+ * the long-term client surface is still being designed.
+ *
+ * Expected behavior is covered by:
+ * - `SpringKafkaClientGenerationTest`
+ */
+class SpringKafkaClientGeneration {
+    fun generate(
+        task: GenerationTask.SpringKafkaClient,
+        generationInput: GenerationInput,
+        generatorOptions: GeneratorOptions,
+    ) {
+        when (task.language) {
+            KOTLIN -> generateKotlinClient(task, generationInput, generatorOptions)
+            JAVA -> generateJavaClient(task, generationInput, generatorOptions)
+        }
+    }
+
+    private fun generateKotlinClient(
+        task: GenerationTask.SpringKafkaClient,
+        generationInput: GenerationInput,
+        generatorOptions: GeneratorOptions,
+    ) {
+        if (task.clientType == SpringKafkaClientType.SIMPLE) {
+            val kafkaGenerator =
+                KotlinSpringKafkaSimpleGenerator(
+                    outputDir = generatorOptions.codegenOutputDirectory,
+                    clientPackage = generatorOptions.clientPackage,
+                    modelPackage = generatorOptions.modelPackage,
+                )
+            kafkaGenerator.generate(generationInput.channels)
+        } else {
+            val kafkaGenerator =
+                KotlinSpringKafkaGenerator(
+                    outputDir = generatorOptions.codegenOutputDirectory,
+                    clientPackage = generatorOptions.clientPackage,
+                    modelPackage = generatorOptions.modelPackage,
+                    topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
+                    resourceOutputDir = generatorOptions.resourceOutputDirectory,
+                )
+            kafkaGenerator.generate(generationInput.channels)
+        }
+    }
+
+    private fun generateJavaClient(
+        task: GenerationTask.SpringKafkaClient,
+        generationInput: GenerationInput,
+        generatorOptions: GeneratorOptions,
+    ) {
+        if (task.clientType == SpringKafkaClientType.SIMPLE) {
+            val kafkaGenerator =
+                JavaSpringKafkaSimpleGenerator(
+                    outputDir = generatorOptions.codegenOutputDirectory,
+                    clientPackage = generatorOptions.clientPackage,
+                    modelPackage = generatorOptions.modelPackage,
+                )
+            kafkaGenerator.generate(generationInput.channels)
+        } else {
+            val kafkaGenerator =
+                JavaSpringKafkaGenerator(
+                    outputDir = generatorOptions.codegenOutputDirectory,
+                    clientPackage = generatorOptions.clientPackage,
+                    modelPackage = generatorOptions.modelPackage,
+                    topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
+                    resourceOutputDir = generatorOptions.resourceOutputDirectory,
+                )
+            kafkaGenerator.generate(generationInput.channels)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGeneration.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGeneration.kt
@@ -7,9 +7,9 @@ import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinS
 import dev.banking.asyncapi.generator.core.generator.kotlin.kafka.spring.KotlinSpringKafkaSimpleGenerator
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.JAVA
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName.KOTLIN
-import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
 import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
 import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
+import java.io.File
 
 /**
  * Dispatches planned Spring Kafka client generation to the current implementations.
@@ -24,35 +24,37 @@ class SpringKafkaClientGeneration {
     fun generate(
         task: GenerationTask.SpringKafkaClient,
         generationInput: GenerationInput,
-        generatorOptions: GeneratorOptions,
+        sourceOutputDirectory: File,
+        resourceOutputDirectory: File,
     ) {
         when (task.language) {
-            KOTLIN -> generateKotlinClient(task, generationInput, generatorOptions)
-            JAVA -> generateJavaClient(task, generationInput, generatorOptions)
+            KOTLIN -> generateKotlinClient(task, generationInput, sourceOutputDirectory, resourceOutputDirectory)
+            JAVA -> generateJavaClient(task, generationInput, sourceOutputDirectory, resourceOutputDirectory)
         }
     }
 
     private fun generateKotlinClient(
         task: GenerationTask.SpringKafkaClient,
         generationInput: GenerationInput,
-        generatorOptions: GeneratorOptions,
+        sourceOutputDirectory: File,
+        resourceOutputDirectory: File,
     ) {
         if (task.clientType == SpringKafkaClientType.SIMPLE) {
             val kafkaGenerator =
                 KotlinSpringKafkaSimpleGenerator(
-                    outputDir = generatorOptions.codegenOutputDirectory,
-                    clientPackage = generatorOptions.clientPackage,
-                    modelPackage = generatorOptions.modelPackage,
+                    outputDir = sourceOutputDirectory,
+                    clientPackage = task.clientPackage,
+                    modelPackage = task.modelPackage,
                 )
             kafkaGenerator.generate(generationInput.channels)
         } else {
             val kafkaGenerator =
                 KotlinSpringKafkaGenerator(
-                    outputDir = generatorOptions.codegenOutputDirectory,
-                    clientPackage = generatorOptions.clientPackage,
-                    modelPackage = generatorOptions.modelPackage,
-                    topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
-                    resourceOutputDir = generatorOptions.resourceOutputDirectory,
+                    outputDir = sourceOutputDirectory,
+                    clientPackage = task.clientPackage,
+                    modelPackage = task.modelPackage,
+                    topicPropertyPrefix = task.topicPropertyPrefix,
+                    resourceOutputDir = resourceOutputDirectory,
                 )
             kafkaGenerator.generate(generationInput.channels)
         }
@@ -61,24 +63,25 @@ class SpringKafkaClientGeneration {
     private fun generateJavaClient(
         task: GenerationTask.SpringKafkaClient,
         generationInput: GenerationInput,
-        generatorOptions: GeneratorOptions,
+        sourceOutputDirectory: File,
+        resourceOutputDirectory: File,
     ) {
         if (task.clientType == SpringKafkaClientType.SIMPLE) {
             val kafkaGenerator =
                 JavaSpringKafkaSimpleGenerator(
-                    outputDir = generatorOptions.codegenOutputDirectory,
-                    clientPackage = generatorOptions.clientPackage,
-                    modelPackage = generatorOptions.modelPackage,
+                    outputDir = sourceOutputDirectory,
+                    clientPackage = task.clientPackage,
+                    modelPackage = task.modelPackage,
                 )
             kafkaGenerator.generate(generationInput.channels)
         } else {
             val kafkaGenerator =
                 JavaSpringKafkaGenerator(
-                    outputDir = generatorOptions.codegenOutputDirectory,
-                    clientPackage = generatorOptions.clientPackage,
-                    modelPackage = generatorOptions.modelPackage,
-                    topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
-                    resourceOutputDir = generatorOptions.resourceOutputDirectory,
+                    outputDir = sourceOutputDirectory,
+                    clientPackage = task.clientPackage,
+                    modelPackage = task.modelPackage,
+                    topicPropertyPrefix = task.topicPropertyPrefix,
+                    resourceOutputDir = resourceOutputDirectory,
                 )
             kafkaGenerator.generate(generationInput.channels)
         }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparer.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparer.kt
@@ -3,6 +3,8 @@ package dev.banking.asyncapi.generator.core.generator.kotlin
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
 import dev.banking.asyncapi.generator.core.generator.kotlin.factory.KotlinGeneratorModelFactory
 import dev.banking.asyncapi.generator.core.generator.kotlin.model.GeneratorItem
+import dev.banking.asyncapi.generator.core.generator.loader.HeaderSchemaCollector
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 
 /**
  * Prepares Kotlin model items from analyzed generator input.
@@ -25,6 +27,27 @@ class KotlinModelPreparer {
             )
 
         return input.schemas.mapNotNull { (name, schema) ->
+            factory.create(name, schema)
+        }
+    }
+
+    fun prepareHeaders(
+        input: GenerationInput,
+        asyncApiDocument: AsyncApiDocument,
+        packageName: String,
+    ): List<GeneratorItem> {
+        val headerSchemas = HeaderSchemaCollector.collect(asyncApiDocument)
+        if (headerSchemas.isEmpty()) return emptyList()
+
+        val factory =
+            KotlinGeneratorModelFactory(
+                packageName = packageName,
+                context = input.schemaContextWith(headerSchemas),
+                polymorphicRelationships = input.polymorphicRelationships,
+                annotation = null,
+            )
+
+        return headerSchemas.mapNotNull { (name, schema) ->
             factory.create(name, schema)
         }
     }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparer.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparer.kt
@@ -1,0 +1,31 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin
+
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
+import dev.banking.asyncapi.generator.core.generator.kotlin.factory.KotlinGeneratorModelFactory
+import dev.banking.asyncapi.generator.core.generator.kotlin.model.GeneratorItem
+
+/**
+ * Prepares Kotlin model items from analyzed generator input.
+ *
+ * Expected behavior is covered by:
+ * - `KotlinModelPreparerTest`
+ */
+class KotlinModelPreparer {
+    fun prepare(
+        input: GenerationInput,
+        packageName: String,
+        annotation: String? = null,
+    ): List<GeneratorItem> {
+        val factory =
+            KotlinGeneratorModelFactory(
+                packageName = packageName,
+                context = input.schemaContext,
+                polymorphicRelationships = input.polymorphicRelationships,
+                annotation = annotation,
+            )
+
+        return input.schemas.mapNotNull { (name, schema) ->
+            factory.create(name, schema)
+        }
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlan.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlan.kt
@@ -1,0 +1,11 @@
+package dev.banking.asyncapi.generator.core.generator.plan
+
+/**
+ * Ordered generation work selected before rendering or writing artifacts.
+ *
+ * Expected behavior is covered by:
+ * - `GenerationPlannerTest`
+ */
+data class GenerationPlan(
+    val tasks: List<GenerationTask>,
+)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
@@ -54,9 +54,5 @@ class GenerationPlanner {
         )
 
     private fun GeneratorOptions.springKafkaClientType(): SpringKafkaClientType =
-        if (configOptions["client.type"] == "spring-kafka-simple") {
-            SpringKafkaClientType.SIMPLE
-        } else {
-            SpringKafkaClientType.FULL
-        }
+        SpringKafkaClientType.fromConfigValue(configOptions["client.type"])
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
@@ -1,0 +1,62 @@
+package dev.banking.asyncapi.generator.core.generator.plan
+
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
+
+/**
+ * Creates an ordered generation plan from generator options.
+ *
+ * Expected behavior is covered by:
+ * - `GenerationPlannerTest`
+ */
+class GenerationPlanner {
+    fun plan(generatorOptions: GeneratorOptions): GenerationPlan =
+        GenerationPlan(
+            buildList {
+                if (generatorOptions.generateModels) {
+                    add(
+                        GenerationTask.ModelArtifacts(
+                            language = generatorOptions.generatorName,
+                            packageName = generatorOptions.modelPackage,
+                        ),
+                    )
+                }
+
+                if (generatorOptions.generateSpringKafkaClient) {
+                    require(generatorOptions.kafkaTopicsPropertyPrefix.isNotBlank()) {
+                        "kafka.topics.property.prefix cannot be empty"
+                    }
+
+                    val clientType = generatorOptions.springKafkaClientType()
+                    if (clientType != SpringKafkaClientType.SIMPLE) {
+                        add(
+                            GenerationTask.HeaderModelArtifacts(
+                                language = generatorOptions.generatorName,
+                                packageName = "${generatorOptions.clientPackage}.header",
+                            ),
+                        )
+                    }
+                    add(
+                        GenerationTask.SpringKafkaClient(
+                            language = generatorOptions.generatorName,
+                            clientType = clientType,
+                        ),
+                    )
+                }
+
+                if (generatorOptions.generateQuarkusKafkaClient) {
+                    add(GenerationTask.QuarkusKafkaClient(generatorOptions.generatorName))
+                }
+
+                if (generatorOptions.generateAvroSchema) {
+                    add(GenerationTask.AvroSchemaArtifacts(generatorOptions.schemaPackage))
+                }
+            },
+        )
+
+    private fun GeneratorOptions.springKafkaClientType(): SpringKafkaClientType =
+        if (configOptions["client.type"] == "spring-kafka-simple") {
+            SpringKafkaClientType.SIMPLE
+        } else {
+            SpringKafkaClientType.FULL
+        }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
@@ -17,6 +17,7 @@ class GenerationPlanner {
                         GenerationTask.ModelArtifacts(
                             language = generatorOptions.generatorName,
                             packageName = generatorOptions.modelPackage,
+                            annotation = generatorOptions.configOptions["model.annotation"],
                         ),
                     )
                 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlanner.kt
@@ -40,6 +40,9 @@ class GenerationPlanner {
                         GenerationTask.SpringKafkaClient(
                             language = generatorOptions.generatorName,
                             clientType = clientType,
+                            clientPackage = generatorOptions.clientPackage,
+                            modelPackage = generatorOptions.modelPackage,
+                            topicPropertyPrefix = generatorOptions.kafkaTopicsPropertyPrefix,
                         ),
                     )
                 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationTask.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationTask.kt
@@ -12,6 +12,7 @@ sealed interface GenerationTask {
     data class ModelArtifacts(
         val language: GeneratorName,
         val packageName: String,
+        val annotation: String? = null,
     ) : GenerationTask
 
     data class HeaderModelArtifacts(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationTask.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationTask.kt
@@ -1,0 +1,34 @@
+package dev.banking.asyncapi.generator.core.generator.plan
+
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName
+
+/**
+ * Planned generator work item.
+ *
+ * Expected behavior is covered by:
+ * - `GenerationPlannerTest`
+ */
+sealed interface GenerationTask {
+    data class ModelArtifacts(
+        val language: GeneratorName,
+        val packageName: String,
+    ) : GenerationTask
+
+    data class HeaderModelArtifacts(
+        val language: GeneratorName,
+        val packageName: String,
+    ) : GenerationTask
+
+    data class SpringKafkaClient(
+        val language: GeneratorName,
+        val clientType: SpringKafkaClientType,
+    ) : GenerationTask
+
+    data class QuarkusKafkaClient(
+        val language: GeneratorName,
+    ) : GenerationTask
+
+    data class AvroSchemaArtifacts(
+        val packageName: String,
+    ) : GenerationTask
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationTask.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationTask.kt
@@ -23,6 +23,9 @@ sealed interface GenerationTask {
     data class SpringKafkaClient(
         val language: GeneratorName,
         val clientType: SpringKafkaClientType,
+        val clientPackage: String,
+        val modelPackage: String,
+        val topicPropertyPrefix: String,
     ) : GenerationTask
 
     data class QuarkusKafkaClient(

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/SpringKafkaClientType.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/SpringKafkaClientType.kt
@@ -3,10 +3,29 @@ package dev.banking.asyncapi.generator.core.generator.plan
 /**
  * Spring Kafka client generation mode selected during planning.
  *
+ * The full client remains the default when a caller enables Spring Kafka
+ * generation without supplying a `client.type` config option.
+ *
  * Expected behavior is covered by:
  * - `GenerationPlannerTest`
  */
-enum class SpringKafkaClientType {
-    FULL,
-    SIMPLE,
+enum class SpringKafkaClientType(
+    val configValue: String,
+) {
+    FULL("spring-kafka"),
+    SIMPLE("spring-kafka-simple"),
+    ;
+
+    companion object {
+        fun fromConfigValue(value: String?): SpringKafkaClientType =
+            when (value) {
+                null -> FULL
+                FULL.configValue -> FULL
+                SIMPLE.configValue -> SIMPLE
+                else ->
+                    throw IllegalArgumentException(
+                        "Unsupported client.type '$value'. Supported values: ${entries.joinToString { it.configValue }}",
+                    )
+            }
+    }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/SpringKafkaClientType.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/plan/SpringKafkaClientType.kt
@@ -1,0 +1,12 @@
+package dev.banking.asyncapi.generator.core.generator.plan
+
+/**
+ * Spring Kafka client generation mode selected during planning.
+ *
+ * Expected behavior is covered by:
+ * - `GenerationPlannerTest`
+ */
+enum class SpringKafkaClientType {
+    FULL,
+    SIMPLE,
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
@@ -1,0 +1,77 @@
+package dev.banking.asyncapi.generator.core.fixtures
+
+import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
+import dev.banking.asyncapi.generator.core.model.channels.Channel
+import dev.banking.asyncapi.generator.core.model.channels.ChannelInterface
+import dev.banking.asyncapi.generator.core.model.components.Component
+import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
+import dev.banking.asyncapi.generator.core.model.info.Info
+import dev.banking.asyncapi.generator.core.model.messages.Message
+import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
+import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
+
+/**
+ * Fixture facade for generation-input tests.
+ *
+ * It builds focused AsyncAPI model objects for generator preparation scenarios
+ * without requiring the tests to repeat the full object graph.
+ */
+internal class GenerationInputFixtures {
+    fun documentWithPolymorphicComponentAndChannel(): AsyncApiDocument {
+        val externalSchema =
+            Schema(
+                type = "object",
+                properties =
+                    mapOf(
+                        "status" to SchemaInterface.SchemaInline(Schema(type = "string", enum = listOf("ACTIVE"))),
+                    ),
+            )
+        val rootSchema =
+            Schema(
+                oneOf =
+                    listOf(
+                        SchemaInterface.SchemaReference(
+                            Reference(
+                                ref = "#/components/schemas/External",
+                                model = externalSchema,
+                            ),
+                        ),
+                    ),
+            )
+
+        return AsyncApiDocument(
+            asyncapi = "3.0.0",
+            info = Info(title = "Test API", version = "1.0.0"),
+            channels =
+                mapOf(
+                    "userEvents" to
+                        ChannelInterface.ChannelInline(
+                            Channel(
+                                address = "user.events",
+                                messages =
+                                    mapOf(
+                                        "userCreated" to
+                                            MessageInterface.MessageInline(
+                                                Message(
+                                                    name = "UserCreated",
+                                                    payload = SchemaInterface.SchemaInline(Schema(type = "object")),
+                                                ),
+                                            ),
+                                    ),
+                            ),
+                        ),
+                ),
+            components =
+                ComponentInterface.ComponentInline(
+                    Component(
+                        schemas =
+                            mapOf(
+                                "Root" to SchemaInterface.SchemaInline(rootSchema),
+                            ),
+                    ),
+                ),
+        )
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
@@ -1,5 +1,7 @@
 package dev.banking.asyncapi.generator.core.fixtures
 
+import dev.banking.asyncapi.generator.core.generator.analyzer.AnalyzedChannel
+import dev.banking.asyncapi.generator.core.generator.analyzer.AnalyzedMessage
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 import dev.banking.asyncapi.generator.core.model.channels.Channel
@@ -20,6 +22,29 @@ import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
  * without requiring the tests to repeat the full object graph.
  */
 internal class GenerationInputFixtures {
+    fun generationInputWithUserSignupChannel(): GenerationInput =
+        GenerationInput(
+            schemas = emptyMap(),
+            polymorphicRelationships = emptyMap(),
+            channels =
+                listOf(
+                    AnalyzedChannel(
+                        channelName = "userEvents",
+                        topic = "user.events",
+                        isProducer = true,
+                        isConsumer = true,
+                        messages =
+                            listOf(
+                                AnalyzedMessage(
+                                    messageName = "UserSignedUp",
+                                    payloadTypeName = "UserSignedUpPayload",
+                                    schema = Schema(type = "object"),
+                                ),
+                            ),
+                    ),
+                ),
+        )
+
     fun generationInputWithObjectEnumAndPrimitive(): GenerationInput {
         val userSchema =
             Schema(

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
@@ -1,5 +1,6 @@
 package dev.banking.asyncapi.generator.core.fixtures
 
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInput
 import dev.banking.asyncapi.generator.core.model.asyncapi.AsyncApiDocument
 import dev.banking.asyncapi.generator.core.model.channels.Channel
 import dev.banking.asyncapi.generator.core.model.channels.ChannelInterface
@@ -19,6 +20,34 @@ import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
  * without requiring the tests to repeat the full object graph.
  */
 internal class GenerationInputFixtures {
+    fun generationInputWithObjectEnumAndPrimitive(): GenerationInput {
+        val userSchema =
+            Schema(
+                type = "object",
+                required = listOf("id"),
+                properties =
+                    mapOf(
+                        "id" to SchemaInterface.SchemaInline(Schema(type = "string")),
+                    ),
+            )
+        val statusSchema =
+            Schema(
+                type = "string",
+                enum = listOf("ACTIVE", "INACTIVE"),
+            )
+
+        return GenerationInput(
+            schemas =
+                linkedMapOf(
+                    "User" to userSchema,
+                    "Status" to statusSchema,
+                    "IgnoredPrimitive" to Schema(type = "string"),
+                ),
+            polymorphicRelationships = mapOf("User" to listOf("Command")),
+            channels = emptyList(),
+        )
+    }
+
     fun documentWithPolymorphicComponentAndChannel(): AsyncApiDocument {
         val externalSchema =
             Schema(

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
@@ -48,6 +48,43 @@ internal class GenerationInputFixtures {
         )
     }
 
+    fun documentWithMessageHeaders(): AsyncApiDocument =
+        AsyncApiDocument(
+            asyncapi = "3.0.0",
+            info = Info(title = "Test API", version = "1.0.0"),
+            channels =
+                mapOf(
+                    "userEvents" to
+                        ChannelInterface.ChannelInline(
+                            Channel(
+                                messages =
+                                    mapOf(
+                                        "userSignup" to
+                                            MessageInterface.MessageInline(
+                                                Message(
+                                                    name = "UserSignup",
+                                                    payload = SchemaInterface.SchemaInline(Schema(type = "object")),
+                                                    headers =
+                                                        SchemaInterface.SchemaInline(
+                                                            Schema(
+                                                                type = "object",
+                                                                properties =
+                                                                    mapOf(
+                                                                        "correlationId" to
+                                                                            SchemaInterface.SchemaInline(Schema(type = "string")),
+                                                                        "applicationInstanceId" to
+                                                                            SchemaInterface.SchemaInline(Schema(type = "string")),
+                                                                    ),
+                                                            ),
+                                                        ),
+                                                ),
+                                            ),
+                                    ),
+                            ),
+                        ),
+                ),
+        )
+
     fun documentWithPolymorphicComponentAndChannel(): AsyncApiDocument {
         val externalSchema =
             Schema(

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/AvroSchemaArtifactGenerationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/AvroSchemaArtifactGenerationTest.kt
@@ -1,0 +1,41 @@
+package dev.banking.asyncapi.generator.core.generator.artifact
+
+import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import dev.banking.asyncapi.generator.core.generator.output.FileSystemGeneratedArtifactWriter
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AvroSchemaArtifactGenerationTest {
+    private val generation = AvroSchemaArtifactGeneration()
+    private val fixtures = GenerationInputFixtures()
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `generate writes Avro schema artifacts through writer`() {
+        val sourceOutputDirectory = tempDir.resolve("sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("resources").toFile()
+        val artifactWriter =
+            FileSystemGeneratedArtifactWriter(
+                sourceOutputDirectory = sourceOutputDirectory,
+                resourceOutputDirectory = resourceOutputDirectory,
+            )
+
+        generation.generate(
+            task = GenerationTask.AvroSchemaArtifacts(packageName = "com.example.avro"),
+            generationInput = fixtures.generationInputWithObjectEnumAndPrimitive(),
+            resourceOutputDirectory = resourceOutputDirectory,
+            artifactWriter = artifactWriter,
+        )
+
+        assertTrue(resourceOutputDirectory.resolve("com/example/avro/User.avsc").exists())
+        assertTrue(resourceOutputDirectory.resolve("com/example/avro/Status.avsc").exists())
+        assertFalse(resourceOutputDirectory.resolve("com/example/avro/IgnoredPrimitive.avsc").exists())
+        assertFalse(sourceOutputDirectory.resolve("com/example/avro/User.avsc").exists())
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/ModelArtifactGenerationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/artifact/ModelArtifactGenerationTest.kt
@@ -1,0 +1,81 @@
+package dev.banking.asyncapi.generator.core.generator.artifact
+
+import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName
+import dev.banking.asyncapi.generator.core.generator.output.FileSystemGeneratedArtifactWriter
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ModelArtifactGenerationTest {
+    private val generation = ModelArtifactGeneration()
+    private val fixtures = GenerationInputFixtures()
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `generate model artifacts writes Kotlin source artifacts through writer`() {
+        val sourceOutputDirectory = tempDir.resolve("sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("resources").toFile()
+        val artifactWriter =
+            FileSystemGeneratedArtifactWriter(
+                sourceOutputDirectory = sourceOutputDirectory,
+                resourceOutputDirectory = resourceOutputDirectory,
+            )
+
+        generation.generateModelArtifacts(
+            task =
+                GenerationTask.ModelArtifacts(
+                    language = GeneratorName.KOTLIN,
+                    packageName = "com.example.model",
+                    annotation = "com.example.NoArg",
+                ),
+            generationInput = fixtures.generationInputWithObjectEnumAndPrimitive(),
+            sourceOutputDirectory = sourceOutputDirectory,
+            artifactWriter = artifactWriter,
+        )
+
+        val user = sourceOutputDirectory.resolve("com/example/model/User.kt")
+        assertTrue(user.exists())
+        assertTrue(user.readText().contains("@NoArg"))
+        assertFalse(resourceOutputDirectory.resolve("com/example/model/User.kt").exists())
+    }
+
+    @Test
+    fun `generate header model artifacts writes Java header artifacts through writer`() {
+        val sourceOutputDirectory = tempDir.resolve("sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("resources").toFile()
+        val artifactWriter =
+            FileSystemGeneratedArtifactWriter(
+                sourceOutputDirectory = sourceOutputDirectory,
+                resourceOutputDirectory = resourceOutputDirectory,
+            )
+
+        generation.generateHeaderModelArtifacts(
+            task =
+                GenerationTask.HeaderModelArtifacts(
+                    language = GeneratorName.JAVA,
+                    packageName = "com.example.client.header",
+                ),
+            asyncApiDocument = fixtures.documentWithMessageHeaders(),
+            generationInput = fixtures.generationInputWithObjectEnumAndPrimitive(),
+            sourceOutputDirectory = sourceOutputDirectory,
+            artifactWriter = artifactWriter,
+        )
+
+        assertTrue(
+            sourceOutputDirectory
+                .resolve("com/example/client/header/TopicUserEventsHeadersUserSignup.java")
+                .exists(),
+        )
+        assertFalse(
+            resourceOutputDirectory
+                .resolve("com/example/client/header/TopicUserEventsHeadersUserSignup.java")
+                .exists(),
+        )
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactoryTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactoryTest.kt
@@ -1,0 +1,31 @@
+package dev.banking.asyncapi.generator.core.generator.input
+
+import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class GenerationInputFactoryTest {
+    private val factory = GenerationInputFactory()
+    private val fixtures = GenerationInputFixtures()
+
+    @Test
+    fun `create prepares analyzed schemas polymorphic relationships and channels`() {
+        val input = factory.create(fixtures.documentWithPolymorphicComponentAndChannel())
+
+        assertTrue(input.schemas.containsKey("Root"))
+        assertTrue(input.schemas.containsKey("External"))
+        assertTrue(input.schemas.containsKey("Status"))
+        assertEquals(listOf("Root"), input.polymorphicRelationships["External"])
+        assertSame(input.schemas["Root"], input.schemaContext.findSchemaByName("Root"))
+
+        val channel = input.channels.single()
+        assertEquals("userEvents", channel.channelName)
+        assertEquals("user.events", channel.topic)
+        assertTrue(channel.isProducer)
+        assertTrue(channel.isConsumer)
+        assertEquals("UserCreated", channel.messages.single().messageName)
+        assertEquals("UserCreatedPayload", channel.messages.single().payloadTypeName)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputTest.kt
@@ -1,0 +1,38 @@
+package dev.banking.asyncapi.generator.core.generator.input
+
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import org.junit.jupiter.api.Test
+import kotlin.test.assertSame
+
+class GenerationInputTest {
+
+    @Test
+    fun `schema context exposes analyzed schemas`() {
+        val userSchema = Schema(type = "object")
+        val input =
+            GenerationInput(
+                schemas = mapOf("User" to userSchema),
+                polymorphicRelationships = emptyMap(),
+                channels = emptyList(),
+            )
+
+        assertSame(userSchema, input.schemaContext.findSchemaByName("User"))
+    }
+
+    @Test
+    fun `schema context with additional schemas includes original and additional schemas`() {
+        val userSchema = Schema(type = "object")
+        val headerSchema = Schema(type = "object")
+        val input =
+            GenerationInput(
+                schemas = mapOf("User" to userSchema),
+                polymorphicRelationships = emptyMap(),
+                channels = emptyList(),
+            )
+
+        val context = input.schemaContextWith(mapOf("UserHeader" to headerSchema))
+
+        assertSame(userSchema, context.findSchemaByName("User"))
+        assertSame(headerSchema, context.findSchemaByName("UserHeader"))
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparerTest.kt
@@ -1,0 +1,32 @@
+package dev.banking.asyncapi.generator.core.generator.java
+
+import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import dev.banking.asyncapi.generator.core.generator.java.model.GeneratorItem
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class JavaModelPreparerTest {
+    private val preparer = JavaModelPreparer()
+    private val fixtures = GenerationInputFixtures()
+
+    @Test
+    fun `prepare maps generation input into Java model items`() {
+        val items =
+            preparer.prepare(
+                input = fixtures.generationInputWithObjectEnumAndPrimitive(),
+                packageName = "com.example.model",
+            )
+
+        assertEquals(listOf("User", "Status"), items.map { it.name })
+
+        val user = items.filterIsInstance<GeneratorItem.ClassModel>().single()
+        assertEquals("com.example.model", user.packageName)
+        assertEquals(listOf("Command", "Serializable"), user.implementsInterfaces)
+        assertEquals("id", user.properties.single().name)
+        assertEquals("String", user.properties.single().typeName)
+
+        val status = items.filterIsInstance<GeneratorItem.EnumModel>().single()
+        assertEquals("com.example.model", status.packageName)
+        assertEquals(listOf("ACTIVE", "INACTIVE"), status.values)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/JavaModelPreparerTest.kt
@@ -29,4 +29,23 @@ class JavaModelPreparerTest {
         assertEquals("com.example.model", status.packageName)
         assertEquals(listOf("ACTIVE", "INACTIVE"), status.values)
     }
+
+    @Test
+    fun `prepare headers maps message headers into Java model items`() {
+        val items =
+            preparer.prepareHeaders(
+                input = fixtures.generationInputWithObjectEnumAndPrimitive(),
+                asyncApiDocument = fixtures.documentWithMessageHeaders(),
+                packageName = "com.example.client.header",
+            )
+
+        val header = items.filterIsInstance<GeneratorItem.ClassModel>().single()
+        assertEquals("TopicUserEventsHeadersUserSignup", header.name)
+        assertEquals("com.example.client.header", header.packageName)
+        assertEquals(
+            listOf("correlationId", "applicationInstanceId"),
+            header.properties.map { it.name },
+        )
+        assertEquals(listOf("String", "String"), header.properties.map { it.typeName })
+    }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGenerationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGenerationTest.kt
@@ -47,6 +47,45 @@ class SpringKafkaClientGenerationTest {
     }
 
     @Test
+    fun `generate delegates Kotlin full client task to Kotlin full generator`() {
+        val sourceOutputDirectory = tempDir.resolve("kotlin-full-sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("kotlin-full-resources").toFile()
+
+        generator.generate(
+            task =
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.KOTLIN,
+                    clientType = SpringKafkaClientType.FULL,
+                ),
+            generationInput = fixtures.generationInputWithUserSignupChannel(),
+            generatorOptions =
+                generatorOptions(
+                    generatorName = GeneratorName.KOTLIN,
+                    sourceOutputDirectory = sourceOutputDirectory,
+                    resourceOutputDirectory = resourceOutputDirectory,
+                ),
+        )
+
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/config/AsyncApiKafkaAutoConfiguration.kt").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/listener/TopicUserEventsListenerUserSignedUp.kt").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/handler/TopicUserEventsHandlerUserSignedUp.kt").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/producer/TopicUserEventsProducerUserSignedUp.kt").exists(),
+        )
+        assertTrue(
+            resourceOutputDirectory
+                .resolve("META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports")
+                .exists(),
+        )
+    }
+
+    @Test
     fun `generate delegates Java simple client task to Java simple generator`() {
         val sourceOutputDirectory = tempDir.resolve("java-sources").toFile()
         val resourceOutputDirectory = tempDir.resolve("java-resources").toFile()
@@ -71,6 +110,45 @@ class SpringKafkaClientGenerationTest {
         )
         assertTrue(
             sourceOutputDirectory.resolve("com/example/client/consumer/UserEventsConsumer.java").exists(),
+        )
+    }
+
+    @Test
+    fun `generate delegates Java full client task to Java full generator`() {
+        val sourceOutputDirectory = tempDir.resolve("java-full-sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("java-full-resources").toFile()
+
+        generator.generate(
+            task =
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.JAVA,
+                    clientType = SpringKafkaClientType.FULL,
+                ),
+            generationInput = fixtures.generationInputWithUserSignupChannel(),
+            generatorOptions =
+                generatorOptions(
+                    generatorName = GeneratorName.JAVA,
+                    sourceOutputDirectory = sourceOutputDirectory,
+                    resourceOutputDirectory = resourceOutputDirectory,
+                ),
+        )
+
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/config/AsyncApiKafkaAutoConfiguration.java").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/listener/TopicUserEventsListenerUserSignedUp.java").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/handler/TopicUserEventsHandlerUserSignedUp.java").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/producer/TopicUserEventsProducerUserSignedUp.java").exists(),
+        )
+        assertTrue(
+            resourceOutputDirectory
+                .resolve("META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports")
+                .exists(),
         )
     }
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGenerationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGenerationTest.kt
@@ -1,0 +1,92 @@
+package dev.banking.asyncapi.generator.core.generator.kafka.spring
+
+import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.assertTrue
+
+class SpringKafkaClientGenerationTest {
+    private val generator = SpringKafkaClientGeneration()
+    private val fixtures = GenerationInputFixtures()
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `generate delegates Kotlin simple client task to Kotlin simple generator`() {
+        val sourceOutputDirectory = tempDir.resolve("kotlin-sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("kotlin-resources").toFile()
+
+        generator.generate(
+            task =
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.KOTLIN,
+                    clientType = SpringKafkaClientType.SIMPLE,
+                ),
+            generationInput = fixtures.generationInputWithUserSignupChannel(),
+            generatorOptions =
+                generatorOptions(
+                    generatorName = GeneratorName.KOTLIN,
+                    sourceOutputDirectory = sourceOutputDirectory,
+                    resourceOutputDirectory = resourceOutputDirectory,
+                ),
+        )
+
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/producer/UserEventsProducerUserSignedUp.kt").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/consumer/UserEventsConsumer.kt").exists(),
+        )
+    }
+
+    @Test
+    fun `generate delegates Java simple client task to Java simple generator`() {
+        val sourceOutputDirectory = tempDir.resolve("java-sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("java-resources").toFile()
+
+        generator.generate(
+            task =
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.JAVA,
+                    clientType = SpringKafkaClientType.SIMPLE,
+                ),
+            generationInput = fixtures.generationInputWithUserSignupChannel(),
+            generatorOptions =
+                generatorOptions(
+                    generatorName = GeneratorName.JAVA,
+                    sourceOutputDirectory = sourceOutputDirectory,
+                    resourceOutputDirectory = resourceOutputDirectory,
+                ),
+        )
+
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/producer/UserEventsProducerUserSignedUp.java").exists(),
+        )
+        assertTrue(
+            sourceOutputDirectory.resolve("com/example/client/consumer/UserEventsConsumer.java").exists(),
+        )
+    }
+
+    private fun generatorOptions(
+        generatorName: GeneratorName,
+        sourceOutputDirectory: File,
+        resourceOutputDirectory: File,
+    ): GeneratorOptions =
+        GeneratorOptions(
+            generatorName = generatorName,
+            modelPackage = "com.example.model",
+            clientPackage = "com.example.client",
+            schemaPackage = "com.example.schema",
+            codegenOutputDirectory = sourceOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
+            generateModels = false,
+            generateSpringKafkaClient = true,
+        )
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGenerationTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kafka/spring/SpringKafkaClientGenerationTest.kt
@@ -2,12 +2,10 @@ package dev.banking.asyncapi.generator.core.generator.kafka.spring
 
 import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName
-import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
 import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
 import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
 import java.nio.file.Path
 import kotlin.test.assertTrue
 
@@ -25,17 +23,13 @@ class SpringKafkaClientGenerationTest {
 
         generator.generate(
             task =
-                GenerationTask.SpringKafkaClient(
+                springKafkaClientTask(
                     language = GeneratorName.KOTLIN,
                     clientType = SpringKafkaClientType.SIMPLE,
                 ),
             generationInput = fixtures.generationInputWithUserSignupChannel(),
-            generatorOptions =
-                generatorOptions(
-                    generatorName = GeneratorName.KOTLIN,
-                    sourceOutputDirectory = sourceOutputDirectory,
-                    resourceOutputDirectory = resourceOutputDirectory,
-                ),
+            sourceOutputDirectory = sourceOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
         )
 
         assertTrue(
@@ -53,17 +47,14 @@ class SpringKafkaClientGenerationTest {
 
         generator.generate(
             task =
-                GenerationTask.SpringKafkaClient(
+                springKafkaClientTask(
                     language = GeneratorName.KOTLIN,
                     clientType = SpringKafkaClientType.FULL,
+                    topicPropertyPrefix = "custom.topics",
                 ),
             generationInput = fixtures.generationInputWithUserSignupChannel(),
-            generatorOptions =
-                generatorOptions(
-                    generatorName = GeneratorName.KOTLIN,
-                    sourceOutputDirectory = sourceOutputDirectory,
-                    resourceOutputDirectory = resourceOutputDirectory,
-                ),
+            sourceOutputDirectory = sourceOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
         )
 
         assertTrue(
@@ -77,6 +68,13 @@ class SpringKafkaClientGenerationTest {
         )
         assertTrue(
             sourceOutputDirectory.resolve("com/example/client/producer/TopicUserEventsProducerUserSignedUp.kt").exists(),
+        )
+        val producerContent =
+            sourceOutputDirectory
+                .resolve("com/example/client/producer/TopicUserEventsProducerUserSignedUp.kt")
+                .readText()
+        assertTrue(
+            producerContent.contains("custom.topics.userEvents"),
         )
         assertTrue(
             resourceOutputDirectory
@@ -92,17 +90,13 @@ class SpringKafkaClientGenerationTest {
 
         generator.generate(
             task =
-                GenerationTask.SpringKafkaClient(
+                springKafkaClientTask(
                     language = GeneratorName.JAVA,
                     clientType = SpringKafkaClientType.SIMPLE,
                 ),
             generationInput = fixtures.generationInputWithUserSignupChannel(),
-            generatorOptions =
-                generatorOptions(
-                    generatorName = GeneratorName.JAVA,
-                    sourceOutputDirectory = sourceOutputDirectory,
-                    resourceOutputDirectory = resourceOutputDirectory,
-                ),
+            sourceOutputDirectory = sourceOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
         )
 
         assertTrue(
@@ -120,17 +114,13 @@ class SpringKafkaClientGenerationTest {
 
         generator.generate(
             task =
-                GenerationTask.SpringKafkaClient(
+                springKafkaClientTask(
                     language = GeneratorName.JAVA,
                     clientType = SpringKafkaClientType.FULL,
                 ),
             generationInput = fixtures.generationInputWithUserSignupChannel(),
-            generatorOptions =
-                generatorOptions(
-                    generatorName = GeneratorName.JAVA,
-                    sourceOutputDirectory = sourceOutputDirectory,
-                    resourceOutputDirectory = resourceOutputDirectory,
-                ),
+            sourceOutputDirectory = sourceOutputDirectory,
+            resourceOutputDirectory = resourceOutputDirectory,
         )
 
         assertTrue(
@@ -152,19 +142,16 @@ class SpringKafkaClientGenerationTest {
         )
     }
 
-    private fun generatorOptions(
-        generatorName: GeneratorName,
-        sourceOutputDirectory: File,
-        resourceOutputDirectory: File,
-    ): GeneratorOptions =
-        GeneratorOptions(
-            generatorName = generatorName,
-            modelPackage = "com.example.model",
+    private fun springKafkaClientTask(
+        language: GeneratorName,
+        clientType: SpringKafkaClientType,
+        topicPropertyPrefix: String = "kafka.topics",
+    ): GenerationTask.SpringKafkaClient =
+        GenerationTask.SpringKafkaClient(
+            language = language,
+            clientType = clientType,
             clientPackage = "com.example.client",
-            schemaPackage = "com.example.schema",
-            codegenOutputDirectory = sourceOutputDirectory,
-            resourceOutputDirectory = resourceOutputDirectory,
-            generateModels = false,
-            generateSpringKafkaClient = true,
+            modelPackage = "com.example.model",
+            topicPropertyPrefix = topicPropertyPrefix,
         )
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparerTest.kt
@@ -1,0 +1,35 @@
+package dev.banking.asyncapi.generator.core.generator.kotlin
+
+import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import dev.banking.asyncapi.generator.core.generator.kotlin.model.GeneratorItem
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class KotlinModelPreparerTest {
+    private val preparer = KotlinModelPreparer()
+    private val fixtures = GenerationInputFixtures()
+
+    @Test
+    fun `prepare maps generation input into Kotlin model items`() {
+        val items =
+            preparer.prepare(
+                input = fixtures.generationInputWithObjectEnumAndPrimitive(),
+                packageName = "com.example.model",
+                annotation = "jakarta.validation.Valid",
+            )
+
+        assertEquals(listOf("User", "Status"), items.map { it.name })
+
+        val user = items.filterIsInstance<GeneratorItem.DataClassModel>().single()
+        assertEquals("com.example.model", user.packageName)
+        assertEquals(listOf("Command"), user.parentInterfaces)
+        assertEquals(listOf("@Valid"), user.classAnnotations)
+        assertEquals(listOf("jakarta.validation.Valid"), user.classAnnotationImports)
+        assertEquals("id", user.properties.single().name)
+        assertEquals("String", user.properties.single().typeName)
+
+        val status = items.filterIsInstance<GeneratorItem.EnumClassModel>().single()
+        assertEquals("com.example.model", status.packageName)
+        assertEquals(listOf("ACTIVE", "INACTIVE"), status.values)
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/KotlinModelPreparerTest.kt
@@ -32,4 +32,23 @@ class KotlinModelPreparerTest {
         assertEquals("com.example.model", status.packageName)
         assertEquals(listOf("ACTIVE", "INACTIVE"), status.values)
     }
+
+    @Test
+    fun `prepare headers maps message headers into Kotlin model items`() {
+        val items =
+            preparer.prepareHeaders(
+                input = fixtures.generationInputWithObjectEnumAndPrimitive(),
+                asyncApiDocument = fixtures.documentWithMessageHeaders(),
+                packageName = "com.example.client.header",
+            )
+
+        val header = items.filterIsInstance<GeneratorItem.DataClassModel>().single()
+        assertEquals("TopicUserEventsHeadersUserSignup", header.name)
+        assertEquals("com.example.client.header", header.packageName)
+        assertEquals(
+            listOf("correlationId", "applicationInstanceId"),
+            header.properties.map { it.name },
+        )
+        assertEquals(listOf("String?", "String?"), header.properties.map { it.typeName })
+    }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
@@ -1,0 +1,161 @@
+package dev.banking.asyncapi.generator.core.generator.plan
+
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorOptions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class GenerationPlannerTest {
+    private val planner = GenerationPlanner()
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `plan includes model and schema artifact tasks when enabled`() {
+        val plan =
+            planner.plan(
+                generatorOptions(
+                    generateModels = true,
+                    generateAvroSchema = true,
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                GenerationTask.ModelArtifacts(
+                    language = GeneratorName.KOTLIN,
+                    packageName = "com.example.model",
+                ),
+                GenerationTask.AvroSchemaArtifacts(
+                    packageName = "com.example.schema",
+                ),
+            ),
+            plan.tasks,
+        )
+    }
+
+    @Test
+    fun `plan includes header and full Spring Kafka client tasks for full client generation`() {
+        val plan =
+            planner.plan(
+                generatorOptions(
+                    generateModels = false,
+                    generateSpringKafkaClient = true,
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                GenerationTask.HeaderModelArtifacts(
+                    language = GeneratorName.KOTLIN,
+                    packageName = "com.example.client.header",
+                ),
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.KOTLIN,
+                    clientType = SpringKafkaClientType.FULL,
+                ),
+            ),
+            plan.tasks,
+        )
+    }
+
+    @Test
+    fun `plan excludes header model task for simple Spring Kafka client generation`() {
+        val plan =
+            planner.plan(
+                generatorOptions(
+                    generateModels = false,
+                    generateSpringKafkaClient = true,
+                    configOptions = mapOf("client.type" to "spring-kafka-simple"),
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.KOTLIN,
+                    clientType = SpringKafkaClientType.SIMPLE,
+                ),
+            ),
+            plan.tasks,
+        )
+    }
+
+    @Test
+    fun `plan uses selected language for language-specific tasks`() {
+        val plan =
+            planner.plan(
+                generatorOptions(
+                    generatorName = GeneratorName.JAVA,
+                    generateModels = true,
+                    generateSpringKafkaClient = true,
+                    generateQuarkusKafkaClient = true,
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                GenerationTask.ModelArtifacts(
+                    language = GeneratorName.JAVA,
+                    packageName = "com.example.model",
+                ),
+                GenerationTask.HeaderModelArtifacts(
+                    language = GeneratorName.JAVA,
+                    packageName = "com.example.client.header",
+                ),
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.JAVA,
+                    clientType = SpringKafkaClientType.FULL,
+                ),
+                GenerationTask.QuarkusKafkaClient(
+                    language = GeneratorName.JAVA,
+                ),
+            ),
+            plan.tasks,
+        )
+    }
+
+    @Test
+    fun `plan rejects Spring Kafka client generation with blank topic prefix`() {
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                planner.plan(
+                    generatorOptions(
+                        generateModels = false,
+                        generateSpringKafkaClient = true,
+                        kafkaTopicsPropertyPrefix = "",
+                    ),
+                )
+            }
+
+        assertEquals("kafka.topics.property.prefix cannot be empty", exception.message)
+    }
+
+    private fun generatorOptions(
+        generatorName: GeneratorName = GeneratorName.KOTLIN,
+        generateModels: Boolean = true,
+        generateSpringKafkaClient: Boolean = false,
+        generateQuarkusKafkaClient: Boolean = false,
+        generateAvroSchema: Boolean = false,
+        kafkaTopicsPropertyPrefix: String = "kafka.topics",
+        configOptions: Map<String, String> = emptyMap(),
+    ): GeneratorOptions =
+        GeneratorOptions(
+            generatorName = generatorName,
+            modelPackage = "com.example.model",
+            clientPackage = "com.example.client",
+            schemaPackage = "com.example.schema",
+            codegenOutputDirectory = tempDir.resolve("sources").toFile(),
+            resourceOutputDirectory = tempDir.resolve("resources").toFile(),
+            kafkaTopicsPropertyPrefix = kafkaTopicsPropertyPrefix,
+            generateModels = generateModels,
+            generateSpringKafkaClient = generateSpringKafkaClient,
+            generateQuarkusKafkaClient = generateQuarkusKafkaClient,
+            generateAvroSchema = generateAvroSchema,
+            configOptions = configOptions,
+        )
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
@@ -64,6 +64,32 @@ class GenerationPlannerTest {
     }
 
     @Test
+    fun `plan accepts explicit full Spring Kafka client type`() {
+        val plan =
+            planner.plan(
+                generatorOptions(
+                    generateModels = false,
+                    generateSpringKafkaClient = true,
+                    configOptions = mapOf("client.type" to "spring-kafka"),
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                GenerationTask.HeaderModelArtifacts(
+                    language = GeneratorName.KOTLIN,
+                    packageName = "com.example.client.header",
+                ),
+                GenerationTask.SpringKafkaClient(
+                    language = GeneratorName.KOTLIN,
+                    clientType = SpringKafkaClientType.FULL,
+                ),
+            ),
+            plan.tasks,
+        )
+    }
+
+    @Test
     fun `plan excludes header model task for simple Spring Kafka client generation`() {
         val plan =
             planner.plan(
@@ -133,6 +159,25 @@ class GenerationPlannerTest {
             }
 
         assertEquals("kafka.topics.property.prefix cannot be empty", exception.message)
+    }
+
+    @Test
+    fun `plan rejects unsupported Spring Kafka client type`() {
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                planner.plan(
+                    generatorOptions(
+                        generateModels = false,
+                        generateSpringKafkaClient = true,
+                        configOptions = mapOf("client.type" to "springkafka"),
+                    ),
+                )
+            }
+
+        assertEquals(
+            "Unsupported client.type 'springkafka'. Supported values: spring-kafka, spring-kafka-simple",
+            exception.message,
+        )
     }
 
     private fun generatorOptions(

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
@@ -39,6 +39,28 @@ class GenerationPlannerTest {
     }
 
     @Test
+    fun `plan includes model annotation on model artifact task when configured`() {
+        val plan =
+            planner.plan(
+                generatorOptions(
+                    generateModels = true,
+                    configOptions = mapOf("model.annotation" to "com.example.NoArg"),
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                GenerationTask.ModelArtifacts(
+                    language = GeneratorName.KOTLIN,
+                    packageName = "com.example.model",
+                    annotation = "com.example.NoArg",
+                ),
+            ),
+            plan.tasks,
+        )
+    }
+
+    @Test
     fun `plan includes header and full Spring Kafka client tasks for full client generation`() {
         val plan =
             planner.plan(

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/plan/GenerationPlannerTest.kt
@@ -76,10 +76,7 @@ class GenerationPlannerTest {
                     language = GeneratorName.KOTLIN,
                     packageName = "com.example.client.header",
                 ),
-                GenerationTask.SpringKafkaClient(
-                    language = GeneratorName.KOTLIN,
-                    clientType = SpringKafkaClientType.FULL,
-                ),
+                springKafkaClientTask(clientType = SpringKafkaClientType.FULL),
             ),
             plan.tasks,
         )
@@ -102,10 +99,7 @@ class GenerationPlannerTest {
                     language = GeneratorName.KOTLIN,
                     packageName = "com.example.client.header",
                 ),
-                GenerationTask.SpringKafkaClient(
-                    language = GeneratorName.KOTLIN,
-                    clientType = SpringKafkaClientType.FULL,
-                ),
+                springKafkaClientTask(clientType = SpringKafkaClientType.FULL),
             ),
             plan.tasks,
         )
@@ -124,9 +118,32 @@ class GenerationPlannerTest {
 
         assertEquals(
             listOf(
-                GenerationTask.SpringKafkaClient(
+                springKafkaClientTask(clientType = SpringKafkaClientType.SIMPLE),
+            ),
+            plan.tasks,
+        )
+    }
+
+    @Test
+    fun `plan includes custom topic prefix on Spring Kafka client task`() {
+        val plan =
+            planner.plan(
+                generatorOptions(
+                    generateModels = false,
+                    generateSpringKafkaClient = true,
+                    kafkaTopicsPropertyPrefix = "custom.topics",
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                GenerationTask.HeaderModelArtifacts(
                     language = GeneratorName.KOTLIN,
-                    clientType = SpringKafkaClientType.SIMPLE,
+                    packageName = "com.example.client.header",
+                ),
+                springKafkaClientTask(
+                    clientType = SpringKafkaClientType.FULL,
+                    topicPropertyPrefix = "custom.topics",
                 ),
             ),
             plan.tasks,
@@ -155,7 +172,7 @@ class GenerationPlannerTest {
                     language = GeneratorName.JAVA,
                     packageName = "com.example.client.header",
                 ),
-                GenerationTask.SpringKafkaClient(
+                springKafkaClientTask(
                     language = GeneratorName.JAVA,
                     clientType = SpringKafkaClientType.FULL,
                 ),
@@ -224,5 +241,20 @@ class GenerationPlannerTest {
             generateQuarkusKafkaClient = generateQuarkusKafkaClient,
             generateAvroSchema = generateAvroSchema,
             configOptions = configOptions,
+        )
+
+    private fun springKafkaClientTask(
+        language: GeneratorName = GeneratorName.KOTLIN,
+        clientType: SpringKafkaClientType,
+        clientPackage: String = "com.example.client",
+        modelPackage: String = "com.example.model",
+        topicPropertyPrefix: String = "kafka.topics",
+    ): GenerationTask.SpringKafkaClient =
+        GenerationTask.SpringKafkaClient(
+            language = language,
+            clientType = clientType,
+            clientPackage = clientPackage,
+            modelPackage = modelPackage,
+            topicPropertyPrefix = topicPropertyPrefix,
         )
 }


### PR DESCRIPTION
- Closes #114 
- Closes #115 
- Closes #116 
- Closes #117 
- Closes #118 

The previous generator flow had too much orchestration inside `AsyncApiGenerator`. It loaded and analyzed schemas, decided what should be generated, prepared Kotlin and Java model objects, rendered model artifacts, rendered header artifacts, rendered Avro schemas, dispatched Spring Kafka generation, and wrote files. That made the generator harder to reason about as a production-ready input-output stage.

This PR introduces a clearer generator contract by separating the generator into smaller stages with explicit responsibilities.

`GenerationInput` now represents the analyzed input that the generator works from. It contains the schemas, polymorphic relationships, analyzed channels, and schema context needed by downstream generator pieces. `GenerationInputFactory` is responsible for creating that input from the parsed and bundled AsyncAPI document.

The language-specific model preparation has also been moved into dedicated preparers. `KotlinModelPreparer` prepares Kotlin model items, including optional model annotations. `JavaModelPreparer` prepares Java model items. Both preparers also support message-header models, so header generation no longer lives directly inside the top-level generator.

A new `GenerationPlanner` creates an ordered `GenerationPlan` from `GeneratorOptions`. The plan contains explicit `GenerationTask` values for model artifacts, header model artifacts, Spring Kafka clients, Quarkus Kafka clients, and Avro schema artifacts. This makes the generator decision step easier to test and easier to extend later.

Spring Kafka generation now has its own boundary through `SpringKafkaClientGeneration`. The planner decides whether the Spring Kafka client is the full client or the simple client, and the Spring Kafka boundary dispatches to the current Kotlin or Java implementation. The accepted `client.type` values are now owned by `SpringKafkaClientType`, so unsupported values fail clearly instead of silently falling back to the full client.

Model and schema artifact rendering have also been extracted from `AsyncApiGenerator`. `ModelArtifactGeneration` handles Kotlin and Java model artifacts, including header model artifacts. `AvroSchemaArtifactGeneration` handles Avro schema artifacts. This leaves `AsyncApiGenerator` closer to a coordinator: create generator input, create a plan, dispatch planned tasks, and write artifacts.

The output contract from the previous generator is still preserved. Source artifacts are written through the source output directory, schema artifacts are written through the resource output directory, and Spring auto-configuration resources continue to be written as resources.

Tests were added for the new generator input contract, generation planner, Kotlin and Java model preparers, Spring Kafka generation boundary, model artifact generation, and Avro schema artifact generation. Existing top-level generator output tests still verify that the full generator writes artifacts to the expected output locations.
