### PR TITLE
Fixed arrays/maps primitive and complex types parsing

### DIFF
--- a/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/avro/mapper/AvroTypeMapper.kt
+++ b/asyncapi-generator-core/src/main/kotlin/dev/banking/asyncapi/generator/core/generator/avro/mapper/AvroTypeMapper.kt
@@ -8,14 +8,17 @@ import dev.banking.asyncapi.generator.core.model.schemas.SchemaInterface
 class AvroTypeMapper(
     val packageName: String,
 ) {
+    fun getTitleFromReference(ref: SchemaInterface.SchemaReference): String {
+        val childName = ref.reference.ref.substringAfterLast('/')
+        return "$packageName.${MapperUtil.toPascalCase(childName)}"
+    }
 
     fun mapToAvroType(schema: Schema?, isOptional: Boolean, refName: String? = null): String {
         if (schema != null && !schema.oneOf.isNullOrEmpty()) {
             val unionTypes = schema.oneOf.mapNotNull { ref ->
-                if (ref is SchemaInterface.SchemaReference) {
-                    val childName = ref.reference.ref.substringAfterLast('/')
-                    "\"$packageName.${MapperUtil.toPascalCase(childName)}\""
-                } else null
+                if (ref is SchemaInterface.SchemaReference)
+                    "\"${getTitleFromReference(ref)}\""
+                else null
             }
 
             if (unionTypes.isNotEmpty()) {
@@ -35,17 +38,17 @@ class AvroTypeMapper(
             return if (isOptional) "[\"null\", $fullName]" else fullName
         }
 
-        if (schema == null) {
+        if (schema == null)
             return "\"string\""
-        }
-        val baseType = resolveBaseType(schema)
-        val finalType = if (schema.type.getPrimaryType() == "integer" && schema.format == "int64") {
+
+        val finalType = if (schema.type.getPrimaryType() == "integer" && schema.format == "int64")
             "\"long\""
-        } else if (schema.type.getPrimaryType() == "object") {
-            "{\"type\":\"map\", \"values\":\"${resolveMapValuesType(schema)}\"}"
-        } else {
-            baseType
-        }
+        else if (schema.type.getPrimaryType() == "array")
+            "{\"type\": \"array\", \"items\": ${resolveArrayItemsType(schema)}}"
+        else if (schema.type.getPrimaryType() == "object")
+            "{\"type\": \"map\", \"values\": ${resolveMapValuesType(schema)}}"
+        else
+            resolveBaseType(schema)
         return if (isOptional) {
             "[\"null\", $finalType]"
         } else {
@@ -53,13 +56,34 @@ class AvroTypeMapper(
         }
     }
 
+    private fun resolveArrayItemsType(schema: Schema): String {
+        try {
+            val defaultSchema = "\"string\""
+            if (schema.items == null)
+                return defaultSchema
+            if (schema.items is SchemaInterface.SchemaInline && schema.items.schema.type.getPrimaryType() != null)
+                return resolveBaseType(schema.items.schema)
+                    ?: defaultSchema
+            else if (schema.items is SchemaInterface.SchemaReference)
+                return "\"${getTitleFromReference(schema.items)}\""
+            return defaultSchema
+        } catch (e: Exception) {
+            throw RuntimeException("Error while resolving map values $schema")
+        }
+    }
+
     private fun resolveMapValuesType(schema: Schema): String {
         try {
-            val defaultSchema = "\"string\"";
+            val defaultSchema = "\"string\""
             if (schema.additionalProperties == null)
                 return defaultSchema
-            return (schema.additionalProperties as SchemaInterface.SchemaInline).schema.type.getPrimaryType() ?: defaultSchema
-        }catch (e:Exception){
+            else if (schema.additionalProperties is SchemaInterface.SchemaInline)
+                return resolveBaseType(schema.additionalProperties.schema)
+                    ?: defaultSchema
+            else if (schema.additionalProperties is SchemaInterface.SchemaReference)
+                return "\"${getTitleFromReference(schema.additionalProperties)}\""
+            return defaultSchema
+        } catch (e: Exception) {
             throw RuntimeException("Error while resolving map values $schema")
         }
     }
@@ -85,10 +109,6 @@ class AvroTypeMapper(
             "long" -> {
                 if (schema.format == "date-time") "{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}"
                 else "\"long\""
-            }
-
-            "array" -> {
-                "{\"type\": \"array\", \"items\": \"string\"}"
             }
 
             else -> "\"string\""

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/array/AvroArrayTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/array/AvroArrayTest.kt
@@ -15,6 +15,28 @@ class AvroArrayTest : AbstractAvroGeneratorClass() {
             schema = "CustomerWithContacts.avsc"
         )
         assertTrue(content.isNotEmpty(), "Generated content should not be empty")
+        assertTrue(content.contains("{\"type\": \"array\", \"items\": \"dev.banking.asyncapi.generator.core.generated.avro.ContactPointType\"}"), "Missing array of objects")
+    }
+
+    @Test
+    fun `should generate array with strings correctly`() {
+        val content = generateAvro(
+            yaml = File("src/test/resources/generator/asyncapi_array_string.yaml"),
+            packageName = "dev.banking.asyncapi.generator.core.generated.avro.string",
+            schema = "CustomerWithContacts.avsc"
+        )
+        assertTrue(content.isNotEmpty(), "Generated content should not be empty")
         assertTrue(content.contains("{\"type\": \"array\", \"items\": \"string\"}"), "Missing array of strings")
+    }
+
+    @Test
+    fun `should generate array with integers correctly`() {
+        val content = generateAvro(
+            yaml = File("src/test/resources/generator/asyncapi_array_int.yaml"),
+            packageName = "dev.banking.asyncapi.generator.core.generated.avro.integer",
+            schema = "CustomerWithContacts.avsc"
+        )
+        assertTrue(content.isNotEmpty(), "Generated content should not be empty")
+        assertTrue(content.contains("{\"type\": \"array\", \"items\": \"int\"}"), "Missing array of strings")
     }
 }

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/complexorder/AvroComplexOrderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/complexorder/AvroComplexOrderTest.kt
@@ -35,7 +35,7 @@ class AvroComplexOrderTest : AbstractAvroGeneratorClass() {
             content.contains("\"type\": \"dev.banking.avro.CustomerWithContacts\""),
             "Customer reference missing or incorrect"
         )
-        assertTrue(content.contains("{\"type\": \"array\", \"items\": \"string\"}"), "Array should default to string items for now")
+        assertTrue(content.contains("{\"type\": \"array\", \"items\": \"dev.banking.avro.OrderLineType\"}"), "Array should default to string items for now")
     }
 
     @Test

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/oneof/AvroArraysOneOfTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/avro/oneof/AvroArraysOneOfTest.kt
@@ -1,0 +1,26 @@
+package dev.banking.asyncapi.generator.core.generator.avro.oneof
+
+import dev.banking.asyncapi.generator.core.generator.AbstractAvroGeneratorClass
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AvroArraysOneOfTest : AbstractAvroGeneratorClass() {
+
+    @Test
+    fun `should generate individual records for polymorphic types`() {
+        generateAvro(
+            yaml = File("src/test/resources/generator/asyncapi_oneof_arrays_composition.yaml"),
+            packageName = "com.example.poly.arrays",
+            schema = null
+        )
+
+        val outputDir = File("target/generated-resources/asyncapi")
+        val packageDir = outputDir.resolve("com/example/poly/arrays")
+
+        assertTrue(packageDir.resolve("Payment.avsc").exists(), "Payment missing")
+        assertTrue(packageDir.resolve("PaymentBulk.avsc").exists(), "PaymentBulk missing")
+        assertFalse(packageDir.resolve("PaymentOperation.avsc").exists(), "PaymentOperation missing")
+    }
+}

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/complexorder/GenerateComplexOrderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/java/complexorder/GenerateComplexOrderTest.kt
@@ -146,36 +146,46 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
         val classBody = extractClassBody(generated)
         val expected = """
             public class ComplexOrderPayloadType implements Serializable {
-            
+
+                private List<String> attributes;
+
+                @Valid
+                private Map<String, MetaData> metadataObjects;
+
+                private Map<String, Integer> metadataIntegers;
+
                 private Map<String, String> metadata;
-            
+
                 @NotNull
                 private UUID orderId;
-            
+
                 @NotNull
                 private OffsetDateTime createdAt;
-            
+
                 @Size(min = 3, max = 30)
                 @NotNull
                 private String status;
-            
+
                 @NotNull
                 @Valid
                 private CustomerWithContacts customer;
-            
+
                 @NotNull
                 @Valid
                 private List<OrderLineType> orderLines;
-            
+
                 @Size(max = 2000)
                 private String notes;
-            
+
                 public ComplexOrderPayloadType() {
                     // Default constructor
                 }
-            
+
                 // All-args constructor
                 public ComplexOrderPayloadType(
+                    List<String> attributes,
+                    Map<String, MetaData> metadataObjects,
+                    Map<String, Integer> metadataIntegers,
                     Map<String, String> metadata,
                     UUID orderId,
                     OffsetDateTime createdAt,
@@ -184,6 +194,9 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                     List<OrderLineType> orderLines,
                     String notes
                 ) {
+                    this.attributes = attributes;
+                    this.metadataObjects = metadataObjects;
+                    this.metadataIntegers = metadataIntegers;
                     this.metadata = metadata;
                     this.orderId = orderId;
                     this.createdAt = createdAt;
@@ -192,7 +205,55 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                     this.orderLines = orderLines;
                     this.notes = notes;
                 }
-            
+
+                /**
+                 * Get attributes.
+                 * @return List<String>
+                 */
+                public List<String> getAttributes() {
+                    return attributes;
+                }
+
+                /**
+                 * Set attributes.
+                 * @param attributes
+                 */
+                public void setAttributes(List<String> attributes) {
+                    this.attributes = attributes;
+                }
+
+                /**
+                 * Get metadataObjects.
+                 * @return Map<String, MetaData>
+                 */
+                public Map<String, MetaData> getMetadataObjects() {
+                    return metadataObjects;
+                }
+
+                /**
+                 * Set metadataObjects.
+                 * @param metadataObjects
+                 */
+                public void setMetadataObjects(Map<String, MetaData> metadataObjects) {
+                    this.metadataObjects = metadataObjects;
+                }
+
+                /**
+                 * Get metadataIntegers.
+                 * @return Map<String, Integer>
+                 */
+                public Map<String, Integer> getMetadataIntegers() {
+                    return metadataIntegers;
+                }
+
+                /**
+                 * Set metadataIntegers.
+                 * @param metadataIntegers
+                 */
+                public void setMetadataIntegers(Map<String, Integer> metadataIntegers) {
+                    this.metadataIntegers = metadataIntegers;
+                }
+
                 /**
                  * Get metadata.
                  * @return Map<String, String>
@@ -200,7 +261,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public Map<String, String> getMetadata() {
                     return metadata;
                 }
-            
+
                 /**
                  * Set metadata.
                  * @param metadata
@@ -208,7 +269,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public void setMetadata(Map<String, String> metadata) {
                     this.metadata = metadata;
                 }
-            
+
                 /**
                  * Get orderId.
                  * Unique identifier for the order.
@@ -217,7 +278,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public UUID getOrderId() {
                     return orderId;
                 }
-            
+
                 /**
                  * Set orderId.
                  * @param orderId Unique identifier for the order.
@@ -225,7 +286,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public void setOrderId(UUID orderId) {
                     this.orderId = orderId;
                 }
-            
+
                 /**
                  * Get createdAt.
                  * Timestamp for when the order was created.
@@ -234,7 +295,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public OffsetDateTime getCreatedAt() {
                     return createdAt;
                 }
-            
+
                 /**
                  * Set createdAt.
                  * @param createdAt Timestamp for when the order was created.
@@ -242,7 +303,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public void setCreatedAt(OffsetDateTime createdAt) {
                     this.createdAt = createdAt;
                 }
-            
+
                 /**
                  * Get status.
                  * Current status of the order. Valid values include:
@@ -255,7 +316,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public String getStatus() {
                     return status;
                 }
-            
+
                 /**
                  * Set status.
                  * @param status Current status of the order. Valid values include:
@@ -263,7 +324,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public void setStatus(String status) {
                     this.status = status;
                 }
-            
+
                 /**
                  * Get customer.
                  * Customer object with nested contact points and primitive lists.
@@ -272,7 +333,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public CustomerWithContacts getCustomer() {
                     return customer;
                 }
-            
+
                 /**
                  * Set customer.
                  * @param customer Customer object with nested contact points and primitive lists.
@@ -280,7 +341,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public void setCustomer(CustomerWithContacts customer) {
                     this.customer = customer;
                 }
-            
+
                 /**
                  * Get orderLines.
                  * One or more order lines included in the order.
@@ -289,7 +350,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public List<OrderLineType> getOrderLines() {
                     return orderLines;
                 }
-            
+
                 /**
                  * Set orderLines.
                  * @param orderLines One or more order lines included in the order.
@@ -297,7 +358,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public void setOrderLines(List<OrderLineType> orderLines) {
                     this.orderLines = orderLines;
                 }
-            
+
                 /**
                  * Get notes.
                  * Optional free-text notes attached to the order.
@@ -306,7 +367,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public String getNotes() {
                     return notes;
                 }
-            
+
                 /**
                  * Set notes.
                  * @param notes Optional free-text notes attached to the order.
@@ -314,33 +375,42 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                 public void setNotes(String notes) {
                     this.notes = notes;
                 }
-            
+
                 @Override
                 public boolean equals(Object o) {
                     if (this == o) return true;
                     if (o == null || getClass() != o.getClass()) return false;
                     ComplexOrderPayloadType that = (ComplexOrderPayloadType) o;
                     return
+                        Objects.equals(attributes, that.attributes) &&
+
+                        Objects.equals(metadataObjects, that.metadataObjects) &&
+
+                        Objects.equals(metadataIntegers, that.metadataIntegers) &&
+
                         Objects.equals(metadata, that.metadata) &&
-            
+
                         Objects.equals(orderId, that.orderId) &&
-            
+
                         Objects.equals(createdAt, that.createdAt) &&
-            
+
                         Objects.equals(status, that.status) &&
-            
+
                         Objects.equals(customer, that.customer) &&
-            
+
                         Objects.equals(orderLines, that.orderLines) &&
-            
+
                         Objects.equals(notes, that.notes)
             ;
                 }
-            
+
                 @Override
                 public int hashCode() {
                     return Objects.hash(
-            
+
+                        attributes,
+                        metadataObjects,
+                        metadataIntegers,
                         metadata,
                         orderId,
                         createdAt,
@@ -350,11 +420,14 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                         notes
                     );
                 }
-            
+
                 @Override
                 public String toString() {
                     StringBuilder sb = new StringBuilder();
                     sb.append("class ComplexOrderPayloadType {\n");
+                    sb.append("    attributes: ").append(attributes).append("\n");
+                    sb.append("    metadataObjects: ").append(metadataObjects).append("\n");
+                    sb.append("    metadataIntegers: ").append(metadataIntegers).append("\n");
                     sb.append("    metadata: ").append(metadata).append("\n");
                     sb.append("    orderId: ").append(orderId).append("\n");
                     sb.append("    createdAt: ").append(createdAt).append("\n");
@@ -366,7 +439,7 @@ class GenerateComplexOrderTest : AbstractJavaGeneratorClass() {
                     return sb.toString();
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         assertEquals(expected, classBody)
     }
 

--- a/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/complexorder/GenerateComplexOrderTest.kt
+++ b/asyncapi-generator-core/src/test/kotlin/dev/banking/asyncapi/generator/core/generator/kotlin/complexorder/GenerateComplexOrderTest.kt
@@ -44,26 +44,33 @@ class GenerateComplexOrderTest : AbstractKotlinGeneratorClass() {
         val expected = """
             data class ComplexOrderPayloadType(
 
+                val attributes: List<String>? = null,
+
+                @field:Valid
+                val metadataObjects: Map<String, MetaData>? = null,
+
+                val metadataIntegers: Map<String, Int>? = null,
+
                 val metadata: Map<String, String>? = null,
-            
+
                 val orderId: UUID,
-            
+
                 val createdAt: OffsetDateTime,
-            
+
                 @field:Size(min = 3, max = 30)
                 val status: String,
-            
+
                 @field:Valid
                 val customer: CustomerWithContacts,
-            
+
                 @field:Valid
                 val orderLines: List<OrderLineType>,
-            
+
                 @field:Size(max = 2000)
                 val notes: String? = null
             ) {
             }
-            """.trimIndent()
+        """.trimIndent()
         assertEquals(expected, dataClass)
     }
 

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_array_int.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_array_int.yaml
@@ -1,0 +1,37 @@
+asyncapi: 3.0.0
+info:
+  title: Array of Primitive Types Example
+  version: 1.0.0
+defaultContentType: application/json
+components:
+  schemas:
+    CustomerWithContacts:
+      type: object
+      description: >
+        Customer object with nested contact points and primitive lists.
+      required:
+        - customerId
+        - fullName
+        - contactPoints
+      properties:
+        customerId:
+          description: Unique identifier for the customer.
+          type: string
+          format: uuid
+        fullName:
+          description: >
+            Customer's full name as presented in UI and reports.
+          type: string
+          maxLength: 140
+        tags:
+          description: >
+            Free-form tags associated with the customer.
+          type: array
+          items:
+            type: string
+        contactPoints:
+          description: >
+            List of contact points associated with the customer.
+          type: array
+          items:
+            type: integer

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_array_string.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_array_string.yaml
@@ -1,0 +1,37 @@
+asyncapi: 3.0.0
+info:
+  title: Array of Primitive Types Example
+  version: 1.0.0
+defaultContentType: application/json
+components:
+  schemas:
+    CustomerWithContacts:
+      type: object
+      description: >
+        Customer object with nested contact points and primitive lists.
+      required:
+        - customerId
+        - fullName
+        - contactPoints
+      properties:
+        customerId:
+          description: Unique identifier for the customer.
+          type: string
+          format: uuid
+        fullName:
+          description: >
+            Customer's full name as presented in UI and reports.
+          type: string
+          maxLength: 140
+        tags:
+          description: >
+            Free-form tags associated with the customer.
+          type: array
+          items:
+            type: string
+        contactPoints:
+          description: >
+            List of contact points associated with the customer.
+          type: array
+          items:
+            type: string

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_complex_order_payload_type.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_complex_order_payload_type.yaml
@@ -17,6 +17,19 @@ components:
         - customer
         - orderLines
       properties:
+        attributes:
+          type: array
+          items:
+            type: string
+        metadataObjects:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MetaData'
+        metadataIntegers:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
         metadata:
           type: object
           additionalProperties:
@@ -54,6 +67,13 @@ components:
             Optional free-text notes attached to the order.
           type: string
           maxLength: 2000
+    MetaData:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
     OrderLineType:
       type: object
       description: A single order line with product, quantity and price.

--- a/asyncapi-generator-core/src/test/resources/generator/asyncapi_oneof_arrays_composition.yaml
+++ b/asyncapi-generator-core/src/test/resources/generator/asyncapi_oneof_arrays_composition.yaml
@@ -1,0 +1,25 @@
+asyncapi: 3.0.0
+info:
+  title: OneOf Composition Example
+  version: 1.0.0
+defaultContentType: application/json
+components:
+  schemas:
+    Payment:
+      type: object
+      required:
+        - paymentType
+      properties:
+        paymentType:
+          type: string
+    PaymentBulk:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Payment'
+    PaymentOperation:
+      oneOf:
+        - $ref: '#/components/schemas/Payment'
+        - $ref: '#/components/schemas/PaymentBulk'


### PR DESCRIPTION
Motivation:
Generator doesn't handle avro array items types (it's hardcoded as always string). Also map items types needed to be fixed

```
asyncapi: 3.0.0
info:
  title: OneOf Composition Example
  version: 1.0.0
defaultContentType: application/json
components:
  schemas:
    Payment:
      type: object
      required:
        - paymentType
      properties:
        paymentType:
          type: string
    PaymentBulk:
      type: object
      properties:
        items:
          type: array
          items:
            $ref: '#/components/schemas/Payment'
    PaymentOperation:
      oneOf:
        - $ref: '#/components/schemas/Payment'
        - $ref: '#/components/schemas/PaymentBulk'
```

should look as avro like:

```
{
  "type": "record",
  "name": "PaymentBulk",
  "namespace": "com.example.poly.arrays",
  "fields": [
    {
      "name": "items",
      "type": ["null", {"type": "array", "items": "com.example.poly.arrays.Payment"}],
      "default": null
    }
  ]
}
```

The same about maps

This PR should fix this