### PR TITLE
feature/payload format boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # asyncapi-generator
 
-The asyncapi-generator is an open-source tool for generating code and schemas from AsyncAPI Yaml specifications.
+The asyncapi-generator is an open-source tool for generating code and schemas from AsyncAPI YAML or JSON specifications.
 
 The project is currently in BETA.
 
 ## Supported generators
 
-- Kotlin - Data classes with Jakarta Validation annotations
-- Java - POJOs or records with Jakarta Validation annotations
-- Spring Kafka - Client source artifacts for both Kotlin and Java
-- Avro - Schema generation from AsyncAPI schemas
+- Kotlin - Data classes with Jakarta Validation annotations from AsyncAPI Schema Object payloads
+- Java - POJOs or records with Jakarta Validation annotations from AsyncAPI Schema Object payloads
+- Spring Kafka - Client source artifacts for JSON-compatible payload models in both Kotlin and Java
+- Avro Projection - `.avsc` schema generation from AsyncAPI Schema Object payloads
 
 The current documentation provided is still a draft, found in `docs/` folder at the repository root.
 
@@ -196,26 +196,60 @@ The generated output depends on the channel direction from the AsyncAPI operatio
 
 The Spring Kafka client surface is still being redesigned for the next major version. The generated artifacts should currently be treated as a source-generation contract, not as final application architecture guidance.
 
+### Payload Schema Formats
+
+The generator separates JSON-compatible AsyncAPI payloads from native or explicit multi-format payload schemas.
+
+The default payload path is the AsyncAPI Schema Object. This is the JSON-compatible schema shape used by model generation, Spring Kafka client generation, and Avro Projection. In this mode, a schema is written directly as an AsyncAPI schema:
+
+```yaml
+components:
+  schemas:
+    UserCreated:
+      type: object
+      required:
+        - userId
+      properties:
+        userId:
+          type: string
+```
+
+Avro Projection is an explicit projection from this AsyncAPI Schema Object shape into `.avsc` files. It does not consume native Avro schemas and it does not generate Avro `SpecificRecord` classes.
+
+Native schema formats are represented with `schemaFormat`, for example Avro or Protobuf:
+
+```yaml
+components:
+  schemas:
+    UserCreated:
+      schemaFormat: application/vnd.apache.avro+json;version=1.9.0
+      schema:
+        type: record
+        name: UserCreated
+        fields: []
+```
+
+The reader and parser recognize known `schemaFormat` values and preserve those schemas as multi-format payloads. Existing model, Spring Kafka, and Avro Projection outputs reject those payloads with a clear generator error because they currently support AsyncAPI Schema Object payloads only. Dedicated native Avro and Protobuf generator capabilities will be modeled separately.
+
 ## Features supported 
 
 ### Parser
 
 The core parsing logic is stable and handles the structural validation of AsyncAPI documents.
 
-- [x] **AsyncAPI YAML Support:** Reads and Parses yaml format.
-- [ ] **AsyncAPI JSON Support:** Reads and Parses yaml format.
+- [x] **AsyncAPI YAML Support:** Reads and parses YAML format.
+- [x] **AsyncAPI JSON Support:** Reads and parses JSON format.
 - [x] **Context-Aware Error Handling:** Provides precise error messages with line numbers and JSON paths.
 - [x] **Reference Resolution:** Supports internal and external file references.
 - [x] **Components:** Full parsing support for Schemas, Messages, Channels, Parameters, etc.
 
 ### Schema Formats
 
-- [x] **Yaml Schema:** Fully supported (default format).
-- [ ] **Multi-Format Schemas:**
-  - [ ] **JSON Schema:** Support for parsing JSON schemas defined in AsyncAPI documents.
-  - [ ] **Avro Schema:** Support for parsing Avro schemas defined in AsyncAPI documents.
-  - [ ] **Protobuf Schema:** Support for parsing Protobuf schemas defined in AsyncAPI documents.
-  - [ ] **RAML Schema:** Support for parsing Protobuf schemas defined in AsyncAPI documents.
+- [x] **AsyncAPI Schema Object:** Fully supported for model, Spring Kafka, and Avro Projection outputs.
+- [x] **Known Multi-Format Schemas:** Known `schemaFormat` values are recognized and preserved separately from AsyncAPI Schema Object payloads.
+- [ ] **Native Avro Generation:** Dedicated native Avro generation is not yet implemented.
+- [ ] **Native Protobuf Generation:** Dedicated Protobuf generation is not yet implemented.
+- [ ] **Other Multi-Format Outputs:** JSON Schema, OpenAPI, RAML, and other schema families are not yet consumed by generator outputs.
 
 ### Validator
 
@@ -230,5 +264,5 @@ The core parsing logic is stable and handles the structural validation of AsyncA
 - [ ] **CLI Tool:** Publish the already made CLI module to package managers like brew and dnf.
 - [ ] **Documentation:** Complete documentation with examples and guides.
 - [ ] **Additional Generators:** Expand support for more programming languages and frameworks, i.e., Quarkus Kafka.
-- [ ] **Enhanced Schema Support:** Full support for multi-format schemas including Avro and Protobuf.
+- [ ] **Enhanced Schema Support:** Dedicated native schema generation capabilities including Avro and Protobuf.
 - [ ] **Serialization:** Consider using kotlinx-serialization for writing bundled schemas to files.

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGenerator.kt
@@ -3,6 +3,7 @@ package dev.banking.asyncapi.generator.core.generator
 import dev.banking.asyncapi.generator.core.generator.artifact.AvroSchemaArtifactGeneration
 import dev.banking.asyncapi.generator.core.generator.artifact.ModelArtifactGeneration
 import dev.banking.asyncapi.generator.core.generator.configuration.GeneratorConfiguration
+import dev.banking.asyncapi.generator.core.generator.input.GenerationInputCompatibilityValidator
 import dev.banking.asyncapi.generator.core.generator.input.GenerationInputFactory
 import dev.banking.asyncapi.generator.core.generator.kafka.spring.SpringKafkaClientGeneration
 import dev.banking.asyncapi.generator.core.generator.output.FileSystemGeneratedArtifactWriter
@@ -21,6 +22,7 @@ class AsyncApiGenerator {
     private val log = LoggerFactory.getLogger(AsyncApiGenerator::class.java)
 
     private val generationInputFactory = GenerationInputFactory()
+    private val generationInputCompatibilityValidator = GenerationInputCompatibilityValidator()
     private val generationPlanner = GenerationPlanner()
     private val modelArtifactGeneration = ModelArtifactGeneration()
     private val avroSchemaArtifactGeneration = AvroSchemaArtifactGeneration()
@@ -32,6 +34,10 @@ class AsyncApiGenerator {
     ) {
         val generationInput = generationInputFactory.create(asyncApiDocument)
         val generationPlan = generationPlanner.plan(generatorConfiguration)
+        generationInputCompatibilityValidator.validate(
+            generationInput = generationInput,
+            generationPlan = generationPlan,
+        )
         val artifactWriter =
             FileSystemGeneratedArtifactWriter(
                 sourceOutputDirectory = generatorConfiguration.output.sourceOutputDirectory,

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/AnalyzedChannel.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/AnalyzedChannel.kt
@@ -5,5 +5,6 @@ data class AnalyzedChannel(
     val topic: String,
     val isProducer: Boolean, // Generate Producer class?
     val isConsumer: Boolean, // Generate Listener/Handler?
-    val messages: List<AnalyzedMessage>
+    val messages: List<AnalyzedMessage>,
+    val multiFormatMessages: List<AnalyzedMultiFormatMessage> = emptyList(),
 )

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/AnalyzedMultiFormatMessage.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/AnalyzedMultiFormatMessage.kt
@@ -1,0 +1,18 @@
+package dev.banking.asyncapi.generator.core.generator.analyzer
+
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
+
+/**
+ * Message payload backed by an explicit non-AsyncAPI `schemaFormat`.
+ *
+ * These payloads are kept separate from [AnalyzedMessage] because they should not
+ * be normalized or generated as JSON-compatible model schemas.
+ *
+ * Expected behavior is covered by:
+ * - `ChannelAnalyzerTest`
+ */
+data class AnalyzedMultiFormatMessage(
+    val messageName: String,
+    val payloadName: String,
+    val schema: MultiFormatSchema,
+)

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/ChannelAnalyzer.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/ChannelAnalyzer.kt
@@ -8,6 +8,7 @@ import dev.banking.asyncapi.generator.core.model.messages.Message
 import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
 import dev.banking.asyncapi.generator.core.model.operations.Operation
 import dev.banking.asyncapi.generator.core.model.operations.OperationInterface
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
@@ -62,29 +63,35 @@ class ChannelAnalyzer {
                 val usage = channelUsage[name]!!
                 val finalProducer = if (!usage.isProducer && !usage.isConsumer) true else usage.isProducer
                 val finalConsumer = if (!usage.isProducer && !usage.isConsumer) true else usage.isConsumer
+                val resolvedMessages = resolveMessages(channel.messages)
 
                 AnalyzedChannel(
                     channelName = name,
                     topic = channel.address ?: name, // Fallback if address missing
                     isProducer = finalProducer,
                     isConsumer = finalConsumer,
-                    messages = resolveMessages(channel.messages),
+                    messages = resolvedMessages.messages,
+                    multiFormatMessages = resolvedMessages.multiFormatMessages,
                 )
             }
 
         return ChannelAnalysisResult(analyzedChannels)
     }
 
-    private fun resolveMessages(messages: Map<String, MessageInterface>?): List<AnalyzedMessage> {
-        if (messages.isNullOrEmpty()) return emptyList()
-        return messages.mapNotNull { (name, msgInterface) ->
+    private fun resolveMessages(messages: Map<String, MessageInterface>?): ResolvedMessages {
+        if (messages.isNullOrEmpty()) return ResolvedMessages()
+        val analyzedMessages = mutableListOf<AnalyzedMessage>()
+        val analyzedMultiFormatMessages = mutableListOf<AnalyzedMultiFormatMessage>()
+
+        messages.forEach { (name, msgInterface) ->
             val message =
                 when (msgInterface) {
                     is MessageInterface.MessageInline -> msgInterface.message
                     is MessageInterface.MessageReference -> msgInterface.reference.model as? Message
-                } ?: return@mapNotNull null
+                } ?: return@forEach
 
             var payloadSchema: Schema? = null
+            var multiFormatSchema: MultiFormatSchema? = null
             var typeName: String? = null
             val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: name)
             val inlinePayloadTypeName = if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
@@ -95,19 +102,48 @@ class ChannelAnalyzer {
                     typeName = inlinePayloadTypeName
                 }
                 is SchemaInterface.SchemaReference -> {
-                    payloadSchema = p.reference.model as? Schema
                     typeName = MapperUtil.toPascalCase(p.reference.ref.substringAfterLast('/'))
+                    when (val referencedModel = p.reference.model) {
+                        is Schema -> payloadSchema = referencedModel
+                        is MultiFormatSchema -> multiFormatSchema = referencedModel
+                    }
+                }
+                is SchemaInterface.MultiFormatSchemaInline -> {
+                    multiFormatSchema = p.multiFormatSchema
+                    typeName = inlinePayloadTypeName
                 }
                 else -> {}
             }
 
-            if (payloadSchema == null || typeName == null) return@mapNotNull null
+            if (typeName == null) return@forEach
 
-            AnalyzedMessage(
-                messageName = baseName,
-                payloadTypeName = typeName,
-                schema = payloadSchema,
-            )
+            if (payloadSchema != null) {
+                analyzedMessages.add(
+                    AnalyzedMessage(
+                        messageName = baseName,
+                        payloadTypeName = typeName,
+                        schema = payloadSchema,
+                    ),
+                )
+            } else if (multiFormatSchema != null) {
+                analyzedMultiFormatMessages.add(
+                    AnalyzedMultiFormatMessage(
+                        messageName = baseName,
+                        payloadName = typeName,
+                        schema = multiFormatSchema,
+                    ),
+                )
+            }
         }
+
+        return ResolvedMessages(
+            messages = analyzedMessages,
+            multiFormatMessages = analyzedMultiFormatMessages,
+        )
     }
+
+    private data class ResolvedMessages(
+        val messages: List<AnalyzedMessage> = emptyList(),
+        val multiFormatMessages: List<AnalyzedMultiFormatMessage> = emptyList(),
+    )
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInput.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInput.kt
@@ -2,6 +2,7 @@ package dev.banking.asyncapi.generator.core.generator.input
 
 import dev.banking.asyncapi.generator.core.generator.analyzer.AnalyzedChannel
 import dev.banking.asyncapi.generator.core.generator.context.GeneratorContext
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 
 /**
@@ -16,6 +17,7 @@ import dev.banking.asyncapi.generator.core.model.schemas.Schema
  */
 data class GenerationInput(
     val schemas: Map<String, Schema>,
+    val multiFormatSchemas: Map<String, MultiFormatSchema> = emptyMap(),
     val polymorphicRelationships: Map<String, List<String>>,
     val channels: List<AnalyzedChannel>,
 ) {

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputCompatibilityValidator.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputCompatibilityValidator.kt
@@ -1,0 +1,72 @@
+package dev.banking.asyncapi.generator.core.generator.input
+
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationPlan
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException.UnsupportedPayloadSchemaFormat
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
+
+/**
+ * Validates that planned generator outputs can consume the prepared generator input.
+ *
+ * Expected behavior is covered by:
+ * - `GenerationInputCompatibilityValidatorTest`
+ */
+class GenerationInputCompatibilityValidator {
+
+    fun validate(
+        generationInput: GenerationInput,
+        generationPlan: GenerationPlan,
+    ) {
+        generationPlan.tasks.forEach { task ->
+            when (task) {
+                is GenerationTask.ModelArtifacts ->
+                    rejectMultiFormatSchemas(
+                        output = "Model generation",
+                        multiFormatSchemas = generationInput.multiFormatSchemas,
+                    )
+                is GenerationTask.SpringKafkaClient ->
+                    rejectMultiFormatMessages(
+                        output = "Spring Kafka client generation",
+                        generationInput = generationInput,
+                    )
+                is GenerationTask.AvroSchemaArtifacts ->
+                    rejectMultiFormatSchemas(
+                        output = "Avro Projection",
+                        multiFormatSchemas = generationInput.multiFormatSchemas,
+                    )
+                is GenerationTask.HeaderModelArtifacts,
+                is GenerationTask.QuarkusKafkaClient,
+                -> Unit
+            }
+        }
+    }
+
+    private fun rejectMultiFormatSchemas(
+        output: String,
+        multiFormatSchemas: Map<String, MultiFormatSchema>,
+    ) {
+        val firstSchema = multiFormatSchemas.entries.firstOrNull() ?: return
+        throw UnsupportedPayloadSchemaFormat(
+            output = output,
+            payloadName = firstSchema.key,
+            schemaFormat = firstSchema.value.schemaFormat,
+        )
+    }
+
+    private fun rejectMultiFormatMessages(
+        output: String,
+        generationInput: GenerationInput,
+    ) {
+        val firstMessage =
+            generationInput.channels
+                .asSequence()
+                .flatMap { channel -> channel.multiFormatMessages.asSequence() }
+                .firstOrNull() ?: return
+
+        throw UnsupportedPayloadSchemaFormat(
+            output = output,
+            payloadName = firstMessage.payloadName,
+            schemaFormat = firstMessage.schema.schemaFormat,
+        )
+    }
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactory.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactory.kt
@@ -19,12 +19,14 @@ class GenerationInputFactory(
 ) {
     fun create(asyncApiDocument: AsyncApiDocument): GenerationInput {
         val schemas = AsyncApiSchemaLoader.load(asyncApiDocument)
+        val multiFormatSchemas = AsyncApiSchemaLoader.loadMultiFormatSchemas(asyncApiDocument)
         val normalizedSchemas = schemaNormalizer.normalize(schemas)
         val (analyzedSchemas, polymorphicRelationships) = schemaAnalyzer.analyze(normalizedSchemas)
         val analyzedChannels = channelAnalyzer.analyze(asyncApiDocument).channels
 
         return GenerationInput(
             schemas = analyzedSchemas,
+            multiFormatSchemas = multiFormatSchemas,
             polymorphicRelationships = polymorphicRelationships,
             channels = analyzedChannels,
         )

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoader.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoader.kt
@@ -10,6 +10,7 @@ import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
 import dev.banking.asyncapi.generator.core.model.messages.MessageTrait
 import dev.banking.asyncapi.generator.core.model.messages.MessageTraitInterface
 import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
@@ -33,8 +34,7 @@ object AsyncApiSchemaLoader {
             val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
             if (message.payload is SchemaInterface.SchemaInline) {
                 val inlinePayload = message.payload.schema
-                val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: messageKey)
-                val schemaName = if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
+                val schemaName = payloadSchemaName(message, messageKey)
                 if (!collectedSchemas.containsKey(schemaName)) {
                     collectedSchemas[schemaName] = inlinePayload
                 }
@@ -47,13 +47,44 @@ object AsyncApiSchemaLoader {
             channel.messages?.forEach { (messageKey, messageInterface) ->
                 val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
                 val inlinePayload = message.payload as? SchemaInterface.SchemaInline ?: return@forEach
-                val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: messageKey)
-                val schemaName = if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
+                val schemaName = payloadSchemaName(message, messageKey)
                 if (!collectedSchemas.containsKey(schemaName)) {
                     collectedSchemas[schemaName] = inlinePayload.schema
                 }
             }
         }
+        return collectedSchemas
+    }
+
+    fun loadMultiFormatSchemas(asyncApiDocument: AsyncApiDocument): Map<String, MultiFormatSchema> {
+        val collectedSchemas = mutableMapOf<String, MultiFormatSchema>()
+        val componentNode = (asyncApiDocument.components as? ComponentInterface.ComponentInline)?.component
+
+        componentNode?.schemas?.forEach { (name, schemaInterface) ->
+            val multiFormatSchema =
+                (schemaInterface as? SchemaInterface.MultiFormatSchemaInline)?.multiFormatSchema ?: return@forEach
+            collectedSchemas[MapperUtil.toPascalCase(name)] = multiFormatSchema
+        }
+
+        componentNode?.messages?.forEach { (messageKey, messageInterface) ->
+            val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
+            val inlinePayload =
+                (message.payload as? SchemaInterface.MultiFormatSchemaInline)?.multiFormatSchema ?: return@forEach
+            val schemaName = payloadSchemaName(message, messageKey)
+            collectedSchemas.putIfAbsent(schemaName, inlinePayload)
+        }
+
+        asyncApiDocument.channels?.forEach { (_, channelInterface) ->
+            val channel = (channelInterface as? ChannelInterface.ChannelInline)?.channel ?: return@forEach
+            channel.messages?.forEach { (messageKey, messageInterface) ->
+                val message = (messageInterface as? MessageInterface.MessageInline)?.message ?: return@forEach
+                val inlinePayload =
+                    (message.payload as? SchemaInterface.MultiFormatSchemaInline)?.multiFormatSchema ?: return@forEach
+                val schemaName = payloadSchemaName(message, messageKey)
+                collectedSchemas.putIfAbsent(schemaName, inlinePayload)
+            }
+        }
+
         return collectedSchemas
     }
 
@@ -136,5 +167,13 @@ object AsyncApiSchemaLoader {
         schema.anyOf?.forEach { collectFromSchemaInterface(it, sink, visitedRefs) }
         schema.allOf?.forEach { collectFromSchemaInterface(it, sink, visitedRefs) }
         schema.not?.let { collectFromSchemaInterface(it, sink, visitedRefs) }
+    }
+
+    private fun payloadSchemaName(
+        message: Message,
+        messageKey: String,
+    ): String {
+        val baseName = MapperUtil.toPascalCase(message.name ?: message.title ?: messageKey)
+        return if (baseName.endsWith("Payload")) baseName else "${baseName}Payload"
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiGeneratorException.kt
@@ -41,4 +41,18 @@ sealed class AsyncApiGeneratorException(
             private fun formatOriginals(values: List<String>): String = values.joinToString(prefix = "[", postfix = "]") { "'$it'" }
         }
     }
+
+    class UnsupportedPayloadSchemaFormat(
+        output: String,
+        payloadName: String,
+        schemaFormat: String,
+    ) : AsyncApiGeneratorException(
+            buildString {
+                appendLine()
+                appendLine("$output cannot consume payload '$payloadName' because it uses schemaFormat '$schemaFormat'.")
+                appendLine("This output currently supports AsyncAPI Schema Object payloads only.")
+                appendLine("Native Avro, Protobuf, and other explicit schema formats must be handled by dedicated generator capabilities.")
+                appendLine()
+            }.trimEnd(),
+        )
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiParseException.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/exceptions/AsyncApiParseException.kt
@@ -10,9 +10,6 @@ sealed class AsyncApiParseException(message: String) : Exception(message) {
     class Mandatory(name: String, path: String, context: AsyncApiContext) :
         AsyncApiParseException(buildMessage("Missing mandatory '$name'", path, context))
 
-    class UnsupportedSchemaFormat(format: String, path: String, context: AsyncApiContext) :
-        AsyncApiParseException(buildMessage("SchemaFormat: $format is not supported.", path, context))
-
     class UnexpectedSchemaFormat(format: String, path: String, context: AsyncApiContext) :
         AsyncApiParseException(buildMessage("SchemaFormat: $format is not valid.", path, context))
 

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/schemas/MultiFormatSchema.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/schemas/MultiFormatSchema.kt
@@ -1,34 +1,22 @@
 package dev.banking.asyncapi.generator.core.model.schemas
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 /**
- * Defaults:
- * application/vnd.aai.asyncapi;version=3.0.0,
- * application/vnd.aai.asyncapi+json;version=3.0.0,
- * application/vnd.aai.asyncapi+yaml;version=3.0.0
+ * Parsed representation of an AsyncAPI schema object that declares an explicit
+ * non-AsyncAPI `schemaFormat`.
  *
- * JSON Schema draft-07:
- * application/schema+json;version=draft-07,
- * application/schema+yaml;version=draft-07
+ * The original [schemaFormat] string is retained for serialization and bundling,
+ * while [format] gives later stages a typed way to distinguish native formats.
  *
- * Avro:
- * application/vnd.apache.avro;version=1.9.0,
- * application/vnd.apache.avro+json;version=1.9.0,
- * application/vnd.apache.avro+yaml;version=1.9.0
- *
- * OpenAPI 3.0 Schema Object:
- * application/vnd.oai.openapi;version=3.0.0,
- * application/vnd.oai.openapi+json;version=3.0.0,
- * application/vnd.oai.openapi+yaml;version=3.0.0
- *
- * RAML 1.0 Data Type:
- * application/raml+yaml;version=1.0
- *
- * Protobuf:
- * application/vnd.google.protobuf;version=2,
- * application/vnd.google.protobuf;version=3
- *
- * */
+ * Expected behavior is covered by:
+ * - `MultiFormatSchemaParserTest`
+ */
 data class MultiFormatSchema(
     val schemaFormat: String,
-    val schema: Any
+    val schema: Any?,
+    @get:JsonIgnore
+    val format: SchemaFormat = requireNotNull(SchemaFormat.fromValue(schemaFormat)) {
+        "Unknown schemaFormat '$schemaFormat'"
+    },
 )

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/schemas/SchemaFormat.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/model/schemas/SchemaFormat.kt
@@ -1,0 +1,103 @@
+package dev.banking.asyncapi.generator.core.model.schemas
+
+import dev.banking.asyncapi.generator.core.constants.AsyncApiConstants
+
+/**
+ * Known AsyncAPI `schemaFormat` values grouped by their semantic schema family.
+ *
+ * The parser can use this type to distinguish JSON-compatible AsyncAPI schema objects
+ * from native schema formats such as Avro and Protobuf before generation decides which
+ * outputs can consume each payload format.
+ *
+ * Expected behavior is covered by:
+ * - `SchemaFormatTest`
+ * - `MultiFormatSchemaParserTest`
+ */
+enum class SchemaFormat(
+    val value: String,
+    val family: SchemaFormatFamily,
+) {
+    ASYNCAPI_3_0_0(
+        value = AsyncApiConstants.ASYNCAPI_V_3_0_0,
+        family = SchemaFormatFamily.ASYNCAPI,
+    ),
+    ASYNCAPI_3_0_0_JSON(
+        value = AsyncApiConstants.ASYNCAPI_V_3_0_0_JSON,
+        family = SchemaFormatFamily.ASYNCAPI,
+    ),
+    ASYNCAPI_3_0_0_YAML(
+        value = AsyncApiConstants.ASYNCAPI_V_3_0_0_YAML,
+        family = SchemaFormatFamily.ASYNCAPI,
+    ),
+    JSON_SCHEMA_DRAFT_07_JSON(
+        value = AsyncApiConstants.JSON_SCHEMA_DRAFT_07_JSON,
+        family = SchemaFormatFamily.JSON_SCHEMA_DRAFT_07,
+    ),
+    JSON_SCHEMA_DRAFT_07_YAML(
+        value = AsyncApiConstants.JSON_SCHEMA_DRAFT_07_YAML,
+        family = SchemaFormatFamily.JSON_SCHEMA_DRAFT_07,
+    ),
+    AVRO_1_9_0(
+        value = AsyncApiConstants.AVRO_V_1_9_0,
+        family = SchemaFormatFamily.AVRO,
+    ),
+    AVRO_1_9_0_JSON(
+        value = AsyncApiConstants.AVRO_V_1_9_0_JSON,
+        family = SchemaFormatFamily.AVRO,
+    ),
+    AVRO_1_9_0_YAML(
+        value = AsyncApiConstants.AVRO_V_1_9_0_YAML,
+        family = SchemaFormatFamily.AVRO,
+    ),
+    OPENAPI_3_0_0(
+        value = AsyncApiConstants.OPENAPI_V_3_0_0,
+        family = SchemaFormatFamily.OPENAPI,
+    ),
+    OPENAPI_3_0_0_JSON(
+        value = AsyncApiConstants.OPENAPI_V_3_0_0_JSON,
+        family = SchemaFormatFamily.OPENAPI,
+    ),
+    OPENAPI_3_0_0_YAML(
+        value = AsyncApiConstants.OPENAPI_V_3_0_0_YAML,
+        family = SchemaFormatFamily.OPENAPI,
+    ),
+    RAML_1_0_YAML(
+        value = AsyncApiConstants.RAML_V_1_0_YAML,
+        family = SchemaFormatFamily.RAML,
+    ),
+    PROTOBUF_2(
+        value = AsyncApiConstants.PROTOBUF_V_2,
+        family = SchemaFormatFamily.PROTOBUF,
+    ),
+    PROTOBUF_3(
+        value = AsyncApiConstants.PROTOBUF_V_3,
+        family = SchemaFormatFamily.PROTOBUF,
+    );
+
+    val isAsyncApiSchemaObject: Boolean
+        get() = family == SchemaFormatFamily.ASYNCAPI
+
+    val isNativeAvro: Boolean
+        get() = family == SchemaFormatFamily.AVRO
+
+    val isNativeProtobuf: Boolean
+        get() = family == SchemaFormatFamily.PROTOBUF
+
+    companion object {
+        private val byValue = entries.associateBy(SchemaFormat::value)
+
+        fun fromValue(value: String): SchemaFormat? = byValue[value]
+    }
+}
+
+/**
+ * Broad semantic family for a known `schemaFormat` value.
+ */
+enum class SchemaFormatFamily {
+    ASYNCAPI,
+    JSON_SCHEMA_DRAFT_07,
+    AVRO,
+    OPENAPI,
+    RAML,
+    PROTOBUF,
+}

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
@@ -2,27 +2,20 @@ package dev.banking.asyncapi.generator.core.parser.schemas
 
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException.UnexpectedSchemaFormat
-import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException.UnsupportedSchemaFormat
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaFormat
 
 /**
- * [MultiFormatSchemaParser] currently acts as a **validator** for schema format choices.
+ * [MultiFormatSchemaParser] parses the `schemaFormat` value from AsyncAPI schema objects.
  *
- * Its primary responsibility is to check the `schemaFormat` string provided in an AsyncAPI document
- * against a predefined list of known formats.
+ * Its primary responsibility is to translate known schema format strings into a typed
+ * [SchemaFormat], so later parser and generator stages can distinguish AsyncAPI schema
+ * objects from native schema formats such as Avro and Protobuf.
  *
  * **Current State:**
- * - It fully supports and *allows* standard AsyncAPI schema formats (e.g., `application/vnd.aai.asyncapi+yaml`).
- *   When such a format is encountered, it passes validation, and the schema content is then parsed
- *   by the regular [SchemaParser].
- * - For other known formats (e.g., JSON Schema Draft-07, Avro, OpenAPI, RAML, Protobuf),
- *   it *recognizes* the format but **throws a [UnsupportedSchemaFormat]**, indicating that
- *   code generation for these specific formats is not yet implemented in the generator.
+ * - Standard AsyncAPI schema formats are parsed and then handled by the regular [SchemaParser].
+ * - Other known formats are preserved as multi-format schemas. Generator support for these
+ *   formats is handled by later stages.
  * - For any unknown `schemaFormat` string, it throws an [UnexpectedSchemaFormat] error.
- *
- * **Future Expansion:**
- * This parser is designed to be expanded in the future to provide full parsing and
- * code generation support for the currently unimplemented schema formats.
  *
  * Expected behavior is covered by:
  * - `MultiFormatSchemaParserTest`
@@ -32,13 +25,7 @@ class MultiFormatSchemaParser(
     val asyncApiContext: AsyncApiContext,
 ) {
 
-    fun validateFormat(format: String, path: String) {
-        val schemaFormat =
-            SchemaFormat.fromValue(format)
-                ?: throw UnexpectedSchemaFormat(format, path, asyncApiContext)
-        if (schemaFormat.isAsyncApiSchemaObject) {
-            return
-        }
-        throw UnsupportedSchemaFormat(format, path, asyncApiContext)
-    }
+    fun parseFormat(format: String, path: String): SchemaFormat =
+        SchemaFormat.fromValue(format)
+            ?: throw UnexpectedSchemaFormat(format, path, asyncApiContext)
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParser.kt
@@ -1,11 +1,9 @@
 package dev.banking.asyncapi.generator.core.parser.schemas
 
-import dev.banking.asyncapi.generator.core.constants.AsyncApiConstants
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
-import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException.UnexpectedSchemaFormat
-import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException.UnexpectedValue
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException.UnsupportedSchemaFormat
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaFormat
 
 /**
  * [MultiFormatSchemaParser] currently acts as a **validator** for schema format choices.
@@ -35,46 +33,12 @@ class MultiFormatSchemaParser(
 ) {
 
     fun validateFormat(format: String, path: String) {
-        when {
-            isAsyncApiFormat(format) -> return
-            isJsonSchemaDraftFormat(format) -> throw UnsupportedSchemaFormat(format, path, asyncApiContext)
-            isAvroFormat(format) -> throw UnsupportedSchemaFormat(format, path, asyncApiContext)
-            isOpenApiFormat(format) -> throw UnsupportedSchemaFormat(format, path, asyncApiContext)
-            isRamlFormat(format) -> throw UnsupportedSchemaFormat(format, path, asyncApiContext)
-            isProtobufFormat(format) -> throw UnsupportedSchemaFormat(format, path, asyncApiContext)
-            else -> throw UnexpectedSchemaFormat(format, path, asyncApiContext)
+        val schemaFormat =
+            SchemaFormat.fromValue(format)
+                ?: throw UnexpectedSchemaFormat(format, path, asyncApiContext)
+        if (schemaFormat.isAsyncApiSchemaObject) {
+            return
         }
-    }
-
-    private fun isAsyncApiFormat(format: String): Boolean {
-        return format == AsyncApiConstants.ASYNCAPI_V_3_0_0 ||
-            format == AsyncApiConstants.ASYNCAPI_V_3_0_0_JSON ||
-            format == AsyncApiConstants.ASYNCAPI_V_3_0_0_YAML
-    }
-
-    private fun isJsonSchemaDraftFormat(format: String): Boolean {
-        return format == AsyncApiConstants.JSON_SCHEMA_DRAFT_07_JSON ||
-            format == AsyncApiConstants.JSON_SCHEMA_DRAFT_07_YAML
-    }
-
-    private fun isAvroFormat(format: String): Boolean {
-        return format == AsyncApiConstants.AVRO_V_1_9_0 ||
-            format == AsyncApiConstants.AVRO_V_1_9_0_JSON ||
-            format == AsyncApiConstants.AVRO_V_1_9_0_YAML
-    }
-
-    private fun isOpenApiFormat(format: String): Boolean {
-        return format == AsyncApiConstants.OPENAPI_V_3_0_0 ||
-            format == AsyncApiConstants.OPENAPI_V_3_0_0_JSON ||
-            format == AsyncApiConstants.OPENAPI_V_3_0_0_YAML
-    }
-
-    private fun isRamlFormat(format: String): Boolean {
-        return format == AsyncApiConstants.RAML_V_1_0_YAML
-    }
-
-    private fun isProtobufFormat(format: String): Boolean {
-        return format == AsyncApiConstants.PROTOBUF_V_2 ||
-            format == AsyncApiConstants.PROTOBUF_V_3
+        throw UnsupportedSchemaFormat(format, path, asyncApiContext)
     }
 }

--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParser.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/SchemaParser.kt
@@ -1,6 +1,7 @@
 package dev.banking.asyncapi.generator.core.parser.schemas
 
 import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.parser.externaldocs.ExternalDocsParser
@@ -50,8 +51,19 @@ class SchemaParser(
             )
         }
         parserNode.optional("schemaFormat")?.coerce<String>()?.let { format ->
-            multiFormatParser.validateFormat(format, parserNode.path)
-            return parseElement(parserNode.mandatory("schema"))
+            val schemaFormat = multiFormatParser.parseFormat(format, parserNode.path)
+            val schemaNode = parserNode.mandatory("schema")
+            if (schemaFormat.isAsyncApiSchemaObject) {
+                return parseElement(schemaNode)
+            }
+            val multiFormatSchema =
+                MultiFormatSchema(
+                    schemaFormat = format,
+                    schema = schemaNode.node,
+                    format = schemaFormat,
+                )
+            return SchemaInterface.MultiFormatSchemaInline(multiFormatSchema)
+                .also { asyncApiContext.register(multiFormatSchema, parserNode) }
         }
         if (isBooleanSchema(parserNode)) {
             val bool = parserNode.coerce<Boolean>()

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
@@ -12,6 +12,7 @@ import dev.banking.asyncapi.generator.core.model.info.Info
 import dev.banking.asyncapi.generator.core.model.messages.Message
 import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
 import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 
@@ -165,4 +166,30 @@ internal class GenerationInputFixtures {
                 ),
         )
     }
+
+    fun documentWithMultiFormatComponent(): AsyncApiDocument =
+        AsyncApiDocument(
+            asyncapi = "3.0.0",
+            info = Info(title = "Test API", version = "1.0.0"),
+            components =
+                ComponentInterface.ComponentInline(
+                    Component(
+                        schemas =
+                            mapOf(
+                                "UserCreated" to
+                                    SchemaInterface.MultiFormatSchemaInline(
+                                        MultiFormatSchema(
+                                            schemaFormat = "application/vnd.apache.avro+json;version=1.9.0",
+                                            schema =
+                                                mapOf(
+                                                    "type" to "record",
+                                                    "name" to "UserCreated",
+                                                    "fields" to emptyList<Any>(),
+                                                ),
+                                        ),
+                                    ),
+                            ),
+                    ),
+                ),
+        )
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/fixtures/GenerationInputFixtures.kt
@@ -178,18 +178,49 @@ internal class GenerationInputFixtures {
                             mapOf(
                                 "UserCreated" to
                                     SchemaInterface.MultiFormatSchemaInline(
-                                        MultiFormatSchema(
-                                            schemaFormat = "application/vnd.apache.avro+json;version=1.9.0",
-                                            schema =
-                                                mapOf(
-                                                    "type" to "record",
-                                                    "name" to "UserCreated",
-                                                    "fields" to emptyList<Any>(),
-                                                ),
-                                        ),
+                                        nativeAvroUserCreatedSchema(),
                                     ),
                             ),
                     ),
+                ),
+        )
+
+    fun documentWithMultiFormatMessagePayload(): AsyncApiDocument =
+        AsyncApiDocument(
+            asyncapi = "3.0.0",
+            info = Info(title = "Test API", version = "1.0.0"),
+            channels =
+                mapOf(
+                    "userEvents" to
+                        ChannelInterface.ChannelInline(
+                            Channel(
+                                address = "user.events",
+                                messages =
+                                    mapOf(
+                                        "userCreated" to
+                                            MessageInterface.MessageInline(
+                                                Message(
+                                                    name = "UserCreated",
+                                                    payload =
+                                                        SchemaInterface.MultiFormatSchemaInline(
+                                                            nativeAvroUserCreatedSchema(),
+                                                        ),
+                                                ),
+                                            ),
+                                    ),
+                            ),
+                        ),
+                ),
+        )
+
+    private fun nativeAvroUserCreatedSchema(): MultiFormatSchema =
+        MultiFormatSchema(
+            schemaFormat = "application/vnd.apache.avro+json;version=1.9.0",
+            schema =
+                mapOf(
+                    "type" to "record",
+                    "name" to "UserCreated",
+                    "fields" to emptyList<Any>(),
                 ),
         )
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGeneratorOutputContractTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/AsyncApiGeneratorOutputContractTest.kt
@@ -2,21 +2,27 @@ package dev.banking.asyncapi.generator.core.generator
 
 import dev.banking.asyncapi.generator.core.context.AsyncApiContext
 import dev.banking.asyncapi.generator.core.fixtures.BundlerFixtures
+import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import dev.banking.asyncapi.generator.core.generator.configuration.ClientGeneration
 import dev.banking.asyncapi.generator.core.generator.configuration.GeneratorConfiguration
 import dev.banking.asyncapi.generator.core.generator.configuration.GeneratorOutputConfiguration
 import dev.banking.asyncapi.generator.core.generator.configuration.ModelGeneration
 import dev.banking.asyncapi.generator.core.generator.configuration.SchemaGeneration
 import dev.banking.asyncapi.generator.core.generator.model.GeneratorName
+import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AsyncApiGeneratorOutputContractTest {
     private val asyncApiContext = AsyncApiContext()
     private val bundlerFixtures = BundlerFixtures(asyncApiContext)
+    private val generationInputFixtures = GenerationInputFixtures()
     private val generator = AsyncApiGenerator()
 
     @TempDir
@@ -62,6 +68,82 @@ class AsyncApiGeneratorOutputContractTest {
         assertFalse(sourceOutputDirectory.resolve("com/example/avro/Task.avsc").exists())
     }
 
+    @Test
+    fun `generate rejects multi format component schemas before writing model artifacts`() {
+        val sourceOutputDirectory = tempDir.resolve("sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("resources").toFile()
+
+        val error =
+            assertFailsWith<AsyncApiGeneratorException.UnsupportedPayloadSchemaFormat> {
+                generator.generate(
+                    asyncApiDocument = generationInputFixtures.documentWithMultiFormatComponent(),
+                    generatorConfiguration =
+                        generatorConfiguration(
+                            sourceOutputDirectory = sourceOutputDirectory,
+                            resourceOutputDirectory = resourceOutputDirectory,
+                            models = ModelGeneration.Enabled(packageName = "com.example.model"),
+                        ),
+                )
+            }
+
+        assertTrue(error.message!!.contains("Model generation cannot consume payload 'UserCreated'"))
+        assertFalse(sourceOutputDirectory.exists())
+        assertFalse(resourceOutputDirectory.exists())
+    }
+
+    @Test
+    fun `generate rejects multi format component schemas before writing avro projection artifacts`() {
+        val sourceOutputDirectory = tempDir.resolve("sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("resources").toFile()
+
+        val error =
+            assertFailsWith<AsyncApiGeneratorException.UnsupportedPayloadSchemaFormat> {
+                generator.generate(
+                    asyncApiDocument = generationInputFixtures.documentWithMultiFormatComponent(),
+                    generatorConfiguration =
+                        generatorConfiguration(
+                            sourceOutputDirectory = sourceOutputDirectory,
+                            resourceOutputDirectory = resourceOutputDirectory,
+                            schemas = listOf(SchemaGeneration.AvroProjection(packageName = "com.example.avro")),
+                        ),
+                )
+            }
+
+        assertTrue(error.message!!.contains("Avro Projection cannot consume payload 'UserCreated'"))
+        assertFalse(sourceOutputDirectory.exists())
+        assertFalse(resourceOutputDirectory.exists())
+    }
+
+    @Test
+    fun `generate rejects multi format message payloads before writing spring kafka artifacts`() {
+        val sourceOutputDirectory = tempDir.resolve("sources").toFile()
+        val resourceOutputDirectory = tempDir.resolve("resources").toFile()
+
+        val error =
+            assertFailsWith<AsyncApiGeneratorException.UnsupportedPayloadSchemaFormat> {
+                generator.generate(
+                    asyncApiDocument = generationInputFixtures.documentWithMultiFormatMessagePayload(),
+                    generatorConfiguration =
+                        generatorConfiguration(
+                            sourceOutputDirectory = sourceOutputDirectory,
+                            resourceOutputDirectory = resourceOutputDirectory,
+                            clients =
+                                listOf(
+                                    ClientGeneration.SpringKafka(
+                                        packageName = "com.example.kafka",
+                                        modelPackageName = "com.example.model",
+                                        clientType = SpringKafkaClientType.SIMPLE,
+                                    ),
+                                ),
+                        ),
+                )
+            }
+
+        assertTrue(error.message!!.contains("Spring Kafka client generation cannot consume payload 'UserCreatedPayload'"))
+        assertFalse(sourceOutputDirectory.exists())
+        assertFalse(resourceOutputDirectory.exists())
+    }
+
     private fun bundledDocument() =
         bundlerFixtures.bundledDocument(
             File("src/test/resources/generator/asyncapi_enum_default_value.yaml"),
@@ -72,6 +154,7 @@ class AsyncApiGeneratorOutputContractTest {
         resourceOutputDirectory: File,
         models: ModelGeneration = ModelGeneration.Disabled,
         schemas: List<SchemaGeneration> = emptyList(),
+        clients: List<ClientGeneration> = emptyList(),
     ): GeneratorConfiguration =
         GeneratorConfiguration(
             language = GeneratorName.KOTLIN,
@@ -82,5 +165,6 @@ class AsyncApiGeneratorOutputContractTest {
                 ),
             models = models,
             schemas = schemas,
+            clients = clients,
         )
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/ChannelAnalyzerTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/analyzer/ChannelAnalyzerTest.kt
@@ -9,6 +9,8 @@ import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
 import dev.banking.asyncapi.generator.core.model.operations.Operation
 import dev.banking.asyncapi.generator.core.model.operations.OperationInterface
 import dev.banking.asyncapi.generator.core.model.references.Reference
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaFormat
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import org.junit.jupiter.api.Test
@@ -80,4 +82,71 @@ class ChannelAnalyzerTest {
         assertTrue(analyzed.isProducer, "Should be producer")
         assertEquals(false, analyzed.isConsumer, "Should NOT be consumer")
     }
+
+    @Test
+    fun `should preserve inline multi format payload separately from asyncapi messages`() {
+        val avroSchema = nativeAvroSchema()
+        val channel = Channel(
+            messages = mapOf(
+                "msg" to MessageInterface.MessageInline(
+                    Message(
+                        name = "MyMessage",
+                        payload = SchemaInterface.MultiFormatSchemaInline(avroSchema),
+                    ),
+                ),
+            ),
+        )
+        val doc = AsyncApiDocument(
+            asyncapi = "3.0.0",
+            info = Info("Title", "1.0"),
+            channels = mapOf("myChannel" to ChannelInterface.ChannelInline(channel)),
+        )
+
+        val analyzed = analyzer.analyze(doc).channels.single()
+
+        assertTrue(analyzed.messages.isEmpty())
+        val multiFormatMessage = analyzed.multiFormatMessages.single()
+        assertEquals("MyMessage", multiFormatMessage.messageName)
+        assertEquals("MyMessagePayload", multiFormatMessage.payloadName)
+        assertEquals(SchemaFormat.AVRO_1_9_0_JSON, multiFormatMessage.schema.format)
+    }
+
+    @Test
+    fun `should preserve referenced multi format payload separately from asyncapi messages`() {
+        val avroSchema = nativeAvroSchema()
+        val channel = Channel(
+            messages = mapOf(
+                "msg" to MessageInterface.MessageInline(
+                    Message(
+                        name = "MyMessage",
+                        payload = SchemaInterface.SchemaReference(
+                            Reference(
+                                ref = "#/components/schemas/UserCreated",
+                                model = avroSchema,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val doc = AsyncApiDocument(
+            asyncapi = "3.0.0",
+            info = Info("Title", "1.0"),
+            channels = mapOf("myChannel" to ChannelInterface.ChannelInline(channel)),
+        )
+
+        val analyzed = analyzer.analyze(doc).channels.single()
+
+        assertTrue(analyzed.messages.isEmpty())
+        val multiFormatMessage = analyzed.multiFormatMessages.single()
+        assertEquals("MyMessage", multiFormatMessage.messageName)
+        assertEquals("UserCreated", multiFormatMessage.payloadName)
+        assertEquals(SchemaFormat.AVRO_1_9_0_JSON, multiFormatMessage.schema.format)
+    }
+
+    private fun nativeAvroSchema(): MultiFormatSchema =
+        MultiFormatSchema(
+            schemaFormat = "application/vnd.apache.avro+json;version=1.9.0",
+            schema = mapOf("type" to "record", "name" to "UserCreated", "fields" to emptyList<Any>()),
+        )
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputCompatibilityValidatorTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputCompatibilityValidatorTest.kt
@@ -1,0 +1,150 @@
+package dev.banking.asyncapi.generator.core.generator.input
+
+import dev.banking.asyncapi.generator.core.generator.analyzer.AnalyzedChannel
+import dev.banking.asyncapi.generator.core.generator.analyzer.AnalyzedMultiFormatMessage
+import dev.banking.asyncapi.generator.core.generator.configuration.JavaModelType
+import dev.banking.asyncapi.generator.core.generator.model.GeneratorName
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationPlan
+import dev.banking.asyncapi.generator.core.generator.plan.GenerationTask
+import dev.banking.asyncapi.generator.core.generator.plan.SpringKafkaClientType
+import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiGeneratorException
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
+import dev.banking.asyncapi.generator.core.model.schemas.Schema
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class GenerationInputCompatibilityValidatorTest {
+    private val validator = GenerationInputCompatibilityValidator()
+
+    @Test
+    fun `allows asyncapi schema object input for model and avro projection tasks`() {
+        validator.validate(
+            generationInput =
+                GenerationInput(
+                    schemas = mapOf("UserCreated" to Schema(type = "object")),
+                    polymorphicRelationships = emptyMap(),
+                    channels = emptyList(),
+                ),
+            generationPlan =
+                GenerationPlan(
+                    listOf(
+                        GenerationTask.ModelArtifacts(
+                            language = GeneratorName.KOTLIN,
+                            packageName = "com.example.model",
+                        ),
+                        GenerationTask.AvroSchemaArtifacts(
+                            packageName = "com.example.avro",
+                        ),
+                    ),
+                ),
+        )
+    }
+
+    @Test
+    fun `rejects multi format schemas for model generation`() {
+        val error =
+            assertFailsWith<AsyncApiGeneratorException.UnsupportedPayloadSchemaFormat> {
+                validator.validate(
+                    generationInput = generationInputWithMultiFormatSchema(),
+                    generationPlan =
+                        GenerationPlan(
+                            listOf(
+                                GenerationTask.ModelArtifacts(
+                                    language = GeneratorName.JAVA,
+                                    packageName = "com.example.model",
+                                    javaModelType = JavaModelType.RECORD,
+                                ),
+                            ),
+                        ),
+                )
+            }
+
+        assertTrue(error.message!!.contains("Model generation cannot consume payload 'UserCreated'"))
+        assertTrue(error.message!!.contains("application/vnd.apache.avro+json;version=1.9.0"))
+    }
+
+    @Test
+    fun `rejects multi format schemas for avro projection`() {
+        val error =
+            assertFailsWith<AsyncApiGeneratorException.UnsupportedPayloadSchemaFormat> {
+                validator.validate(
+                    generationInput = generationInputWithMultiFormatSchema(),
+                    generationPlan =
+                        GenerationPlan(
+                            listOf(
+                                GenerationTask.AvroSchemaArtifacts(
+                                    packageName = "com.example.avro",
+                                ),
+                            ),
+                        ),
+                )
+            }
+
+        assertTrue(error.message!!.contains("Avro Projection cannot consume payload 'UserCreated'"))
+        assertTrue(error.message!!.contains("This output currently supports AsyncAPI Schema Object payloads only."))
+    }
+
+    @Test
+    fun `rejects multi format messages for spring kafka client generation`() {
+        val error =
+            assertFailsWith<AsyncApiGeneratorException.UnsupportedPayloadSchemaFormat> {
+                validator.validate(
+                    generationInput = generationInputWithMultiFormatMessage(),
+                    generationPlan =
+                        GenerationPlan(
+                            listOf(
+                                GenerationTask.SpringKafkaClient(
+                                    language = GeneratorName.KOTLIN,
+                                    clientType = SpringKafkaClientType.SIMPLE,
+                                    clientPackage = "com.example.kafka",
+                                    modelPackage = "com.example.model",
+                                    topicPropertyPrefix = "kafka.topics",
+                                ),
+                            ),
+                        ),
+                )
+            }
+
+        assertTrue(error.message!!.contains("Spring Kafka client generation cannot consume payload 'UserCreated'"))
+        assertTrue(error.message!!.contains("Native Avro, Protobuf, and other explicit schema formats"))
+    }
+
+    private fun generationInputWithMultiFormatSchema(): GenerationInput =
+        GenerationInput(
+            schemas = emptyMap(),
+            multiFormatSchemas = mapOf("UserCreated" to nativeAvroSchema()),
+            polymorphicRelationships = emptyMap(),
+            channels = emptyList(),
+        )
+
+    private fun generationInputWithMultiFormatMessage(): GenerationInput =
+        GenerationInput(
+            schemas = emptyMap(),
+            polymorphicRelationships = emptyMap(),
+            channels =
+                listOf(
+                    AnalyzedChannel(
+                        channelName = "userEvents",
+                        topic = "users",
+                        isProducer = true,
+                        isConsumer = true,
+                        messages = emptyList(),
+                        multiFormatMessages =
+                            listOf(
+                                AnalyzedMultiFormatMessage(
+                                    messageName = "UserCreated",
+                                    payloadName = "UserCreated",
+                                    schema = nativeAvroSchema(),
+                                ),
+                            ),
+                    ),
+                ),
+        )
+
+    private fun nativeAvroSchema(): MultiFormatSchema =
+        MultiFormatSchema(
+            schemaFormat = "application/vnd.apache.avro+json;version=1.9.0",
+            schema = mapOf("type" to "record", "name" to "UserCreated", "fields" to emptyList<Any>()),
+        )
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactoryTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/input/GenerationInputFactoryTest.kt
@@ -1,9 +1,11 @@
 package dev.banking.asyncapi.generator.core.generator.input
 
 import dev.banking.asyncapi.generator.core.fixtures.GenerationInputFixtures
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaFormat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class GenerationInputFactoryTest {
@@ -27,5 +29,13 @@ class GenerationInputFactoryTest {
         assertTrue(channel.isConsumer)
         assertEquals("UserCreated", channel.messages.single().messageName)
         assertEquals("UserCreatedPayload", channel.messages.single().payloadTypeName)
+    }
+
+    @Test
+    fun `create preserves multi format schemas separately from asyncapi schemas`() {
+        val input = factory.create(fixtures.documentWithMultiFormatComponent())
+
+        assertFalse(input.schemas.containsKey("UserCreated"))
+        assertEquals(SchemaFormat.AVRO_1_9_0_JSON, input.multiFormatSchemas["UserCreated"]?.format)
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoaderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/loader/AsyncApiSchemaLoaderTest.kt
@@ -5,9 +5,14 @@ import dev.banking.asyncapi.generator.core.model.components.Component
 import dev.banking.asyncapi.generator.core.model.components.ComponentInterface
 import dev.banking.asyncapi.generator.core.model.messages.Message
 import dev.banking.asyncapi.generator.core.model.messages.MessageInterface
+import dev.banking.asyncapi.generator.core.model.schemas.MultiFormatSchema
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaFormat
 import dev.banking.asyncapi.generator.core.model.schemas.Schema
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class AsyncApiSchemaLoaderTest {
@@ -40,6 +45,43 @@ class AsyncApiSchemaLoaderTest {
         assertTrue(loaded.containsKey("UserSignedUpPayload"))
     }
 
+    @Test
+    fun `should load explicit multi format schemas separately from asyncapi schemas`() {
+        val avroSchema = nativeAvroSchema()
+        val components = Component(
+            schemas = mapOf(
+                "UserCreated" to SchemaInterface.MultiFormatSchemaInline(avroSchema),
+            ),
+        )
+        val doc = docWithComponents(components)
+
+        val loadedSchemas = AsyncApiSchemaLoader.load(doc)
+        val loadedMultiFormatSchemas = AsyncApiSchemaLoader.loadMultiFormatSchemas(doc)
+
+        assertFalse(loadedSchemas.containsKey("UserCreated"))
+        assertSame(avroSchema, loadedMultiFormatSchemas["UserCreated"])
+        assertEquals(SchemaFormat.AVRO_1_9_0_JSON, loadedMultiFormatSchemas["UserCreated"]?.format)
+    }
+
+    @Test
+    fun `should harvest multi format schemas from message payloads`() {
+        val avroSchema = nativeAvroSchema()
+        val components = Component(
+            messages = mapOf(
+                "UserSignedUp" to MessageInterface.MessageInline(
+                    Message(
+                        payload = SchemaInterface.MultiFormatSchemaInline(avroSchema),
+                    ),
+                ),
+            ),
+        )
+        val doc = docWithComponents(components)
+
+        val loadedMultiFormatSchemas = AsyncApiSchemaLoader.loadMultiFormatSchemas(doc)
+
+        assertSame(avroSchema, loadedMultiFormatSchemas["UserSignedUpPayload"])
+    }
+
     private fun docWithComponents(component: Component): AsyncApiDocument {
         return AsyncApiDocument(
             asyncapi = "3.0.0",
@@ -47,4 +89,10 @@ class AsyncApiSchemaLoaderTest {
             components = ComponentInterface.ComponentInline(component)
         )
     }
+
+    private fun nativeAvroSchema(): MultiFormatSchema =
+        MultiFormatSchema(
+            schemaFormat = "application/vnd.apache.avro+json;version=1.9.0",
+            schema = mapOf("type" to "record", "name" to "UserCreated", "fields" to emptyList<Any>()),
+        )
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/model/schemas/SchemaFormatTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/model/schemas/SchemaFormatTest.kt
@@ -1,0 +1,62 @@
+package dev.banking.asyncapi.generator.core.model.schemas
+
+import dev.banking.asyncapi.generator.core.constants.AsyncApiConstants
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SchemaFormatTest {
+
+    @Test
+    fun `fromValue recognizes asyncapi schema object formats`() {
+        assertEquals(
+            SchemaFormat.ASYNCAPI_3_0_0,
+            SchemaFormat.fromValue(AsyncApiConstants.ASYNCAPI_V_3_0_0),
+        )
+        assertEquals(
+            SchemaFormat.ASYNCAPI_3_0_0_JSON,
+            SchemaFormat.fromValue(AsyncApiConstants.ASYNCAPI_V_3_0_0_JSON),
+        )
+        assertEquals(
+            SchemaFormat.ASYNCAPI_3_0_0_YAML,
+            SchemaFormat.fromValue(AsyncApiConstants.ASYNCAPI_V_3_0_0_YAML),
+        )
+        assertTrue(SchemaFormat.ASYNCAPI_3_0_0_YAML.isAsyncApiSchemaObject)
+    }
+
+    @Test
+    fun `fromValue recognizes native avro formats`() {
+        assertEquals(
+            SchemaFormat.AVRO_1_9_0,
+            SchemaFormat.fromValue(AsyncApiConstants.AVRO_V_1_9_0),
+        )
+        assertEquals(
+            SchemaFormat.AVRO_1_9_0_JSON,
+            SchemaFormat.fromValue(AsyncApiConstants.AVRO_V_1_9_0_JSON),
+        )
+        assertEquals(
+            SchemaFormat.AVRO_1_9_0_YAML,
+            SchemaFormat.fromValue(AsyncApiConstants.AVRO_V_1_9_0_YAML),
+        )
+        assertTrue(SchemaFormat.AVRO_1_9_0_JSON.isNativeAvro)
+    }
+
+    @Test
+    fun `fromValue recognizes native protobuf formats`() {
+        assertEquals(
+            SchemaFormat.PROTOBUF_2,
+            SchemaFormat.fromValue(AsyncApiConstants.PROTOBUF_V_2),
+        )
+        assertEquals(
+            SchemaFormat.PROTOBUF_3,
+            SchemaFormat.fromValue(AsyncApiConstants.PROTOBUF_V_3),
+        )
+        assertTrue(SchemaFormat.PROTOBUF_3.isNativeProtobuf)
+    }
+
+    @Test
+    fun `fromValue returns null for unknown schema format`() {
+        assertNull(SchemaFormat.fromValue("application/unknown"))
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
@@ -1,6 +1,7 @@
 package dev.banking.asyncapi.generator.core.parser.schemas
 
 import dev.banking.asyncapi.generator.core.model.exceptions.AsyncApiParseException
+import dev.banking.asyncapi.generator.core.model.schemas.SchemaFormat
 import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 import dev.banking.asyncapi.generator.core.parser.ParserTestSupport
 import org.junit.jupiter.api.Test
@@ -28,54 +29,60 @@ class MultiFormatSchemaParserTest : ParserTestSupport() {
     }
 
     @Test
-    fun `parse unsupported schema format throws UnsupportedSchemaFormat`() {
+    fun `parse json schema format as multi format schema`() {
         val schemaNode = readNode(
-            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "parser/schemas/asyncapi_parser_schema_format_valid.yaml",
             "components",
             "schemas",
-            "UnsupportedJsonSchemaFormat",
+            "JsonSchemaDraftSchemaFormat",
         )
-        assertParseFailure<AsyncApiParseException.UnsupportedSchemaFormat>(
-            "SchemaFormat: application/schema+json;version=draft-07 is not supported.",
-            "asyncapi_parser_schema_format_invalid.yaml",
-            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnsupportedJsonSchemaFormat",
-        ) {
-            parser.parseElement(schemaNode)
-        }
+
+        val schema = parser.parseElement(schemaNode)
+
+        assertTrue(schema is SchemaInterface.MultiFormatSchemaInline)
+        val rawSchema = schema.multiFormatSchema.schema as Map<*, *>
+        assertEquals("application/schema+json;version=draft-07", schema.multiFormatSchema.schemaFormat)
+        assertEquals(SchemaFormat.JSON_SCHEMA_DRAFT_07_JSON, schema.multiFormatSchema.format)
+        assertEquals("object", rawSchema["type"])
     }
 
     @Test
-    fun `parse native avro schema format throws UnsupportedSchemaFormat`() {
+    fun `parse native avro schema format as multi format schema`() {
         val schemaNode = readNode(
-            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "parser/schemas/asyncapi_parser_schema_format_valid.yaml",
             "components",
             "schemas",
-            "UnsupportedAvroSchemaFormat",
+            "NativeAvroSchemaFormat",
         )
-        assertParseFailure<AsyncApiParseException.UnsupportedSchemaFormat>(
-            "SchemaFormat: application/vnd.apache.avro+json;version=1.9.0 is not supported.",
-            "asyncapi_parser_schema_format_invalid.yaml",
-            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnsupportedAvroSchemaFormat",
-        ) {
-            parser.parseElement(schemaNode)
-        }
+
+        val schema = parser.parseElement(schemaNode)
+
+        assertTrue(schema is SchemaInterface.MultiFormatSchemaInline)
+        val rawSchema = schema.multiFormatSchema.schema as Map<*, *>
+        assertEquals("application/vnd.apache.avro+json;version=1.9.0", schema.multiFormatSchema.schemaFormat)
+        assertEquals(SchemaFormat.AVRO_1_9_0_JSON, schema.multiFormatSchema.format)
+        assertTrue(schema.multiFormatSchema.format.isNativeAvro)
+        assertEquals("record", rawSchema["type"])
+        assertEquals("UserCreated", rawSchema["name"])
     }
 
     @Test
-    fun `parse native protobuf schema format throws UnsupportedSchemaFormat`() {
+    fun `parse native protobuf schema format as multi format schema`() {
         val schemaNode = readNode(
-            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "parser/schemas/asyncapi_parser_schema_format_valid.yaml",
             "components",
             "schemas",
-            "UnsupportedProtobufSchemaFormat",
+            "NativeProtobufSchemaFormat",
         )
-        assertParseFailure<AsyncApiParseException.UnsupportedSchemaFormat>(
-            "SchemaFormat: application/vnd.google.protobuf;version=3 is not supported.",
-            "asyncapi_parser_schema_format_invalid.yaml",
-            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnsupportedProtobufSchemaFormat",
-        ) {
-            parser.parseElement(schemaNode)
-        }
+
+        val schema = parser.parseElement(schemaNode)
+
+        assertTrue(schema is SchemaInterface.MultiFormatSchemaInline)
+        assertEquals("application/vnd.google.protobuf;version=3", schema.multiFormatSchema.schemaFormat)
+        assertEquals(SchemaFormat.PROTOBUF_3, schema.multiFormatSchema.format)
+        assertTrue(schema.multiFormatSchema.format.isNativeProtobuf)
+        val rawSchema = schema.multiFormatSchema.schema as String
+        assertTrue(rawSchema.contains("message UserCreated"))
     }
 
     @Test

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/parser/schemas/MultiFormatSchemaParserTest.kt
@@ -45,6 +45,40 @@ class MultiFormatSchemaParserTest : ParserTestSupport() {
     }
 
     @Test
+    fun `parse native avro schema format throws UnsupportedSchemaFormat`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "UnsupportedAvroSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnsupportedSchemaFormat>(
+            "SchemaFormat: application/vnd.apache.avro+json;version=1.9.0 is not supported.",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnsupportedAvroSchemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+
+    @Test
+    fun `parse native protobuf schema format throws UnsupportedSchemaFormat`() {
+        val schemaNode = readNode(
+            "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",
+            "components",
+            "schemas",
+            "UnsupportedProtobufSchemaFormat",
+        )
+        assertParseFailure<AsyncApiParseException.UnsupportedSchemaFormat>(
+            "SchemaFormat: application/vnd.google.protobuf;version=3 is not supported.",
+            "asyncapi_parser_schema_format_invalid.yaml",
+            "asyncapi_parser_schema_format_invalid.root.components.schemas.UnsupportedProtobufSchemaFormat",
+        ) {
+            parser.parseElement(schemaNode)
+        }
+    }
+
+    @Test
     fun `parse unknown schema format throws UnexpectedSchemaFormat`() {
         val schemaNode = readNode(
             "parser/schemas/asyncapi_parser_schema_format_invalid.yaml",

--- a/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
@@ -4,21 +4,6 @@ info:
   version: 1.0.0
 components:
   schemas:
-    UnsupportedJsonSchemaFormat:
-      schemaFormat: application/schema+json;version=draft-07
-      schema:
-        type: object
-    UnsupportedAvroSchemaFormat:
-      schemaFormat: application/vnd.apache.avro+json;version=1.9.0
-      schema:
-        type: record
-        name: UserCreated
-        fields: []
-    UnsupportedProtobufSchemaFormat:
-      schemaFormat: application/vnd.google.protobuf;version=3
-      schema: |
-        syntax = "proto3";
-        message UserCreated {}
     UnknownSchemaFormat:
       schemaFormat: application/unknown
       schema:

--- a/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_invalid.yaml
@@ -8,6 +8,17 @@ components:
       schemaFormat: application/schema+json;version=draft-07
       schema:
         type: object
+    UnsupportedAvroSchemaFormat:
+      schemaFormat: application/vnd.apache.avro+json;version=1.9.0
+      schema:
+        type: record
+        name: UserCreated
+        fields: []
+    UnsupportedProtobufSchemaFormat:
+      schemaFormat: application/vnd.google.protobuf;version=3
+      schema: |
+        syntax = "proto3";
+        message UserCreated {}
     UnknownSchemaFormat:
       schemaFormat: application/unknown
       schema:

--- a/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_valid.yaml
+++ b/asyncapi-generator-core/src/test/resources/parser/schemas/asyncapi_parser_schema_format_valid.yaml
@@ -9,3 +9,18 @@ components:
       schema:
         title: Supported schema format
         type: object
+    JsonSchemaDraftSchemaFormat:
+      schemaFormat: application/schema+json;version=draft-07
+      schema:
+        type: object
+    NativeAvroSchemaFormat:
+      schemaFormat: application/vnd.apache.avro+json;version=1.9.0
+      schema:
+        type: record
+        name: UserCreated
+        fields: []
+    NativeProtobufSchemaFormat:
+      schemaFormat: application/vnd.google.protobuf;version=3
+      schema: |
+        syntax = "proto3";
+        message UserCreated {}

--- a/docs/generator/generator_strategy.md
+++ b/docs/generator/generator_strategy.md
@@ -9,10 +9,26 @@ delegates specific tasks to specialized components.
 
 ### The Pipeline
 
-1.  **Load & Normalize:** The raw `AsyncApiDocument` is processed to resolve inline schemas and normalize types.
-2.  **Analyze:** The `SchemaAnalyzer` scans the document to build a graph of relationships (inheritance, polymorphism, dependencies).
-3.  **Contextualize:** A `GeneratorContext` is built, holding the "Rich Models" ready for generation.
-4.  **Generate:** Specialized Generators (Kotlin, Java, Avro) iterate over the models and produce files using Mustache templates.
+1.  **Prepare Input:** The parsed `AsyncApiDocument` is converted into `GenerationInput`. JSON-compatible AsyncAPI Schema Object payloads are kept separately from explicit multi-format schemas.
+2.  **Plan:** The typed generator configuration is converted into a `GenerationPlan` with explicit output tasks.
+3.  **Validate Compatibility:** The planned outputs are checked against the prepared input before any files are written.
+4.  **Analyze:** Schema and channel analyzers build generation-focused models such as relationships, payload names, channel directions, and message payload contracts.
+5.  **Generate:** Specialized generators render source and schema artifacts from the prepared input and planned tasks.
+6.  **Write:** Generated artifacts are written through the output contract into either source or resource output directories.
+
+---
+
+## Payload Format Boundary
+
+The generator intentionally separates AsyncAPI Schema Object payloads from native or explicit multi-format payload schemas.
+
+`GenerationInput.schemas` contains component schemas that can be consumed as JSON-compatible AsyncAPI Schema Object payloads. These are the schemas used by Kotlin model generation, Java model generation, Spring Kafka client generation, and Avro Projection.
+
+`GenerationInput.multiFormatSchemas` contains component schemas declared with a known `schemaFormat`, such as native Avro or Protobuf. These schemas are preserved so dedicated future generator capabilities can consume them without losing their original format.
+
+Channel analysis follows the same boundary. `AnalyzedChannel.messages` contains messages with AsyncAPI Schema Object payloads. `AnalyzedChannel.multiFormatMessages` contains messages with explicit multi-format payloads.
+
+Existing model, Spring Kafka, and Avro Projection outputs reject multi-format payloads through `GenerationInputCompatibilityValidator`. This is deliberate. These outputs currently support AsyncAPI Schema Object payloads only, and native Avro or Protobuf support should be modeled as dedicated generator capabilities instead of silently projecting one transfer format into another.
 
 ---
 
@@ -34,7 +50,13 @@ Both generators share a similar structure:
 
 ## Avro Generator Strategy
 
-The Avro generator produces `.avsc` (Avro Schema) files from the AsyncAPI definition.
+The current Avro generator is an **Avro Projection** generator. It produces `.avsc` files from JSON-compatible AsyncAPI Schema Object definitions.
+
+It does not consume native Avro schemas declared through `schemaFormat`, and it does not generate Avro `SpecificRecord` classes. Native Avro support should be implemented as a separate generator capability so users can choose between:
+
+*   AsyncAPI Schema Object -> Java/Kotlin payload models.
+*   AsyncAPI Schema Object -> projected `.avsc` files.
+*   Native Avro schemaFormat -> native Avro artifacts and generated `SpecificRecord` classes.
 
 ### 1. Enum Handling: Strict Support
 Contrary to earlier iterations or loose mapping strategies, this generator **fully supports Avro Enums**.


### PR DESCRIPTION
- Closes #126 
- Closes #127 
- Closes #133 

The previous generator flow did not have a clear enough boundary between JSON-compatible AsyncAPI Schema Object payloads and explicit multi-format payload schemas such as native Avro or Protobuf.

That was risky because these are different schema families with different runtime expectations. A payload described as an AsyncAPI Schema Object can be used for Kotlin models, Java models, Spring Kafka DTO APIs, and Avro Projection. A payload declared with `schemaFormat`, for example native Avro or Protobuf, should not silently flow through those same generators as if it were the same thing.

This PR introduces that boundary explicitly.

Known `schemaFormat` values are now classified through a typed `SchemaFormat` model. The parser still accepts known formats, but non-AsyncAPI schema formats are preserved as multi-format schemas instead of being converted into normal AsyncAPI schemas or rejected too early.

`GenerationInput` now separates regular schemas from multi-format schemas. JSON-compatible AsyncAPI Schema Object payloads continue through the existing model, Spring Kafka, and Avro Projection paths. Native or explicit multi-format component schemas are kept separately so future dedicated generator capabilities can consume them correctly.

Channel analysis now follows the same split. Messages with AsyncAPI Schema Object payloads are analyzed as regular generator messages, while messages with multi-format payloads are preserved as multi-format messages. This prevents native Avro or Protobuf message payloads from being silently dropped or accidentally treated as DTO payloads.

A generator compatibility validation step was added before any files are written. Existing model generation, Spring Kafka generation, and Avro Projection now fail with a clear generator error if they are asked to consume a multi-format payload. This is intentional because these outputs currently support AsyncAPI Schema Object payloads only.

Avro Projection is now documented and enforced as an explicit projection from AsyncAPI Schema Object payloads into `.avsc` files. It does not consume native Avro schemas and it does not generate Avro `SpecificRecord` classes. Native Avro and Protobuf generation should be implemented later as dedicated generator capabilities.

The tests were updated to cover the new boundary. Parser tests verify known schema formats, generation input tests verify that multi-format schemas are collected separately, channel analyzer tests verify that multi-format message payloads are preserved separately, compatibility validator tests verify unsupported output combinations, and generator-level contract tests verify that unsupported payload formats fail before output directories are written.

The README and generator strategy documentation were also updated so the public documentation matches the new behavior. But the doc might change later to a more WIKI based approach.